### PR TITLE
VIH-5255 Remove test for Edge from overnights

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/Features/Filters.feature
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Features/Filters.feature
@@ -3,33 +3,6 @@ Feature: Filters
 	As a Video Hearings Officer
 	I want to limit the number of displayed hearings
 
-@VIH-5503 @Ignore
-Scenario: VHO filters hearings by alert type
-  Given I have a hearing
-  And I have another hearing
-  And the hearing has every type of alert
-	And the Video Hearings Officer user has progressed to the VHO Hearing List page for the existing hearing
-  When the user filters by alert with the options Disconnected,Self-test failed,Cam/mic blocked,Suspended
-  Then the hearings are filtered
-
-@VIH-5846 @Smoketest-Extended  @Ignore
-Scenario: VHO filters hearings by location
-  Given I have a hearing located in Birmingham CFJC
-  And I have another hearing located in Manchester CFJC
-  And the Video Hearings Officer user has progressed to the VHO Venue List page for the existing hearing
-  When the VHO selects the courtroom Manchester CFJC
-  And the VHO confirms their allocation selection
-  Then the hearings are filtered
-
-@VIH-5417 @Ignore
-Scenario: VHO filters hearings by status
-  Given I have a hearing
-  And I have another hearing in -10 minutes time
-	And the Video Hearings Officer user has progressed to the VHO Hearing List page for the existing hearing
-  And the hearing has every type of alert
-  When the user filters by status with the options In session,Paused,Suspended,Closed,Delayed
-  Then the hearings are filtered
-
 Scenario: VHO filters hearings by Judge name
   Given I have a hearing with a Judge
   And I have another hearing with another Judge

--- a/VideoWeb/VideoWeb.AcceptanceTests/Hooks/ZapHooks.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Hooks/ZapHooks.cs
@@ -7,7 +7,7 @@ using TechTalk.SpecFlow;
 namespace VideoWeb.AcceptanceTests.Hooks
 {
     [Binding]
-    public static class ZapHook
+    public static class ZapHooks
     {
         private static VideoWebVhServicesConfig VhServices => ConfigurationManager.BuildConfig("CA353381-2F0D-47D7-A97B-79A30AFF8B86").GetSection("VhServices").Get<VideoWebVhServicesConfig>();
 
@@ -20,7 +20,10 @@ namespace VideoWeb.AcceptanceTests.Hooks
         [AfterTestRun]
         public static void ZapReport()
         {
-            Zap.ReportAndShutDown("VideoWeb-Acceptance", VhServices.VideoWebApiUrl);
+            if (VhServices.VideoWebApiUrl != null)
+            {
+                Zap.ReportAndShutDown("VideoWeb-Acceptance", VhServices.VideoWebApiUrl);
+            }
         }
     }
 }

--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -100,7 +100,7 @@
     <PackageReference Include="SpecFlow.NUnit" Version="3.1.97" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Include="VH.AcceptanceTests.Common" Version="1.0.221" />
+    <PackageReference Include="VH.AcceptanceTests.Common" Version="1.0.222" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -276,9 +276,9 @@
       },
       "VH.AcceptanceTests.Common": {
         "type": "Direct",
-        "requested": "[1.0.221, )",
-        "resolved": "1.0.221",
-        "contentHash": "zy5QX8Eao6nJRvZ11/uhKjW7DUV+ME+BdBZ04bEw/1laz/fs6GcH15Mb7nRWqa+RtOIyiSCbSu6q6w8FWT4CZw==",
+        "requested": "[1.0.222, )",
+        "resolved": "1.0.222",
+        "contentHash": "LodMyTPuo7Xy/buJaoXGgaYa4688SR9U3hgX2dX5EnYvoC7aVQsmbthtEVawD6iWoll71bBwjxpf9TIiZzNveg==",
         "dependencies": {
           "Appium.WebDriver": "4.1.1",
           "Azure.Storage.Blobs": "12.4.4",

--- a/azure-pipelines.nightly.yml
+++ b/azure-pipelines.nightly.yml
@@ -60,12 +60,6 @@ parameters:
       DeviceName:
       TestCaseFilter: TestCategory=Smoketest-Extended
     - OS: Windows
-      Browser: Edge
-      BrowserVersion: Latest
-      DeviceType: Desktop
-      DeviceName:
-      TestCaseFilter: TestCategory=UnsupportedBrowser
-    - OS: Windows
       Browser: Ie11
       BrowserVersion: Latest
       DeviceType: Desktop


### PR DESCRIPTION
### Change description ###
- Edge is supported but not by automation tests. Removing from overnight tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
