### PR TITLE
VIH-6283 set icon width rather than use auto

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.scss
@@ -177,7 +177,7 @@
   color: govuk-colour('white');
   padding-left: 12px;
   display: grid;
-  grid-template-columns: auto 40px 40px 40px auto;
+  grid-template-columns: auto 40px 40px 40px 40px;
   grid-template-rows: auto auto;
 }
 .pName {


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-6283

### Change description ###

* set grid cell width to 40px rather than auto to ensure all rows have the same width

![image](https://user-images.githubusercontent.com/41630528/94574660-49551100-026b-11eb-8f3b-f096f14ded8a.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
