### PR TITLE
listen to 'ended' event listener since Firefox has not implemented 'p…

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
@@ -81,7 +81,10 @@ export class ParticipantWaitingRoomComponent implements OnInit {
   }
 
   announceHearingIsAboutToStart(): void {
-    const audioPromise = this.hearingAlertSound.play();
+    this.hearingAlertSound.play()
+      .catch(function (reason) {
+        console.log(`caught error ${reason}`);
+      });
     this.hearingStartingAnnounced = true;
 
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4557


### Change description ###

listen to 'ended' event listener to determine when to stop playing the 'hearing is about to start' alarm.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```