### PR TITLE
VIH-7453 revert leave consultation from UI on hearing start

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
@@ -194,14 +194,6 @@ export class ParticipantWaitingRoomComponent extends WaitingRoomBaseDirective im
         } else {
             this.notificationSoundsService.stopHearingAlertSound();
         }
-        if (message.status === ConferenceStatus.InSession && this.isOrHasWitnessLink()) {
-            this.consultationService.leaveConsultation(this.conference, this.participant).then(() => {
-                this.logger.info(`[ParticipantWaitingRoomComponent] - moving witness to waiting room for hearing start`, {
-                    conference: this.conference?.id,
-                    participant: this.participant.id
-                });
-            });
-        }
     }
 
     openStartConsultationModal() {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.eventhub.events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.eventhub.events.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { Guid } from 'guid-typescript';
-import { ConferenceResponse, ConferenceStatus, ParticipantResponse, Role } from 'src/app/services/clients/api-client';
+import { ConferenceResponse, ConferenceStatus, ParticipantResponse } from 'src/app/services/clients/api-client';
 import { ConferenceStatusMessage } from 'src/app/services/models/conference-status-message';
 import { hearingStatusSubjectMock } from 'src/app/testing/mocks/mock-events-service';
 import { Hearing } from '../../../shared/models/hearing';
@@ -29,7 +29,6 @@ import {
 } from '../../waiting-room-shared/tests/waiting-room-base-setup';
 import { ParticipantWaitingRoomComponent } from '../participant-waiting-room.component';
 import { translateServiceSpy } from 'src/app/testing/mocks/mock-translation-service';
-import { HearingRole } from '../../models/hearing-role-model';
 
 describe('ParticipantWaitingRoomComponent event hub events', () => {
     let component: ParticipantWaitingRoomComponent;
@@ -71,7 +70,6 @@ describe('ParticipantWaitingRoomComponent event hub events', () => {
         component.connected = true; // assume connected to pexip
         component.startEventHubSubscribers();
         videoWebService.getConferenceById.calls.reset();
-        consultationService.leaveConsultation.calls.reset();
     });
 
     afterEach(() => {
@@ -93,33 +91,6 @@ describe('ParticipantWaitingRoomComponent event hub events', () => {
 
         expect(component.displayDeviceChangeModal).toBeFalsy();
         expect(notificationSoundsService.playHearingAlertSound).toHaveBeenCalled();
-    }));
-
-    it('should move witness to waiting room when "in session" message received', fakeAsync(() => {
-        const status = ConferenceStatus.InSession;
-        const message = new ConferenceStatusMessage(globalConference.id, status);
-        component.participant.hearing_role = HearingRole.WITNESS;
-        hearingStatusSubject.next(message);
-        flushMicrotasks();
-        expect(consultationService.leaveConsultation).toHaveBeenCalled();
-    }));
-
-    it('should not move witness to waiting room when "not started" message received', fakeAsync(() => {
-        const status = ConferenceStatus.NotStarted;
-        const message = new ConferenceStatusMessage(globalConference.id, status);
-        component.participant.hearing_role = HearingRole.WITNESS;
-        hearingStatusSubject.next(message);
-        flushMicrotasks();
-        expect(consultationService.leaveConsultation).toHaveBeenCalledTimes(0);
-    }));
-
-    it('should not move non witness to waiting room when "in session" message received', fakeAsync(() => {
-        const status = ConferenceStatus.InSession;
-        const message = new ConferenceStatusMessage(globalConference.id, status);
-        component.participant.hearing_role = HearingRole.JUDGE;
-        hearingStatusSubject.next(message);
-        flushMicrotasks();
-        expect(consultationService.leaveConsultation).toHaveBeenCalledTimes(0);
     }));
 
     it('should ignore hearing message received for other conferences', fakeAsync(() => {


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7453

### Change description ###

* revert leave consultation from UI on hearing start
  * The witness attempts to leave a consultation room even if they are not in one
  * The CountDownEventHandler in VideoAPI will transition witnesses out of consultation rooms

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
