### PR TITLE
Updated to refliect new booking status funcionality on bookings-api

### DIFF
--- a/VideoWeb/Testing.Common/Helpers/BookingsApiUriFactory.cs
+++ b/VideoWeb/Testing.Common/Helpers/BookingsApiUriFactory.cs
@@ -52,6 +52,7 @@ namespace Testing.Common.Helpers
         public string GetHearingDetailsById(Guid hearingId) => $"{ApiRoot}/{hearingId}";
         public string BookNewHearing() => $"{ApiRoot}";
         public string UpdateHearingDetails(Guid hearingId) => $"{ApiRoot}/{hearingId}";
+        public string UpdateHearingStatus(Guid hearingId) => $"{ApiRoot}/{hearingId}";
         public string RemoveHearing(Guid? hearingId) => $"{ApiRoot}/{hearingId}";
     }
 

--- a/VideoWeb/VideoWeb.AcceptanceTests/Configuration/IConferenceRetriever.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Configuration/IConferenceRetriever.cs
@@ -8,7 +8,9 @@ using Testing.Common.Helpers;
 using VideoWeb.AcceptanceTests.Builders;
 using VideoWeb.AcceptanceTests.Contexts;
 using VideoWeb.Common.Helpers;
+using VideoWeb.Services.Bookings;
 using VideoWeb.Services.Video;
+using ParticipantRequest = VideoWeb.Services.Video.ParticipantRequest;
 using UserRole = VideoWeb.Services.Video.UserRole;
 
 namespace VideoWeb.AcceptanceTests.Configuration
@@ -69,6 +71,7 @@ namespace VideoWeb.AcceptanceTests.Configuration
     {
         public ConferenceDetailsResponse GetConference(TestContext context)
         {
+            UpdateStatusToCreateConference(context);
             const int waitForConferenceToBeCreatedRetries = 10;
             context.Request = context.Get(new VideoApiUriFactory().ConferenceEndpoints.GetConferenceByHearingRefId(context.NewHearingId));
             context.RequestBody = null;
@@ -94,6 +97,21 @@ namespace VideoWeb.AcceptanceTests.Configuration
 
             return conference;
         }
-    }
 
+        public void UpdateStatusToCreateConference(TestContext context)
+        {
+            var updateRequest = new UpdateBookingStatusRequest
+            {
+                Status = UpdateBookingStatusRequestStatus.Created,
+                Updated_by = context.GetCaseAdminUser().Username
+            };
+
+            context.Request = context.Patch(new BookingsApiUriFactory().HearingsEndpoints.UpdateHearingStatus(context.NewHearingId), updateRequest);
+
+            new ExecuteRequestBuilder()
+                .WithContext(context)
+                .WithExpectedStatusCode(HttpStatusCode.NoContent)
+                .SendToBookingsApi();
+        }
+    }
 }

--- a/VideoWeb/VideoWeb.AcceptanceTests/Hooks/DataSetupHooks.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Hooks/DataSetupHooks.cs
@@ -42,6 +42,7 @@ namespace VideoWeb.AcceptanceTests.Hooks
         [BeforeScenario]
         public static void ClearAnyConferences(TestContext context, ConferenceEndpoints endpoints)
         {
+            if (!context.RunningLocally) return;
             ClearConferences(context, endpoints, context.GetIndividualUsers());
             ClearConferences(context, endpoints, context.GetRepresentativeUsers());
         }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] tests have been updated 

### Change description ###
In order for the queue subscriber to create the conference on the video-api, once a hearing has been created, the status needs to be updated to created on that hearing. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
