### PR TITLE
VIH-7482 video hearing bug fixes for tile position and muted video element

### DIFF
--- a/VideoWeb/VideoWeb.UnitTests/Mappings/SharedParticipantRoomMapperTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Mappings/SharedParticipantRoomMapperTests.cs
@@ -28,7 +28,34 @@ namespace VideoWeb.UnitTests.Mappings
             result.PexipNode.Should().Be(testVmr.PexipNode);
             result.ParticipantJoinUri.Should().Be(testVmr.ParticipantJoinUri);
             result.DisplayName.Should().Be(testVmr.Label);
-            result.TileDisplayName.Should().Be($"T201;{participant.DisplayName};{participant.Id}");
+            result.TileDisplayName.Should().EndWith($"{participant.DisplayName};{participant.Id}");
+        }
+        
+        [Test]
+        public void should_have_unique_tile_positions()
+        {
+            var participantA = new Participant
+            {
+                Id = Guid.NewGuid(),
+                DisplayName = "Interpreter Doe"
+            };
+            
+            var participantB = new Participant
+            {
+                Id = Guid.NewGuid(),
+                DisplayName = "Interpretee Doe"
+            };
+            var testVmr = new SharedParticipantRoomResponse
+            {
+                Label = "Interpreter1",
+                ParticipantJoinUri = "joidshfdsf",
+                PexipNode = "sip.unit.test.com"
+            };
+
+            var resultA = _sut.Map(testVmr, participantA, false);
+            var resultB = _sut.Map(testVmr, participantB, false);
+
+            resultA.TileDisplayName.Should().NotMatch(resultB.TileDisplayName);
         }
         
         [Test]
@@ -50,7 +77,8 @@ namespace VideoWeb.UnitTests.Mappings
             result.PexipNode.Should().Be(testVmr.PexipNode);
             result.ParticipantJoinUri.Should().Be(testVmr.ParticipantJoinUri);
             result.DisplayName.Should().Be(testVmr.Label);
-            result.TileDisplayName.Should().Be($"W201;{participant.DisplayName};{participant.Id}");
+            result.TileDisplayName.Should().EndWith($"{participant.DisplayName};{participant.Id}");
+            result.TileDisplayName.Should().StartWith("W");
         }
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -157,6 +157,7 @@ export abstract class WaitingRoomBaseDirective {
             .then((data: ConferenceResponse) => {
                 this.errorCount = 0;
                 this.loadingData = false;
+                this.countdownComplete = data.status === ConferenceStatus.InSession;
                 this.hearing = new Hearing(data);
                 this.conference = this.hearing.getConference();
                 this.videoWebService.getAllowedEndpointsForConference(this.conferenceId).then((endpoints: AllowedEndpointResponse[]) => {

--- a/VideoWeb/VideoWeb/Mappings/SharedParticipantRoomMapper.cs
+++ b/VideoWeb/VideoWeb/Mappings/SharedParticipantRoomMapper.cs
@@ -13,8 +13,9 @@ namespace VideoWeb.Mappings
         {
             var node = sharedRoom.PexipNode.Replace("https://", string.Empty);
             var tilePosition = int.Parse(new string(sharedRoom.Label.Where(char.IsDigit).ToArray()));
+            var randomNumber = GetRandomNumberAsString();
             var tilePrefix = isWitness ? "W" : "T";
-            var tileDisplayName = $"{tilePrefix}{200+tilePosition};{participant.DisplayName};{participant.Id}";
+            var tileDisplayName = $"{tilePrefix}{200+tilePosition}{randomNumber};{participant.DisplayName};{participant.Id}";
             return new SharedParticipantRoom
             {
                 PexipNode = node,
@@ -22,6 +23,12 @@ namespace VideoWeb.Mappings
                 DisplayName = sharedRoom.Label,
                 TileDisplayName = tileDisplayName
             };
+        }
+        
+        private string GetRandomNumberAsString()
+        {
+            var ticksString = DateTime.UtcNow.Ticks.ToString();
+            return string.Concat(ticksString.Reverse().Skip(1).Take(10));
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7482

### Change description ###

* ensure tile positions are unique
* make sure video stream isn't muted when browser is refreshed mid-hearing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
