### PR TITLE
VIH-7176 handle room events

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -67,7 +67,6 @@
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Contract\VideoWeb.Contract.csproj" />
     <ProjectReference Include="..\VideoWeb.EventHub\VideoWeb.EventHub.csproj" />
-    <ProjectReference Include="..\VideoWeb.Services\VideoWeb.Services.csproj" />
   </ItemGroup>
 
 </Project>

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -2371,14 +2371,14 @@
           "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.8",
           "StackExchange.Redis": "2.1.28",
           "System.IdentityModel.Tokens.Jwt": "5.6.0",
-          "VideoWeb.Services": "1.0.0"
+          "UserApi.Client": "1.24.2",
+          "VideoApi.Client": "1.23.48"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
+          "VideoWeb.Common": "1.0.0"
         }
       },
       "videoweb.eventhub": {
@@ -2391,18 +2391,7 @@
           "System.Text.Json": "4.7.1",
           "UserApi.Client": "1.24.2",
           "VideoApi.Client": "1.23.48",
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
-        }
-      },
-      "videoweb.services": {
-        "type": "Project",
-        "dependencies": {
-          "BookingsApi.Client": "1.24.17",
-          "Microsoft.Extensions.Options": "3.1.10",
-          "Newtonsoft.Json": "12.0.3",
-          "UserApi.Client": "1.24.2",
-          "VideoApi.Client": "1.23.48"
+          "VideoWeb.Common": "1.0.0"
         }
       }
     }

--- a/VideoWeb/VideoWeb.Common/Caching/ConferenceCache.cs
+++ b/VideoWeb/VideoWeb.Common/Caching/ConferenceCache.cs
@@ -18,7 +18,11 @@ namespace VideoWeb.Common.Caching
         public async Task AddConferenceAsync(ConferenceDetailsResponse conferenceResponse)
         {
             var conference = ConferenceCacheMapper.MapConferenceToCacheModel(conferenceResponse);
-            
+            await UpdateConferenceAsync(conference);
+        }
+
+        public async Task UpdateConferenceAsync(Conference conference)
+        {
             await _memoryCache.GetOrCreateAsync(conference.Id, entry =>
             {
                 entry.SlidingExpiration = TimeSpan.FromHours(4);

--- a/VideoWeb/VideoWeb.Common/Caching/DistributedConferenceCache.cs
+++ b/VideoWeb/VideoWeb.Common/Caching/DistributedConferenceCache.cs
@@ -20,6 +20,11 @@ namespace VideoWeb.Common.Caching
         public async Task AddConferenceAsync(ConferenceDetailsResponse conferenceResponse)
         {
             var conference = ConferenceCacheMapper.MapConferenceToCacheModel(conferenceResponse);
+            await UpdateConferenceAsync(conference);
+        }
+
+        public async Task UpdateConferenceAsync(Conference conference)
+        {
             var serialisedConference = JsonConvert.SerializeObject(conference, CachingHelper.SerializerSettings);
 
             var data = Encoding.UTF8.GetBytes(serialisedConference);
@@ -29,7 +34,6 @@ namespace VideoWeb.Common.Caching
                 {
                     SlidingExpiration = TimeSpan.FromHours(4)
                 });
-
         }
 
         public async Task<Conference> GetOrAddConferenceAsync(Guid id, Func<Task<ConferenceDetailsResponse>> addConferenceDetailsFactory)

--- a/VideoWeb/VideoWeb.Common/Caching/IConferenceCache.cs
+++ b/VideoWeb/VideoWeb.Common/Caching/IConferenceCache.cs
@@ -8,6 +8,7 @@ namespace VideoWeb.Common.Caching
     public interface IConferenceCache
     {
         Task AddConferenceAsync(ConferenceDetailsResponse conferenceResponse);
+        Task UpdateConferenceAsync(Conference conference);
         Task <Conference>GetOrAddConferenceAsync(Guid id, Func<Task<ConferenceDetailsResponse>> addConferenceDetailsFactory);
     }
 }

--- a/VideoWeb/VideoWeb.Common/Models/CivilianRoom.cs
+++ b/VideoWeb/VideoWeb.Common/Models/CivilianRoom.cs
@@ -5,6 +5,11 @@ namespace VideoWeb.Common.Models
 {
     public class CivilianRoom
     {
+        public CivilianRoom()
+        {
+            Participants = new List<Guid>();
+        }
+        
         public long Id { get; set; }
         public string RoomLabel { get; set; }
         public List<Guid> Participants { get; set; }

--- a/VideoWeb/VideoWeb.Common/Models/Conference.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Conference.cs
@@ -10,6 +10,7 @@ namespace VideoWeb.Common.Models
         {
             Participants = new List<Participant>();
             Endpoints = new List<Endpoint>();
+            CivilianRooms = new List<CivilianRoom>();
         }
 
         public Guid Id { get; set; }
@@ -22,6 +23,34 @@ namespace VideoWeb.Common.Models
         public Participant GetJudge()
         {
             return Participants.SingleOrDefault(x => x.IsJudge());
+        }
+
+        public void AddParticipantToRoom(long roomId, Guid participantId)
+        {
+            var room = GetOrCreateCivilianRoom(roomId);
+            if (!room.Participants.Contains(participantId))
+            {
+                room.Participants.Add(participantId);
+            }
+        }
+
+        public void RemoveParticipantFromRoom(long roomId, Guid participantId)
+        {
+            var room = GetOrCreateCivilianRoom(roomId);
+            if (room.Participants.Contains(participantId))
+            {
+                room.Participants.Remove(participantId);
+            }
+        }
+
+        private CivilianRoom GetOrCreateCivilianRoom(long roomId)
+        {
+            var room = CivilianRooms.FirstOrDefault(x => x.Id == roomId);
+            if (room != null) return room;
+            room = new CivilianRoom {Id = roomId};
+            CivilianRooms.Add(room);
+
+            return room;
         }
     }
 }

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -18,10 +18,8 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="2.1.28" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\VideoWeb.Services\VideoWeb.Services.csproj" />
+    <PackageReference Include="UserApi.Client" Version="1.24.2" />
+    <PackageReference Include="VideoApi.Client" Version="1.23.48" />
   </ItemGroup>
 
 </Project>

--- a/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
+++ b/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />
-    <ProjectReference Include="..\VideoWeb.Services\VideoWeb.Services.csproj" />
   </ItemGroup>
 
 </Project>

--- a/VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj
+++ b/VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />
-    <ProjectReference Include="..\VideoWeb.Services\VideoWeb.Services.csproj" />
   </ItemGroup>
 
 </Project>

--- a/VideoWeb/VideoWeb.IntegrationTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.IntegrationTests/packages.lock.json
@@ -2682,8 +2682,7 @@
           "VH.Core.Configuration": "0.1.12",
           "VideoWeb.Common": "1.0.0",
           "VideoWeb.Contract": "1.0.0",
-          "VideoWeb.EventHub": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
+          "VideoWeb.EventHub": "1.0.0"
         }
       },
       "videoweb.common": {
@@ -2697,14 +2696,14 @@
           "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.8",
           "StackExchange.Redis": "2.1.28",
           "System.IdentityModel.Tokens.Jwt": "5.6.0",
-          "VideoWeb.Services": "1.0.0"
+          "UserApi.Client": "1.24.2",
+          "VideoApi.Client": "1.23.48"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
+          "VideoWeb.Common": "1.0.0"
         }
       },
       "videoweb.eventhub": {
@@ -2717,18 +2716,7 @@
           "System.Text.Json": "4.7.1",
           "UserApi.Client": "1.24.2",
           "VideoApi.Client": "1.23.48",
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
-        }
-      },
-      "videoweb.services": {
-        "type": "Project",
-        "dependencies": {
-          "BookingsApi.Client": "1.24.17",
-          "Microsoft.Extensions.Options": "3.1.10",
-          "Newtonsoft.Json": "12.0.3",
-          "UserApi.Client": "1.24.2",
-          "VideoApi.Client": "1.23.48"
+          "VideoWeb.Common": "1.0.0"
         }
       }
     }

--- a/VideoWeb/VideoWeb.UnitTests/ConferenceCacheTest.cs
+++ b/VideoWeb/VideoWeb.UnitTests/ConferenceCacheTest.cs
@@ -33,6 +33,20 @@ namespace VideoWeb.UnitTests
             await _conferenceCache.AddConferenceAsync(conference);
             _memoryCache.Get(conference.Id).Should().NotBeNull();
         }
+        
+        [Test]
+        public async Task Should_update_conference_to_cache()
+        {
+            var newVenueName = "Updated Name for Test";
+            var conference = CreateConferenceResponse();
+            await _conferenceCache.AddConferenceAsync(conference);
+            var cacheModel = _memoryCache.Get(conference.Id).As<Conference>();
+            cacheModel.HearingVenueName = newVenueName;
+            await _conferenceCache.UpdateConferenceAsync(cacheModel);
+            var updatedCacheModel = _memoryCache.Get(conference.Id).As<Conference>();
+            updatedCacheModel.HearingVenueName.Should().Be(newVenueName);
+
+        }
 
         [Test]
         public async Task GetOrAddConferenceAsync_should_return_conference_when_cache_contains_key()

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/BaseSendHearingEventTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/BaseSendHearingEventTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac.Extras.Moq;
+using FizzWare.NBuilder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using VideoApi.Client;
+using VideoApi.Contract.Enums;
+using VideoApi.Contract.Requests;
+using VideoApi.Contract.Responses;
+using VideoWeb.Common.Caching;
+using VideoWeb.Common.Models;
+using VideoWeb.Controllers;
+using VideoWeb.EventHub.Handlers.Core;
+using VideoWeb.EventHub.Models;
+using VideoWeb.Mappings;
+using VideoWeb.UnitTests.Builders;
+using Endpoint = VideoWeb.Common.Models.Endpoint;
+
+namespace VideoWeb.UnitTests.Controllers.VideoEventController
+{
+    public abstract class BaseSendHearingEventTests
+    {
+        protected VideoEventsController Sut;
+        protected Conference TestConference;
+        protected AutoMock Mocker;
+        
+        protected Conference BuildConferenceForTest()
+        {
+            var conference = new Conference
+            {
+                Id = Guid.NewGuid(),
+                HearingId = Guid.NewGuid(),
+                Participants = new List<Participant>()
+                {
+                    Builder<Participant>.CreateNew()
+                        .With(x => x.Role = Role.Judge).With(x => x.Id = Guid.NewGuid())
+                        .Build(),
+                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
+                        .With(x => x.Id = Guid.NewGuid()).Build(),
+                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
+                        .With(x => x.Id = Guid.NewGuid()).Build(),
+                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
+                        .With(x => x.Id = Guid.NewGuid()).Build(),
+                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
+                        .With(x => x.Id = Guid.NewGuid()).Build()
+                },
+                Endpoints = new List<Endpoint>
+                {
+                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid()).With(x => x.DisplayName = "EP1")
+                        .Build(),
+                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid()).With(x => x.DisplayName = "EP2")
+                        .Build()
+                },
+                HearingVenueName = "Hearing Venue Test",
+                CivilianRooms = new List<CivilianRoom>
+                {
+                    new CivilianRoom {Id = 1, RoomLabel = "Interpreter1", Participants = new List<Guid>()}
+                }
+            };
+            
+            
+            conference.CivilianRooms.First().Participants.Add(conference.Participants[1].Id);
+            conference.CivilianRooms.First().Participants.Add(conference.Participants[2].Id);
+
+            return conference;
+        }
+        
+        protected ConferenceEventRequest CreateRequest(string phone = null)
+        {
+            return Builder<ConferenceEventRequest>.CreateNew()
+                .With(x => x.ConferenceId = TestConference.Id.ToString())
+                .With(x => x.ParticipantId = TestConference.Participants[0].Id.ToString())
+                .With(x => x.EventType = EventType.Joined)
+                .With(x => x.Phone = phone)
+                .With(x => x.ParticipantRoomId = null)
+                .Build();
+        }
+        protected ConferenceDetailsResponse CreateValidConferenceResponse(string username = "john@hmcts.net")
+        {
+            var participants = Builder<ParticipantDetailsResponse>.CreateListOfSize(2).Build().ToList();
+            if (!string.IsNullOrWhiteSpace(username))
+            {
+                participants.First().Username = username;
+            }
+
+            var conference = Builder<ConferenceDetailsResponse>.CreateNew()
+                .With(x => x.Participants = participants)
+                .Build();
+            return conference;
+        }
+        protected void SetupTestConferenceAndMocks()
+        {
+            Mocker = AutoMock.GetLoose();
+
+            TestConference = BuildConferenceForTest();
+            
+            var claimsPrincipal = new ClaimsPrincipalBuilder().Build();
+            var context = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = claimsPrincipal
+                }
+            };
+
+            Mocker.Mock<IMapperFactory>().Setup(x => x.Get<ConferenceEventRequest, Conference, CallbackEvent>()).Returns(Mocker.Create<CallbackEventMapper>());
+            Sut = Mocker.Create<VideoEventsController>();
+            Sut.ControllerContext = context;
+
+            var conference = CreateValidConferenceResponse(null);
+            Mocker.Mock<IVideoApiClient>()
+                .Setup(x => x.GetConferenceDetailsByIdAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(conference);
+            Mocker.Mock<IConferenceCache>().Setup(cache => cache.GetOrAddConferenceAsync(TestConference.Id, It.IsAny<Func<Task<ConferenceDetailsResponse>>>()))
+                .Callback(async (Guid anyGuid, Func<Task<ConferenceDetailsResponse>> factory) => await factory())
+                .ReturnsAsync(TestConference);
+            Mocker.Mock<IConferenceCache>().Setup(cache => cache.UpdateConferenceAsync(It.IsAny<Conference>()))
+                .Callback<Conference>(updatedConference => { TestConference = updatedConference; });
+            Mocker.Mock<IEventHandlerFactory>().Setup(x => x.Get(It.IsAny<EventHub.Enums.EventType>())).Returns(Mocker.Mock<IEventHandler>().Object);
+        }
+    }
+}

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/SendHearingEventTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/SendHearingEventTests.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Autofac.Extras.Moq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -11,55 +8,22 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
 using VideoWeb.Common.Caching;
-using VideoWeb.Common.Models;
-using VideoWeb.Controllers;
 using VideoWeb.EventHub.Handlers.Core;
 using VideoWeb.EventHub.Models;
-using VideoWeb.Mappings;
 using VideoApi.Client;
 using VideoApi.Contract.Responses;
 using VideoApi.Contract.Requests;
-using VideoWeb.UnitTests.Builders;
-using Endpoint = VideoWeb.Common.Models.Endpoint;
 using VideoApi.Contract.Enums;
 using RoomType = VideoApi.Contract.Enums.RoomType;
 
 namespace VideoWeb.UnitTests.Controllers.VideoEventController
 {
-    public class SendHearingEventTests
+    public class SendHearingEventTests : BaseSendHearingEventTests
     {
-        private VideoEventsController _sut;
-        private Conference _testConference;
-        private AutoMock _mocker;
-
         [SetUp]
         public void Setup()
         {
-            _mocker = AutoMock.GetLoose();
-
-            _testConference = BuildConferenceForTest();
-            
-            var claimsPrincipal = new ClaimsPrincipalBuilder().Build();
-            var context = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext
-                {
-                    User = claimsPrincipal
-                }
-            };
-
-            _mocker.Mock<IMapperFactory>().Setup(x => x.Get<ConferenceEventRequest, Conference, CallbackEvent>()).Returns(_mocker.Create<CallbackEventMapper>());
-            _sut = _mocker.Create<VideoEventsController>();
-            _sut.ControllerContext = context;
-
-            var conference = CreateValidConferenceResponse(null);
-            _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferenceDetailsByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(conference);
-            _mocker.Mock<IConferenceCache>().Setup(cache => cache.GetOrAddConferenceAsync(_testConference.Id, It.IsAny<Func<Task<ConferenceDetailsResponse>>>()))
-                .Callback(async (Guid anyGuid, Func<Task<ConferenceDetailsResponse>> factory) => await factory())
-                .ReturnsAsync(_testConference);
-            _mocker.Mock<IEventHandlerFactory>().Setup(x => x.Get(It.IsAny<EventHub.Enums.EventType>())).Returns(_mocker.Mock<IEventHandler>().Object);
+            SetupTestConferenceAndMocks();
         }
 
         [Test]
@@ -69,32 +33,15 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             var request = CreateRequest();
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
             result.Should().BeOfType<NoContentResult>();
             var typedResult = (NoContentResult) result;
             typedResult.Should().NotBeNull();
         }
 
-        [Test]
-        public async Task should_return_no_content_when_event_is_for_room()
-        {
-            // Arrange
-            var request = CreateRequest();
-            request.ParticipantId = _testConference.CivilianRooms.First().Id.ToString();
-
-            // Act
-            var result = await _sut.SendHearingEventAsync(request);
-
-            // Assert
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
-            result.Should().BeOfType<NoContentResult>();
-            var typedResult = (NoContentResult) result;
-            typedResult.Should().NotBeNull();
-        }
-        
         [Test]
         public async Task should_return_no_content_when_transfer_to_new_consultation_room()
         {
@@ -105,10 +52,10 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             request.TransferFrom = RoomType.WaitingRoom.ToString();
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
             result.Should().BeOfType<NoContentResult>();
             var typedResult = (NoContentResult) result;
             typedResult.Should().NotBeNull();
@@ -124,10 +71,10 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             request.TransferTo = RoomType.WaitingRoom.ToString();
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
             result.Should().BeOfType<NoContentResult>();
             var typedResult = (NoContentResult) result;
             typedResult.Should().NotBeNull();
@@ -140,10 +87,10 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             var request = CreateRequest("0123456789");
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Never);
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Never);
             result.Should().BeOfType<NoContentResult>();
             var typedResult = (NoContentResult)result;
             typedResult.Should().NotBeNull();
@@ -160,14 +107,14 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             var eventType = Enum.Parse<EventHub.Enums.EventType>(expectedEventType.ToString());
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
             
             // Assert
             result.Should().BeOfType<NoContentResult>();
             var typedResult = (NoContentResult) result;
             typedResult.Should().NotBeNull();
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.Is<CallbackEvent>(c => c.EventType == eventType)), Times.Once);
-            _mocker.Mock<IVideoApiClient>().Verify(x =>
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.Is<CallbackEvent>(c => c.EventType == eventType)), Times.Once);
+            Mocker.Mock<IVideoApiClient>().Verify(x =>
                 x.RaiseVideoEventAsync(It.Is<ConferenceEventRequest>(r => r.EventType == expectedEventType)));
         }
 
@@ -182,14 +129,14 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             var eventType = Enum.Parse<EventHub.Enums.EventType>(incomingEventType.ToString());
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
             result.Should().BeOfType<NoContentResult>();
             var typedResult = (NoContentResult)result;
             typedResult.Should().NotBeNull();
-            _mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.Is<CallbackEvent>(c => c.EventType == eventType)), Times.Once);
-            _mocker.Mock<IVideoApiClient>().Verify(x =>
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.Is<CallbackEvent>(c => c.EventType == eventType)), Times.Once);
+            Mocker.Mock<IVideoApiClient>().Verify(x =>
                 x.RaiseVideoEventAsync(It.Is<ConferenceEventRequest>(r => r.EventType == incomingEventType)));
         }
 
@@ -199,13 +146,13 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             // Arrange
             var apiException = new VideoApiException<ProblemDetails>("Bad Request", (int) HttpStatusCode.BadRequest,
                 "Please provide a valid conference Id", null, default, null);
-            _mocker.Mock<IVideoApiClient>()
+            Mocker.Mock<IVideoApiClient>()
                 .Setup(x => x.RaiseVideoEventAsync(It.IsAny<ConferenceEventRequest>()))
                 .ThrowsAsync(apiException);
             var request = CreateRequest();
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
             result.Should().BeOfType<ObjectResult>();
@@ -219,13 +166,13 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             // Arrange
             var apiException = new VideoApiException<ProblemDetails>("Internal Server Error", (int) HttpStatusCode.InternalServerError,
                 "Stacktrace goes here", null, default, null);
-            _mocker.Mock<IVideoApiClient>()
+            Mocker.Mock<IVideoApiClient>()
                 .Setup(x => x.RaiseVideoEventAsync(It.IsAny<ConferenceEventRequest>()))
                 .ThrowsAsync(apiException);
             var request = CreateRequest();
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
             result.Should().BeOfType<ObjectResult>();
@@ -239,13 +186,13 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             // Arrange
             var apiException = new VideoApiException<ProblemDetails>("Internal Server Error", (int) HttpStatusCode.InternalServerError,
                 "Stacktrace goes here", null, default, null);
-            _mocker.Mock<IConferenceCache>()
+            Mocker.Mock<IConferenceCache>()
                 .Setup(x => x.GetOrAddConferenceAsync(It.IsAny<Guid>(), It.IsAny<Func<Task<ConferenceDetailsResponse>>>()))
                 .ThrowsAsync(apiException);
             var request = CreateRequest();
 
             // Act
-            var result = await _sut.SendHearingEventAsync(request);
+            var result = await Sut.SendHearingEventAsync(request);
 
             // Assert
             result.Should().BeOfType<ObjectResult>();
@@ -253,76 +200,18 @@ namespace VideoWeb.UnitTests.Controllers.VideoEventController
             typedResult.Should().NotBeNull();
             typedResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
         }
-
-        private ConferenceEventRequest CreateRequest(string phone = null)
-        {
-            return Builder<ConferenceEventRequest>.CreateNew()
-                .With(x => x.ConferenceId = _testConference.Id.ToString())
-                .With(x => x.ParticipantId = _testConference.Participants[0].Id.ToString())
-                .With(x => x.EventType = EventType.Joined)
-                .With(x => x.Phone = phone)
-                .Build();
-        }
         
         private ConferenceEventRequest CreateEndpointRequest(EventType incomingEventType)
         {
             return Builder<ConferenceEventRequest>.CreateNew()
-                .With(x => x.ConferenceId = _testConference.Id.ToString())
-                .With(x => x.ParticipantId = _testConference.Endpoints[0].Id.ToString())
+                .With(x => x.ConferenceId = TestConference.Id.ToString())
+                .With(x => x.ParticipantId = TestConference.Endpoints[0].Id.ToString())
                 .With(x => x.EventType = incomingEventType)
                 .With(x => x.TransferTo = "ParticipantConsultationRoom10")
                 .With(x => x.TransferFrom = RoomType.WaitingRoom.ToString())
+                .With(x => x.ParticipantRoomId = null)
                 .With(x => x.Phone = null)
                 .Build();
-        }
-        
-        private static Conference BuildConferenceForTest()
-        {
-            return new Conference
-            {
-                Id = Guid.NewGuid(),
-                HearingId = Guid.NewGuid(),
-                Participants = new List<Participant>()
-                {
-                    Builder<Participant>.CreateNew()
-                        .With(x => x.Role = Role.Judge).With(x => x.Id = Guid.NewGuid())
-                        .Build(),
-                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
-                        .With(x => x.Id = Guid.NewGuid()).Build(),
-                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
-                        .With(x => x.Id = Guid.NewGuid()).Build(),
-                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
-                        .With(x => x.Id = Guid.NewGuid()).Build(),
-                    Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
-                        .With(x => x.Id = Guid.NewGuid()).Build()
-                },
-                Endpoints = new List<Endpoint>
-                {
-                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid()).With(x => x.DisplayName = "EP1")
-                        .Build(),
-                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid()).With(x => x.DisplayName = "EP2")
-                        .Build()
-                },
-                HearingVenueName = "Hearing Venue Test",
-                CivilianRooms = new List<CivilianRoom>
-                {
-                    new CivilianRoom {Id = 1, RoomLabel = "Interpreter1", Participants = new List<Guid>()}
-                }
-            };
-        }
-
-        private ConferenceDetailsResponse CreateValidConferenceResponse(string username = "john@hmcts.net")
-        {
-            var participants = Builder<ParticipantDetailsResponse>.CreateListOfSize(2).Build().ToList();
-            if (!string.IsNullOrWhiteSpace(username))
-            {
-                participants.First().Username = username;
-            }
-
-            var conference = Builder<ConferenceDetailsResponse>.CreateNew()
-                .With(x => x.Participants = participants)
-                .Build();
-            return conference;
         }
         
     }

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/SendVmrHearingEventTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/VideoEventController/SendVmrHearingEventTests.cs
@@ -1,0 +1,118 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using VideoApi.Client;
+using VideoApi.Contract.Enums;
+using VideoApi.Contract.Requests;
+using VideoWeb.EventHub.Handlers.Core;
+using VideoWeb.EventHub.Models;
+
+namespace VideoWeb.UnitTests.Controllers.VideoEventController
+{
+    public class SendVmrHearingEventTests : BaseSendHearingEventTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            SetupTestConferenceAndMocks();
+        }
+        
+        [Test]
+        public async Task should_return_no_content_when_event_is_for_participant_joining_a_room()
+        {
+            // Arrange
+            var request = CreateRequest();
+            request.ParticipantRoomId = TestConference.CivilianRooms.First().Id.ToString();
+
+            // Act
+            var result = await Sut.SendHearingEventAsync(request);
+
+            // Assert
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
+            result.Should().BeOfType<NoContentResult>();
+            var typedResult = (NoContentResult) result;
+            typedResult.Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task should_add_participant_to_room_on_join_room_event()
+        {
+            // Arrange
+            var roomId = 999;
+            var participantId = TestConference.Participants.Last().Id;
+            var request = CreateRequest();
+            request.ParticipantRoomId = roomId.ToString();
+            request.ParticipantId = participantId.ToString();
+            
+            // Act
+            var result = await Sut.SendHearingEventAsync(request);
+            
+            // Assert
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
+            result.Should().BeOfType<NoContentResult>();
+            var typedResult = (NoContentResult) result;
+            typedResult.Should().NotBeNull();
+
+            var newCacheRoom = TestConference.CivilianRooms.FirstOrDefault(x => x.Id == roomId);
+            newCacheRoom.Should().NotBeNull();
+            newCacheRoom?.Participants.Any(x => x == participantId).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task should_remove_participant_from_room_on_disconnect_event()
+        {
+            // Arrange
+            var request = CreateRequest();
+            var room = TestConference.CivilianRooms.First();
+            var roomId = room.Id;
+            var participantId = room.Participants.First();
+            request.ParticipantRoomId = roomId.ToString();
+            request.ParticipantId = participantId.ToString();
+            request.EventType = EventType.Disconnected;
+            
+            // Act
+            var result = await Sut.SendHearingEventAsync(request);
+            
+            // Assert
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()), Times.Once);
+            result.Should().BeOfType<NoContentResult>();
+            var typedResult = (NoContentResult) result;
+            typedResult.Should().NotBeNull();
+
+            var newCacheRoom = TestConference.CivilianRooms.FirstOrDefault(x => x.Id == roomId);
+            newCacheRoom.Should().NotBeNull();
+            newCacheRoom?.Participants.Any(x => x == participantId).Should().BeFalse();
+        }
+
+        [Test]
+        public async Task should_publish_transfer_event_to_all_participants_in_room()
+        {
+            // Arrange
+            var room = TestConference.CivilianRooms.First(x => x.Participants.Any());
+            var participantCount = room.Participants.Count;
+
+            var request = CreateRequest();
+            request.ParticipantId = room.Id.ToString();
+            request.ParticipantRoomId = string.Empty;
+            request.EventType = EventType.Transfer;
+            request.TransferFrom = "WaitingRoom";
+            request.TransferTo = "HearingRoom";
+
+            // Act
+            var result = await Sut.SendHearingEventAsync(request);
+
+            // Assert
+            result.Should().BeOfType<NoContentResult>();
+            var typedResult = (NoContentResult) result;
+            typedResult.Should().NotBeNull();
+
+            Mocker.Mock<IEventHandler>().Verify(x => x.HandleAsync(It.IsAny<CallbackEvent>()),
+                Times.Exactly(participantCount));
+            Mocker.Mock<IVideoApiClient>().Verify(x => x.RaiseVideoEventAsync(It.IsAny<ConferenceEventRequest>()),
+                Times.Exactly(participantCount));
+        }
+    }
+}

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -2376,8 +2376,7 @@
           "VH.Core.Configuration": "0.1.12",
           "VideoWeb.Common": "1.0.0",
           "VideoWeb.Contract": "1.0.0",
-          "VideoWeb.EventHub": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
+          "VideoWeb.EventHub": "1.0.0"
         }
       },
       "videoweb.common": {
@@ -2391,14 +2390,14 @@
           "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.8",
           "StackExchange.Redis": "2.1.28",
           "System.IdentityModel.Tokens.Jwt": "5.6.0",
-          "VideoWeb.Services": "1.0.0"
+          "UserApi.Client": "1.24.2",
+          "VideoApi.Client": "1.23.48"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
+          "VideoWeb.Common": "1.0.0"
         }
       },
       "videoweb.eventhub": {
@@ -2411,18 +2410,7 @@
           "System.Text.Json": "4.7.1",
           "UserApi.Client": "1.24.2",
           "VideoApi.Client": "1.23.48",
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
-        }
-      },
-      "videoweb.services": {
-        "type": "Project",
-        "dependencies": {
-          "BookingsApi.Client": "1.24.17",
-          "Microsoft.Extensions.Options": "3.1.10",
-          "Newtonsoft.Json": "12.0.3",
-          "UserApi.Client": "1.24.2",
-          "VideoApi.Client": "1.23.48"
+          "VideoWeb.Common": "1.0.0"
         }
       }
     }

--- a/VideoWeb/VideoWeb.sln
+++ b/VideoWeb/VideoWeb.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VideoWeb.Common", "VideoWeb
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VideoWeb.Contract", "VideoWeb.Contract\VideoWeb.Contract.csproj", "{6F865A99-C586-4FF1-B102-81F87C686578}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VideoWeb.Services", "VideoWeb.Services\VideoWeb.Services.csproj", "{473B7E77-C3AC-4131-9026-A9EA6107C0B9}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VideoWeb.AcceptanceTests", "VideoWeb.AcceptanceTests\VideoWeb.AcceptanceTests.csproj", "{E901FAB5-4429-4A0B-BEF0-058610D0EDB6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VideoWeb.EventHub", "VideoWeb.EventHub\VideoWeb.EventHub.csproj", "{371E895D-1CDC-4872-BCCC-7199DD3AA519}"
@@ -49,10 +47,6 @@ Global
 		{6F865A99-C586-4FF1-B102-81F87C686578}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F865A99-C586-4FF1-B102-81F87C686578}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F865A99-C586-4FF1-B102-81F87C686578}.Release|Any CPU.Build.0 = Release|Any CPU
-		{473B7E77-C3AC-4131-9026-A9EA6107C0B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{473B7E77-C3AC-4131-9026-A9EA6107C0B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{473B7E77-C3AC-4131-9026-A9EA6107C0B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{473B7E77-C3AC-4131-9026-A9EA6107C0B9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E901FAB5-4429-4A0B-BEF0-058610D0EDB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E901FAB5-4429-4A0B-BEF0-058610D0EDB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E901FAB5-4429-4A0B-BEF0-058610D0EDB6}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/VideoWeb/VideoWeb/Extensions/ConferenceEventRequestExtensions.cs
+++ b/VideoWeb/VideoWeb/Extensions/ConferenceEventRequestExtensions.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using Castle.Core.Internal;
+using VideoApi.Contract.Requests;
+using VideoWeb.Common.Models;
+
+namespace VideoWeb.Extensions
+{
+    public static class ConferenceEventRequestExtensions
+    {
+        public static bool IsParticipantAndVmrEvent(this ConferenceEventRequest request)
+        {
+            return !request.ParticipantRoomId.IsNullOrEmpty() && !request.ParticipantId.IsNullOrEmpty();
+        }
+
+        public static bool IsParticipantAVmr(this ConferenceEventRequest request, Conference conference,
+            out long roomId)
+        {
+            if (!long.TryParse(request.ParticipantId, out roomId)) return false;
+            var id = roomId;
+            return conference.CivilianRooms.Any(x => x.Id == id);
+        }
+
+        public static List<ConferenceEventRequest> CreateEventsForParticipantsInRoom(this ConferenceEventRequest request,
+            Conference conference, long roomId)
+        {
+            return conference.CivilianRooms.First(x => x.Id == roomId).Participants.Select(p =>
+            {
+                var participantEventRequest = new ConferenceEventRequest
+                {
+                    ConferenceId = request.ConferenceId,
+                    EventId = request.EventId,
+                    EventType = request.EventType,
+                    ParticipantId = p.ToString(),
+                    ParticipantRoomId = roomId.ToString(),
+                    Phone = request.Phone,
+                    Reason = request.Reason,
+                    TimeStampUtc = request.TimeStampUtc,
+                    TransferFrom = request.TransferFrom,
+                    TransferTo = request.TransferTo
+                };
+                return participantEventRequest;
+            }).ToList();
+        }
+    }
+}

--- a/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
+++ b/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
@@ -249,19 +249,19 @@ namespace VideoWeb.Extensions
         private static IBookingsApiClient BuildBookingsApiClient(HttpClient httpClient,
             HearingServicesConfiguration servicesConfiguration)
         {
-            return new BookingsApiClient(httpClient) { BaseUrl = servicesConfiguration.BookingsApiUrl };
+            return BookingsApiClient.GetClient(servicesConfiguration.BookingsApiUrl, httpClient);
         }
 
         private static IVideoApiClient BuildVideoApiClient(HttpClient httpClient,
             HearingServicesConfiguration serviceSettings)
         {
-            return new VideoApiClient(httpClient) { BaseUrl = serviceSettings.VideoApiUrl, ReadResponseAsString = true };
+            return VideoApiClient.GetClient(serviceSettings.VideoApiUrl, httpClient);
         }
 
         private static IUserApiClient BuildUserApiClient(HttpClient httpClient,
             HearingServicesConfiguration serviceSettings)
         {
-            return new UserApiClient(httpClient) { BaseUrl = serviceSettings.UserApiUrl };
+            return UserApiClient.GetClient(serviceSettings.UserApiUrl, httpClient);
         }
     }
 }

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -86,7 +86,6 @@
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />
     <ProjectReference Include="..\VideoWeb.Contract\VideoWeb.Contract.csproj" />
     <ProjectReference Include="..\VideoWeb.EventHub\VideoWeb.EventHub.csproj" />
-    <ProjectReference Include="..\VideoWeb.Services\VideoWeb.Services.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -2276,14 +2276,14 @@
           "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.8",
           "StackExchange.Redis": "2.1.28",
           "System.IdentityModel.Tokens.Jwt": "5.6.0",
-          "VideoWeb.Services": "1.0.0"
+          "UserApi.Client": "1.24.2",
+          "VideoApi.Client": "1.23.48"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
+          "VideoWeb.Common": "1.0.0"
         }
       },
       "videoweb.eventhub": {
@@ -2296,18 +2296,7 @@
           "System.Text.Json": "4.7.1",
           "UserApi.Client": "1.24.2",
           "VideoApi.Client": "1.23.48",
-          "VideoWeb.Common": "1.0.0",
-          "VideoWeb.Services": "1.0.0"
-        }
-      },
-      "videoweb.services": {
-        "type": "Project",
-        "dependencies": {
-          "BookingsApi.Client": "1.24.17",
-          "Microsoft.Extensions.Options": "3.1.10",
-          "Newtonsoft.Json": "12.0.3",
-          "UserApi.Client": "1.24.2",
-          "VideoApi.Client": "1.23.48"
+          "VideoWeb.Common": "1.0.0"
         }
       }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7176 

### Change description ###

* When a participant joins a VMR, the transfer event returns room id as the participant. When this happens, we need to iterate over each participant in the VMR and handle the event.
* When a participant joins or leaves a room, the cache needs to be updated to reflect this since the cache is only updated when the `GetConferenceById` is called. This would not happen once the participant is in the WR

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
