### PR TITLE
VIH-6372 unmute individuals after conference mute

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls.component.html
@@ -139,7 +139,7 @@
             (click)="close()"
             aria-label="Close Button"
           >
-            End
+            Close
           </button>
 
           <button

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -189,6 +189,30 @@ describe('ParticipantsPanelComponent', () => {
         component.toggleMuteParticipant(pat);
         expect(videocallService.muteParticipant).toHaveBeenCalledWith(pat.pexipId, true);
     });
+
+    it('should unmute conference when last participant is unmuted after a conference mute', () => {
+        videocallService.muteAllParticipants.calls.reset();
+        component.isMuteAll = true;
+        const pat = component.participants[0];
+        pat.isMuted = true;
+
+        component.toggleMuteParticipant(pat);
+
+        expect(videocallService.muteAllParticipants).toHaveBeenCalledWith(false);
+    });
+
+    it('should not unmute conference when second last participant is unmuted after a conference mute', () => {
+        videocallService.muteAllParticipants.calls.reset();
+        component.isMuteAll = true;
+        const pat = component.participants[0];
+        pat.isMuted = true;
+        component.participants[1].isMuted = true;
+
+        component.toggleMuteParticipant(pat);
+
+        expect(videocallService.muteAllParticipants).toHaveBeenCalledTimes(0);
+    });
+
     it('should lower hand for all participants', () => {
         component.lowerAllHands();
         expect(videocallService.lowerAllHands).toHaveBeenCalled();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -132,8 +132,14 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
     }
 
     toggleMuteParticipant(participant: ParticipantPanelModel) {
+        const numberOfMutedParticipants = this.participants.filter(x => x.isMuted).length;
         const p = this.participants.find(x => x.participantId === participant.participantId);
         this.videoCallService.muteParticipant(p.pexipId, !p.isMuted);
+
+        // check if last person to be unmuted manually
+        if (numberOfMutedParticipants === 1 && this.isMuteAll) {
+            this.videoCallService.muteAllParticipants(false);
+        }
     }
 
     lowerAllHands() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-6372

### Change description ###

* End button renamed to close
* Unmutes a conference after manually unmuting individuals after a conference mute

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
