### PR TITLE
VIH-5422: HOTFIX VideoWeb: Fix logging in the callback end point

### DIFF
--- a/VideoWeb/VideoWeb.EventHub/Handlers/Core/EventHandlerBase.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/Core/EventHandlerBase.cs
@@ -37,6 +37,8 @@ namespace VideoWeb.EventHub.Handlers.Core
             SourceParticipant = SourceConference.Participants
                 .SingleOrDefault(x => x.Id == callbackEvent.ParticipantId);
 
+            _logger.LogError($"Handling Event: {callbackEvent.EventType} for conferenceId {callbackEvent.ConferenceId} with reason " +
+                $"{callbackEvent.Reason} at Timestamp: { (DateTime.Now).ToString("yyyy-MM-dd HH:mm:ss.fffffff") }");
             await PublishStatusAsync(callbackEvent);
         }
 

--- a/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
+++ b/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
@@ -52,7 +52,7 @@ namespace VideoWeb.EventHub.Hub
         {
             var userName = await GetUsername(Context.User.Identity.Name);
             _logger.LogError($"Disconnected from event hub server-side: { userName } ");
-            _logger.LogError($"Disconnected from event hub server-side: { exception.Message } ");
+            _logger.LogError($"Disconnected from event hub server-side: { exception?.Message } ");
             var isAdmin = await IsVhOfficerAsync(Context.User.Identity.Name);
             if (isAdmin)
             {

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/SendHearingEventTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/SendHearingEventTests.cs
@@ -66,14 +66,14 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
         }
 
         [Test]
-        public async Task should_return_ok_result_when_event_is_sent()
+        public async Task should_return_no_content_when_event_is_sent()
         {
             _videoApiClientMock
                 .Setup(x => x.RaiseVideoEventAsync(It.IsAny<ConferenceEventRequest>()))
                 .Returns(Task.FromResult(default(object)));
             
             var result = await _controller.SendHearingEvent(CreateRequest());
-            var typedResult = (OkResult) result;
+            var typedResult = (NoContentResult) result;
             typedResult.Should().NotBeNull();
         }
         

--- a/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Renderer, ElementRef, ViewChild } from '@angular/core';
+import { Component, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { AdalService } from 'adal-angular4';
 import { ConfigService } from './services/api/config.service';
@@ -33,7 +33,6 @@ export class AppComponent implements OnInit {
     private deviceTypeService: DeviceTypeService,
     private profileService: ProfileService,
     private errorService: ErrorService,
-    private renderer: Renderer,
     private titleService: Title,
     private activatedRoute: ActivatedRoute
   ) {
@@ -96,7 +95,7 @@ export class AppComponent implements OnInit {
   }
 
   skipToContent() {
-    this.renderer.invokeElementMethod(this.main.nativeElement, 'focus');
+    this.main.nativeElement.focus();
   }
 
   setPageTitle(): void {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/api/config.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/api/config.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { configureTestSuite } from 'ng-bullet';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { SharedModule } from '../../shared/shared.module';
 import { ApiClient, ClientSettingsResponse } from '../clients/api-client';
 import { ConfigService } from './config.service';
@@ -24,7 +24,7 @@ describe('ConfigService', () => {
     clientSettings.client_id = 'clientId';
     clientSettings.post_logout_redirect_uri = '/dashboard';
     clientSettings.redirect_uri = '/dashboard';
-    apiClientSpy.getClientConfigurationSettings.and.returnValue(Observable.create(clientSettings));
+    apiClientSpy.getClientConfigurationSettings.and.returnValue(of(clientSettings));
     configService = TestBed.get(ConfigService);
   });
 

--- a/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
@@ -43,13 +43,13 @@ namespace VideoWeb.Controllers
             try
             {
                 _logger.LogTrace("Received callback from Kinly");
-                _logger.LogTrace($"ConferenceId: ${request.Conference_id}, EventType: ${request.Event_type}");
+                _logger.LogError($"ConferenceId: ${request.Conference_id}, EventType: ${request.Event_type}");
                 var callbackEvent = new CallbackEventMapper().MapConferenceEventToCallbackEventModel(request);
                 if (_memoryCache.Get<Conference>(callbackEvent.ConferenceId) == null)
                 {
                     try
                     {
-                        _logger.LogTrace($"Retrieving conference details for conference: ${callbackEvent.ConferenceId}");
+                        _logger.LogError($"Retrieving conference details for conference: ${callbackEvent.ConferenceId}");
                         var conference = await _videoApiClient.GetConferenceDetailsByIdAsync(callbackEvent.ConferenceId);
                         await ConferenceCache.AddConferenceToCache(conference, _memoryCache);
                     }

--- a/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using VideoWeb.EventHub.Handlers.Core;
 using VideoWeb.EventHub.Models;
@@ -21,34 +22,40 @@ namespace VideoWeb.Controllers
         private readonly IVideoApiClient _videoApiClient;
         private readonly IEventHandlerFactory _eventHandlerFactory;
         private readonly IMemoryCache _memoryCache;
+        private readonly ILogger<VideoEventsController> _logger;
 
         public VideoEventsController(IVideoApiClient videoApiClient, 
             IEventHandlerFactory eventHandlerFactory, 
-            IMemoryCache memoryCache)
+            IMemoryCache memoryCache, ILogger<VideoEventsController> logger)
         {
             _videoApiClient = videoApiClient;
             _eventHandlerFactory = eventHandlerFactory;
             _memoryCache = memoryCache;
+            _logger = logger;
         }
 
         [HttpPost]
         [SwaggerOperation(OperationId = "SendEvent")]
-        [ProducesResponseType((int) HttpStatusCode.NoContent)]
+        [ProducesResponseType((int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int) HttpStatusCode.BadRequest)]
         public async Task<IActionResult> SendHearingEvent(ConferenceEventRequest request)
         {
             try
             {
+                _logger.LogTrace("Received callback from Kinly");
+                _logger.LogTrace($"ConferenceId: ${request.Conference_id}, EventType: ${request.Event_type}");
                 var callbackEvent = new CallbackEventMapper().MapConferenceEventToCallbackEventModel(request);
                 if (_memoryCache.Get<Conference>(callbackEvent.ConferenceId) == null)
                 {
                     try
                     {
+                        _logger.LogTrace($"Retrieving conference details for conference: ${callbackEvent.ConferenceId}");
                         var conference = await _videoApiClient.GetConferenceDetailsByIdAsync(callbackEvent.ConferenceId);
                         await ConferenceCache.AddConferenceToCache(conference, _memoryCache);
                     }
                     catch (VideoApiException e)
                     {
+                        _logger.LogError($"ConferenceId: ${request.Conference_id}, ErrorCode: ${e.StatusCode}");
                         return StatusCode(e.StatusCode, e.Response);
                     }
                 }
@@ -57,13 +64,15 @@ namespace VideoWeb.Controllers
                 await handler.HandleAsync(callbackEvent);
                 if (callbackEvent.EventType != EventType.VhoCall)
                 {
+                    _logger.LogTrace($"Raising video event: ConferenceId: {request.Conference_id}, EventType: {request.Event_type}");
                     await _videoApiClient.RaiseVideoEventAsync(request);
                 }
 
-                return NoContent();
+                return Ok();
             }
             catch (VideoApiException e)
             {
+                _logger.LogError($"ConferenceId: ${request.Conference_id}, ErrorCode: ${e.StatusCode}");
                 return StatusCode(e.StatusCode, e.Response);
             }
         }

--- a/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
@@ -43,19 +43,19 @@ namespace VideoWeb.Controllers
             try
             {
                 _logger.LogTrace("Received callback from Kinly");
-                _logger.LogError($"ConferenceId: ${request.Conference_id}, EventType: ${request.Event_type}");
+                _logger.LogError($"ConferenceId: {request.Conference_id}, EventType: {request.Event_type}");
                 var callbackEvent = new CallbackEventMapper().MapConferenceEventToCallbackEventModel(request);
                 if (_memoryCache.Get<Conference>(callbackEvent.ConferenceId) == null)
                 {
                     try
                     {
-                        _logger.LogError($"Retrieving conference details for conference: ${callbackEvent.ConferenceId}");
+                        _logger.LogError($"Retrieving conference details for conference: {callbackEvent.ConferenceId}");
                         var conference = await _videoApiClient.GetConferenceDetailsByIdAsync(callbackEvent.ConferenceId);
                         await ConferenceCache.AddConferenceToCache(conference, _memoryCache);
                     }
                     catch (VideoApiException e)
                     {
-                        _logger.LogError($"ConferenceId: ${request.Conference_id}, ErrorCode: ${e.StatusCode}");
+                        _logger.LogError($"ConferenceId: {request.Conference_id}, ErrorCode: {e.StatusCode}");
                         return StatusCode(e.StatusCode, e.Response);
                     }
                 }
@@ -72,7 +72,7 @@ namespace VideoWeb.Controllers
             }
             catch (VideoApiException e)
             {
-                _logger.LogError($"ConferenceId: ${request.Conference_id}, ErrorCode: ${e.StatusCode}");
+                _logger.LogError($"ConferenceId: {request.Conference_id}, ErrorCode: {e.StatusCode}");
                 return StatusCode(e.StatusCode, e.Response);
             }
         }

--- a/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
@@ -36,7 +36,7 @@ namespace VideoWeb.Controllers
 
         [HttpPost]
         [SwaggerOperation(OperationId = "SendEvent")]
-        [ProducesResponseType((int) HttpStatusCode.OK)]
+        [ProducesResponseType((int) HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int) HttpStatusCode.BadRequest)]
         public async Task<IActionResult> SendHearingEvent(ConferenceEventRequest request)
         {
@@ -68,7 +68,7 @@ namespace VideoWeb.Controllers
                     await _videoApiClient.RaiseVideoEventAsync(request);
                 }
 
-                return Ok();
+                return NoContent();
             }
             catch (VideoApiException e)
             {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-5422
### Change description ###
VIH-5422: HOTFIX VideoWeb: Fix logging in the callback end point
added logging for the VideoEventsController.
modified the endpoint to return an OkResult.
updated app.component for set focus on main container (removed Render2 as its obsolete)
update config.spec.ts to use of instead of obsolete Observable.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
