### PR TITLE
Test cleanup workaround

### DIFF
--- a/VideoWeb/Testing.Common/Helpers/VideoApiUriFactory.cs
+++ b/VideoWeb/Testing.Common/Helpers/VideoApiUriFactory.cs
@@ -43,6 +43,7 @@ namespace Testing.Common.Helpers
         public string GetConferenceDetailsById(Guid conferenceId) => $"{ApiRoot}/{conferenceId}";
         public string GetConferenceByHearingRefId(Guid hearingRefId) => $"{ApiRoot}/hearings/{hearingRefId}";
         public string RemoveConference(Guid? conferenceId) => $"{ApiRoot}/{conferenceId}";
+        public string GetTodaysConferences => $"{ApiRoot}/today";
     }
 
     public class VideoApiHealthCheckEndpoints

--- a/VideoWeb/VideoWeb.AcceptanceTests/Helpers/SeleniumEnvironment.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Helpers/SeleniumEnvironment.cs
@@ -17,6 +17,8 @@ namespace VideoWeb.AcceptanceTests.Helpers
         private readonly SauceLabsSettings _saucelabsSettings;
         private readonly ScenarioInfo _scenario;
         private static TargetBrowser _targetBrowser;
+        private const string SaucelabsScreenResolution = "1920x1200";
+        private const int SaucelabsIdleTimeoutInSeconds = 300;
 
         public SeleniumEnvironment(SauceLabsSettings saucelabsSettings, ScenarioInfo scenario, TargetBrowser targetBrowser)
         {
@@ -91,7 +93,8 @@ namespace VideoWeb.AcceptanceTests.Helpers
 
             caps.SetCapability("name", _scenario.Title);
             caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("RELEASE_RELEASENAME")}");
-            caps.SetCapability("screenResolution", "1920x1200");
+            caps.SetCapability("screenResolution", SaucelabsScreenResolution);
+            caps.SetCapability("idleTimeout", SaucelabsIdleTimeoutInSeconds);
 
             // It can take quite a bit of time for some commands to execute remotely so this is higher than default
             var commandTimeout = TimeSpan.FromMinutes(3);

--- a/VideoWeb/VideoWeb.AcceptanceTests/Pages/CommonPages.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Pages/CommonPages.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using FluentAssertions;
 using OpenQA.Selenium;
 using VideoWeb.AcceptanceTests.Contexts;

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/PracticeVideoHearingSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/PracticeVideoHearingSteps.cs
@@ -25,7 +25,7 @@ namespace VideoWeb.AcceptanceTests.Steps
         private readonly PracticeVideoHearingPage _practiceVideoHearingPage;
         private readonly CommonSteps _commonSteps;
         private const int VideoFinishedPlayingTimeout = 120;
-        private const int Retries = 5;
+        private const int Retries = 10;
         private const int ExtraTimeoutToLoadVideoFromKinly = 60;
 
         public PracticeVideoHearingSteps(Dictionary<string, UserBrowser> browsers, TestContext tc,
@@ -86,7 +86,7 @@ namespace VideoWeb.AcceptanceTests.Steps
         {
             var endpoint = new VideoWebParticipantsEndpoints();
             var participantId = _tc.Conference.Participants
-                .Find(x => x.Display_name.Equals(_tc.CurrentUser.Displayname)).Id;
+                .Find(x => x.Display_name.ToLower().Equals(_tc.CurrentUser.Displayname.ToLower())).Id;
             _tc.Request = _tc.Get(endpoint.SelfTestResult(_tc.NewConferenceId, participantId));
 
             var found = false;
@@ -98,7 +98,7 @@ namespace VideoWeb.AcceptanceTests.Steps
                     found = true;
                     break;
                 }
-                Thread.Sleep(TimeSpan.FromSeconds(1));
+                Thread.Sleep(TimeSpan.FromSeconds(3));
             }
 
             found.Should().BeTrue();

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/PrivateConsultationSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/PrivateConsultationSteps.cs
@@ -19,6 +19,7 @@ namespace VideoWeb.AcceptanceTests.Steps
         private readonly TestContext _tc;
         private readonly CommonSteps _commonSteps;
         private readonly WaitingRoomPage _page;
+        private const int SecondsWaitToCallAndAnswers = 3;
 
         public PrivateConsultationSteps(Dictionary<string, UserBrowser> browsers, TestContext testContext, 
             CommonSteps commonSteps, WaitingRoomPage page)
@@ -35,6 +36,8 @@ namespace VideoWeb.AcceptanceTests.Steps
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.TimePanel)
                 .Displayed.Should().BeTrue();
 
+            Thread.Sleep(TimeSpan.FromSeconds(SecondsWaitToCallAndAnswers));
+
             var participantId = _tc.Conference.Participants.First(x => x.Name.ToLower().Contains(user.ToLower())).Id;
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.PrivateConsultationLink(participantId.ToString())).Click();
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.OutgoingCallMessage)
@@ -45,6 +48,9 @@ namespace VideoWeb.AcceptanceTests.Steps
         public void WhenTheUserAcceptsThePrivateConsultation(string user)
         {
             _commonSteps.GivenInTheUsersBrowser(user);
+
+            Thread.Sleep(TimeSpan.FromSeconds(SecondsWaitToCallAndAnswers));
+
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.IncomingCallMessage)
                 .Displayed.Should().BeTrue();
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.AcceptPrivateCall()).Click();

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/PrivateConsultationSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/PrivateConsultationSteps.cs
@@ -19,7 +19,7 @@ namespace VideoWeb.AcceptanceTests.Steps
         private readonly TestContext _tc;
         private readonly CommonSteps _commonSteps;
         private readonly WaitingRoomPage _page;
-        private const int SecondsWaitToCallAndAnswers = 3;
+        private const int SecondsWaitToCallAndAnswer = 3;
 
         public PrivateConsultationSteps(Dictionary<string, UserBrowser> browsers, TestContext testContext, 
             CommonSteps commonSteps, WaitingRoomPage page)
@@ -36,7 +36,7 @@ namespace VideoWeb.AcceptanceTests.Steps
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.TimePanel)
                 .Displayed.Should().BeTrue();
 
-            Thread.Sleep(TimeSpan.FromSeconds(SecondsWaitToCallAndAnswers));
+            Thread.Sleep(TimeSpan.FromSeconds(SecondsWaitToCallAndAnswer));
 
             var participantId = _tc.Conference.Participants.First(x => x.Name.ToLower().Contains(user.ToLower())).Id;
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.PrivateConsultationLink(participantId.ToString())).Click();
@@ -49,7 +49,7 @@ namespace VideoWeb.AcceptanceTests.Steps
         {
             _commonSteps.GivenInTheUsersBrowser(user);
 
-            Thread.Sleep(TimeSpan.FromSeconds(SecondsWaitToCallAndAnswers));
+            Thread.Sleep(TimeSpan.FromSeconds(SecondsWaitToCallAndAnswer));
 
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_page.IncomingCallMessage)
                 .Displayed.Should().BeTrue();


### PR DESCRIPTION
- [X] commit messages are meaningful and follow good commit message guidelines
- [X] tests have been updated / new tests has been added (if needed)


### Change description ###
- Changed the way closed conferences are deleted (workaround until the delete endpoint is fixed). - Extended timeouts for failing saucelabs tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```