### PR TITLE
refresh participant status list to filter on status updates

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/individual-participant-status-list/individual-participant-status-list.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/individual-participant-status-list/individual-participant-status-list.component.ts
@@ -104,6 +104,7 @@ export class IndividualParticipantStatusListComponent implements OnInit {
     if (isCurrentUser && message.status === ParticipantStatus.InConsultation) {
       this.closeAllPCModals();
     }
+    this.filterNonJudgeParticipants();
   }
 
   isParticipantAvailable(participant: ParticipantResponse): boolean {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-4903](https://tools.hmcts.net/jira/browse/VIH-4903)

### Change description ###

On status change, the participant status list is refreshed so that PCs can be started after a conference is closed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
