### PR TITLE
VIH-6372 trigger conference mute and unmute after last manual mute and unmute

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -89,12 +89,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         participant.pexipId = updatedParticipant.uuid;
         participant.isMuted = updatedParticipant.isRemoteMuted;
         participant.handRaised = updatedParticipant.handRaised;
-        this.checkParticipantMuteAllStatus();
-    }
-
-    checkParticipantMuteAllStatus() {
-        const numberOfMutedParticipants = this.participants.filter(x => x.isMuted).length;
-        this.isMuteAll = numberOfMutedParticipants > 0;
     }
 
     handleParticipantStatusChange(message: ParticipantStatusMessage): void {
@@ -134,13 +128,23 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
     }
 
     toggleMuteParticipant(participant: ParticipantPanelModel) {
-        const numberOfMutedParticipants = this.participants.filter(x => x.isMuted).length;
+        const hearingParticipants = this.participants.filter(x => x.status === ParticipantStatus.InHearing);
+        const mutedParticipants = hearingParticipants.filter(x => x.isMuted);
         const p = this.participants.find(x => x.participantId === participant.participantId);
+
+        console.log(hearingParticipants);
+        console.log(mutedParticipants);
+        console.log(p);
         this.videoCallService.muteParticipant(p.pexipId, !p.isMuted);
 
         // check if last person to be unmuted manually
-        if (numberOfMutedParticipants === 1 && this.isMuteAll) {
+        if (mutedParticipants.length === 1 && this.isMuteAll) {
             this.videoCallService.muteAllParticipants(false);
+        }
+
+        // mute conference if last person manually muted
+        if (mutedParticipants.length === hearingParticipants.length - 1) {
+            this.videoCallService.muteAllParticipants(true);
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-6372

### Change description ###

* mute the conference after the last person is muted manually
  * safely updated button to unmute all and correctly unmutes all participants

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
