### PR TITLE
Refresh page for 4 participant call test

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/Features/HearingRoom.feature
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Features/HearingRoom.feature
@@ -65,14 +65,16 @@ Scenario: Two participants join hearing
 	When the countdown finishes
 	Then the Clerk is on the Hearing Room page for 1 minute
 
-@Chrome @Video
+@Chrome @Video @smoketest
 Scenario: Four participants join hearing
 	Given the Individual01 user has progressed to the Waiting Room page
 	And the Representative01 user has progressed to the Waiting Room page for the existing hearing
 	And the Individual02 user has progressed to the Waiting Room page for the existing hearing
 	And the Representative02 user has progressed to the Waiting Room page for the existing hearing
 	And the Clerk user has progressed to the Waiting Room page for the existing hearing
-	When the user clicks the button with innertext Start video call
+	When Individual01 refreshes the waiting room page
+	And in the Clerk's browser
+	And the user clicks the button with innertext Start video call
 	Then the user is on the Countdown page
 	When the countdown finishes
 	Then the Clerk is on the Hearing Room page for 2 minutes

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingRoomSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingRoomSteps.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using TechTalk.SpecFlow;
@@ -18,17 +19,21 @@ namespace VideoWeb.AcceptanceTests.Steps
         private readonly Dictionary<string, UserBrowser> _browsers;
         private readonly TestContext _tc;
         private readonly HearingRoomPage _page;
+        private readonly WaitingRoomPage _waitingRoomPage;
         private readonly CommonSteps _commonSteps;
         private const int CountdownDuration = 30;
         private const int ExtraTimeAfterTheCountdown = 10;
         private const int PauseCloseTransferDuration = 10;
+        private const int ExtraTimeForPageToRefresh = 60;
 
-        public HearingRoomSteps(Dictionary<string, UserBrowser> browsers, TestContext testContext, HearingRoomPage page, CommonSteps commonSteps)
+        public HearingRoomSteps(Dictionary<string, UserBrowser> browsers, TestContext testContext, HearingRoomPage page, 
+            CommonSteps commonSteps, WaitingRoomPage waitingRoomPage)
         {
             _browsers = browsers;
             _tc = testContext;
             _page = page;
             _commonSteps = commonSteps;
+            _waitingRoomPage = waitingRoomPage;
         }
 
         [When(@"the countdown finishes")]
@@ -65,6 +70,8 @@ namespace VideoWeb.AcceptanceTests.Steps
         {
             _commonSteps.GivenInTheUsersBrowser(user);
             _browsers[_tc.CurrentUser.Key].Driver.Navigate().Refresh();
+            _browsers[_tc.CurrentUser.Key].Driver.WaitUntilVisible(_waitingRoomPage.HearingCaseDetails, ExtraTimeForPageToRefresh).Text
+                .Should().Contain(_tc.Hearing.Cases.First().Name);
         }
 
         [Then(@"the Clerk is on the Hearing Room page for (.*) seconds")]

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingRoomSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingRoomSteps.cs
@@ -18,15 +18,17 @@ namespace VideoWeb.AcceptanceTests.Steps
         private readonly Dictionary<string, UserBrowser> _browsers;
         private readonly TestContext _tc;
         private readonly HearingRoomPage _page;
+        private readonly CommonSteps _commonSteps;
         private const int CountdownDuration = 30;
         private const int ExtraTimeAfterTheCountdown = 10;
         private const int PauseCloseTransferDuration = 10;
 
-        public HearingRoomSteps(Dictionary<string, UserBrowser> browsers, TestContext testContext, HearingRoomPage page)
+        public HearingRoomSteps(Dictionary<string, UserBrowser> browsers, TestContext testContext, HearingRoomPage page, CommonSteps commonSteps)
         {
             _browsers = browsers;
             _tc = testContext;
             _page = page;
+            _commonSteps = commonSteps;
         }
 
         [When(@"the countdown finishes")]
@@ -56,6 +58,13 @@ namespace VideoWeb.AcceptanceTests.Steps
             _browsers[_tc.CurrentUser.Key].Driver.WaitUntilElementClickable(_page.CloseButton).Click();
 
             Thread.Sleep(TimeSpan.FromSeconds(PauseCloseTransferDuration));
+        }
+
+        [When(@"(.*) refreshes the waiting room page")]
+        public void WhenIndividualSRefreshesTheWaitingRoomPage(string user)
+        {
+            _commonSteps.GivenInTheUsersBrowser(user);
+            _browsers[_tc.CurrentUser.Key].Driver.Navigate().Refresh();
         }
 
         [Then(@"the Clerk is on the Hearing Room page for (.*) seconds")]

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingsListSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingsListSteps.cs
@@ -157,7 +157,7 @@ namespace VideoWeb.AcceptanceTests.Steps
         private static void ParticipantsDisplayed(IEnumerable<ParticipantResponse> participants, HearingRow rowData)
         {
            foreach (var participant in participants)
-            {
+           {
                 if (!participant.User_role_name.Equals(UserRole.Individual.ToString()) &&
                     !participant.User_role_name.Equals(UserRole.Representative.ToString())) continue;
 
@@ -181,7 +181,7 @@ namespace VideoWeb.AcceptanceTests.Steps
 
                 var participantIsDisplayed = individualIsDisplayed || representativeIsDisplayed;
                 participantIsDisplayed.Should().BeTrue();
-            }           
+           }           
         }
     }
 }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] tests have been updated / new tests has been added (if needed)

### Change description ###
Test has a high chance of failure on saucelabs as there is a long gap between the first user logging in and the clerk starting the hearing. Adding a refresh to keep them from being disconnected.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```