### PR TITLE
fix browser name for edge to ms-edge

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.ts
@@ -22,7 +22,7 @@ export class DeviceTypeService {
   }
 
   isSupportedBrowser(): boolean {
-    const supportedBrowsers = ['Firefox', 'Safari', 'Chrome', 'Edge'];
+    const supportedBrowsers = ['Firefox', 'Safari', 'Chrome', 'MS-Edge'];
     const browser = this.deviceDetectorService.browser;
     return supportedBrowsers.findIndex(x => x.toUpperCase() === browser.toUpperCase()) > -1;
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-4700](https://tools.hmcts.net/jira/browse/VIH-4700)

### Change description ###

Changed 'Edge' to 'MS-Edge' when checking for supported browser name

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
