### PR TITLE
VIH-7548 handle ims for participant when unread array is empty

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages-participant/unread-messages-participant.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages-participant/unread-messages-participant.component.ts
@@ -3,6 +3,7 @@ import { VideoWebService } from 'src/app/services/api/video-web.service';
 import { UnreadAdminMessageResponse } from 'src/app/services/clients/api-client';
 import { EventsService } from 'src/app/services/events.service';
 import { Logger } from 'src/app/services/logging/logger-base';
+import { InstantMessage } from 'src/app/services/models/instant-message';
 import { Hearing } from 'src/app/shared/models/hearing';
 import { Participant } from 'src/app/shared/models/participant';
 import { UnreadMessagesComponentBase } from '../unread-messages-shared/unread-message-base.component';
@@ -62,6 +63,12 @@ export class UnreadMessagesParticipantComponent extends UnreadMessagesComponentB
     incrementUnreadCounter(conferenceId: string, participantId: string): void {
         if (this.hearing.id === conferenceId && this.participant.id === participantId) {
             this.unreadMessages.number_of_unread_messages++;
+        }
+    }
+
+    handleImReceived(message: InstantMessage) {
+        if (this.getHearing().id === message.conferenceId && this.messageFromParticipant(message)) {
+            this.incrementUnreadCounter(message.conferenceId, message.from);
         }
     }
     openImChat() {}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages-shared/unread-message-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages-shared/unread-message-base.component.ts
@@ -15,6 +15,7 @@ export abstract class UnreadMessagesComponentBase {
     abstract resetUnreadCounter(conferenceId: string, participantId: string): void;
     abstract incrementUnreadCounter(conferenceId: string, participantId: string): void;
     abstract openImChat();
+    abstract handleImReceived(message: InstantMessage);
 
     getIMStatus(): string {
         return this.unreadCount > 0 ? 'IM_icon.png' : 'IM-empty.png';
@@ -38,12 +39,6 @@ export abstract class UnreadMessagesComponentBase {
 
     handleAdminAnsweredChat(message: ConferenceMessageAnswered) {
         this.resetUnreadCounter(message.conferenceId, message.participantId);
-    }
-
-    handleImReceived(message: InstantMessage) {
-        if (this.getHearing().id === message.conferenceId && this.messageFromParticipant(message)) {
-            this.incrementUnreadCounter(message.conferenceId, message.from);
-        }
     }
 
     protected messageFromParticipant(message: InstantMessage): boolean {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages/unread-messages.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages/unread-messages.component.spec.ts
@@ -131,6 +131,23 @@ describe('UnreadMessagesComponent', () => {
         expect(component.unreadCount).toBe(expectedCount + 1);
     });
 
+    it('should increase unread count when non-admin sends first message', () => {
+        component.unreadMessages = [];
+        component.hearing = new Hearing(conference);
+        const conferenceId = conference.id;
+        const participantId = conference.participants[0].id;
+        const expectedCount = component.unreadCount;
+        component.setupSubscribers();
+        messageSubjectMock.next(
+            new InstantMessage({
+                conferenceId: conferenceId,
+                from: participantId,
+                to: 'Admin'
+            })
+        );
+        expect(component.unreadCount).toBe(expectedCount + 1);
+    });
+
     it('should not increase unread count when admin sends a message', () => {
         const conferenceId = conference.id;
         const participantUsername = 'admin@hmcts.net';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages/unread-messages.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages/unread-messages.component.ts
@@ -7,6 +7,7 @@ import { Logger } from 'src/app/services/logging/logger-base';
 import { Hearing } from '../../shared/models/hearing';
 import { UnreadMessagesComponentBase } from '../unread-messages-shared/unread-message-base.component';
 import { EventBusService, EmitEvent, VHEventType } from 'src/app/services/event-bus.service';
+import { InstantMessage } from 'src/app/services/models/instant-message';
 
 @Component({
     selector: 'app-unread-messages',
@@ -63,7 +64,24 @@ export class UnreadMessagesComponent extends UnreadMessagesComponentBase impleme
             const messageCount = this.unreadMessages.find(x => x.participant_id === participantId);
             if (messageCount) {
                 messageCount.number_of_unread_messages++;
+            } else {
+                const patFromHearing = this.hearing.participants.find(x => x.id === participantId);
+                if (!patFromHearing) {
+                    return;
+                }
+                this.unreadMessages.push(
+                    new UnreadAdminMessageResponse({
+                        number_of_unread_messages: 1,
+                        participant_id: participantId
+                    })
+                );
             }
+        }
+    }
+
+    handleImReceived(message: InstantMessage) {
+        if (this.getHearing().id === message.conferenceId) {
+            this.incrementUnreadCounter(message.conferenceId, message.from);
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7548

### Change description ###

* unread components need to handle incoming messages differently
handle ims for a participant when the unread array is empty

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
