### PR TITLE
Stop Judge disconnect events being published to clients

### DIFF
--- a/VideoWeb/VideoWeb.EventHub/Handlers/DisconnectedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/DisconnectedEventHandler.cs
@@ -19,7 +19,8 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            await PublishParticipantDisconnectMessage().ConfigureAwait(false);
+            // skip disonnect events since judge available/unavailable statuses are tracked by other events
+            if (!SourceParticipant.IsJudge()) await PublishParticipantDisconnectMessage().ConfigureAwait(false);
             if (SourceParticipant.IsJudge()) await PublishSuspendedEventMessage().ConfigureAwait(false);
         }
 

--- a/VideoWeb/VideoWeb.Services/VideoApiClient.cs
+++ b/VideoWeb/VideoWeb.Services/VideoApiClient.cs
@@ -3681,6 +3681,10 @@ namespace VideoWeb.Services.Video
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.4.0 (Newtonsoft.Json v12.0.0.0)")]
     public partial class ParticipantSummaryResponse 
     {
+        /// <summary>The participant id</summary>
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Guid Id { get; set; }
+    
         /// <summary>The participant username</summary>
         [Newtonsoft.Json.JsonProperty("username", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Username { get; set; }

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/DisconnectedEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/DisconnectedEventHandlerTests.cs
@@ -41,7 +41,7 @@ namespace VideoWeb.UnitTests.EventHandlers
 
         [Test]
         public async Task
-            Should_send_disconnect_and_suspend_messages_to_participants_and_service_bus_on_judge_disconnect()
+            Should_not_send_disconnect_but_send_suspend_messages_to_participants_and_service_bus_on_judge_disconnect()
         {
             _eventHandler = new DisconnectedEventHandler(EventHubContextMock.Object, MemoryCache, LoggerMock.Object);
 
@@ -62,7 +62,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             EventHubClientMock.Verify(
                 x => x.ParticipantStatusMessage(_eventHandler.SourceParticipant.Id,
                     ParticipantState.Disconnected),
-                Times.Exactly(participantCount));
+                Times.Never());
 
             EventHubClientMock.Verify(
                 x => x.ConferenceStatusMessage(conference.Id, ConferenceState.Suspended),


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-5677](https://tools.hmcts.net/jira/browse/VIH-5677)

### Change description ###

There is no need to publish disconnect events for judges since the Judge Available, Judge Unavailable events manage the concern about a judge's availability. This should stop the latter events from being overwritten due to the time is takes for Kinly to notify a judge has been disconnected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
