### PR TITLE
raise self test failure event immediately when a bad score is returned.

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/self-test/self-test.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/self-test/self-test.component.spec.ts
@@ -103,4 +103,15 @@ describe('SelfTestComponent', () => {
         });
         expect(videoWebService.raiseSelfTestFailureEvent).toHaveBeenCalledWith(component.conference.id, request);
     });
+
+    it('should not raise failed self test event when score has already been sent', async () => {
+        spyOn(videoWebService, 'raiseSelfTestFailureEvent');
+        component.scoreSent = true;
+        await component.ngOnDestroy();
+        const request = new AddSelfTestFailureEventRequest({
+            participant_id: component.participant.id,
+            self_test_failure_reason: SelfTestFailureReason.IncompleteTest
+        });
+        expect(videoWebService.raiseSelfTestFailureEvent).toHaveBeenCalledTimes(0);
+    });
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-4614](https://tools.hmcts.net/jira/browse/VIH-4614)

### Change description ###

- Raise a failed self test event on a bad score immediately rather than waiting for the user to click continue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
