### PR TITLE
VIH-7569 truncate long case names in hearing room screen

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.html
@@ -7,9 +7,12 @@
 <div *ngIf="showVideo" class="video-background">
   <div class="header-bar">
     <div class="header-content-grid govuk-body">
-      <h1 class="room-title">
-        {{ getCaseNameAndNumber() }}
-      </h1>
+      <div class="room-title">
+        <div #roomTitleLabel class="room-title-label">{{ getCaseNameAndNumber() }}</div>
+        <div *ngIf="hasCaseNameOverflowed" class="room-title-show-more" appTooltip [text]="getCaseNameAndNumber()" colour="grey">
+          (show more)
+        </div>
+      </div>
       <app-private-consultation-room-controls
         [conferenceId]="conference.id"
         [participant]="participant"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.scss
@@ -1,6 +1,5 @@
 .header-content-grid {
   display: grid;
-  grid-template-columns: auto 600px;
+  grid-template-columns: auto auto;
   width: 100%;
-  margin-bottom: 7px;
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.html
@@ -9,9 +9,12 @@
       <div class="video-background">
         <div class="header-bar">
           <div class="header-content-grid govuk-body">
-            <h1 class="room-title">
-              {{ getCaseNameAndNumber() }}
-            </h1>
+            <div class="room-title">
+              <div #roomTitleLabel class="room-title-label">{{ getCaseNameAndNumber() }}</div>
+              <div *ngIf="hasCaseNameOverflowed" class="room-title-show-more" appTooltip [text]="getCaseNameAndNumber()" colour="grey">
+                (show more)
+              </div>
+            </div>
             <app-private-consultation-room-controls
               [conferenceId]="conference.id"
               [participant]="participant"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.scss
@@ -21,9 +21,8 @@
 
 .header-content-grid {
   display: grid;
-  grid-template-columns: auto 600px;
+  grid-template-columns: auto auto;
   width: 100%;
-  margin-bottom: 7px;
 }
 
 .panel-wrap {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.html
@@ -6,9 +6,9 @@
   <div class="header-bar">
     <div class="govuk-body" [class]="!isJohRoom && isPrivateConsultation ? 'header-content-grid-with-lock' : 'header-content-grid'">
       <ng-container *ngIf="!isJohRoom && isPrivateConsultation">
-        <h1 class="room-title">
+        <div class="room-title">
           {{ getRoomName() }}
-        </h1>
+        </div>
         <div class="room-status">
           <span class="lock-badge" [class]="this.participant?.current_room?.locked ? 'locked' : 'unlocked'">{{
             (this.participant?.current_room?.locked ? 'participant-waiting-room.locked' : 'participant-waiting-room.unlocked') | translate
@@ -22,9 +22,12 @@
         </div>
       </ng-container>
       <ng-container *ngIf="isJohRoom || !isPrivateConsultation">
-        <h1 class="room-title">
-          {{ getCaseNameAndNumber() }}
-        </h1>
+        <div class="room-title">
+          <div #roomTitleLabel class="room-title-label">{{ getCaseNameAndNumber() }}</div>
+          <div *ngIf="hasCaseNameOverflowed" class="room-title-show-more" appTooltip [text]="getCaseNameAndNumber()" colour="grey">
+            (show more)
+          </div>
+        </div>
       </ng-container>
       <ng-container *ngIf="connected">
         <app-private-consultation-room-controls

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.scss
@@ -51,13 +51,12 @@
 
 .header-content-grid {
   display: grid;
-  grid-template-columns: auto 475px;
+  grid-template-columns: auto auto;
   width: 100%;
-  margin-bottom: 7px;
 }
 
 .header-content-grid-with-lock {
   display: grid;
-  grid-template-columns: 200px 100px auto 475px;
+  grid-template-columns: 200px 100px auto auto;
   width: 100%;
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
@@ -175,9 +175,27 @@
   margin-left: 50px;
   display: inline-block;
   margin-top: 10px;
-  white-space: nowrap;
   font-size: 1em;
   font-weight: normal;
+  display: flex;
+  flex-direction: row;
+}
+
+.room-title-label {
+  color: lightgray;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 600px;
+  @media only screen and (max-width: 1024px) {
+    max-width: 400px;
+  }
+}
+
+.room-title-show-more {
+  float: right;
+  color: $govuk-link-colour;
+  cursor: pointer;
 }
 
 #incomingFeed,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
@@ -173,7 +173,6 @@
 .room-title {
   color: lightgray;
   margin-left: 50px;
-  display: inline-block;
   margin-top: 10px;
   font-size: 1em;
   font-weight: normal;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
@@ -488,7 +488,6 @@ describe('WaitingRoomComponent message and clock', () => {
         const caseName = component.getCaseNameAndNumber();
         caseNameElement.innerHTML = caseName;
         spyOnProperty(caseNameElement, 'scrollWidth').and.returnValue(caseName.length + 1);
-        // caseNameElement.scrollWidth = caseName.length * 2;
         const elemRef = new ElementRef(caseNameElement);
         component.roomTitleLabel = elemRef;
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
@@ -43,6 +43,7 @@ import {
 } from './waiting-room-base-setup';
 import { WRTestComponent } from './WRTestComponent';
 import { HearingRole } from '../../models/hearing-role-model';
+import { ElementRef } from '@angular/core';
 
 describe('WaitingRoomComponent message and clock', () => {
     let component: WRTestComponent;
@@ -470,5 +471,32 @@ describe('WaitingRoomComponent message and clock', () => {
 
         component.updateVideoStreamMuteStatus();
         expect(component.toggleVideoStreamMute).toHaveBeenCalledWith(false);
+    });
+
+    it('should return false if case name has not been truncated', () => {
+        const caseNameElement = document.createElement('div');
+        caseNameElement.innerHTML = component.getCaseNameAndNumber();
+
+        const elemRef = new ElementRef(caseNameElement);
+        component.roomTitleLabel = elemRef;
+
+        expect(component.hasCaseNameOverflowed).toBeFalsy();
+    });
+
+    it('should return true if case name has been truncated', () => {
+        const caseNameElement = document.createElement('div');
+        const caseName = component.getCaseNameAndNumber();
+        caseNameElement.innerHTML = caseName;
+        spyOnProperty(caseNameElement, 'scrollWidth').and.returnValue(caseName.length + 1);
+        // caseNameElement.scrollWidth = caseName.length * 2;
+        const elemRef = new ElementRef(caseNameElement);
+        component.roomTitleLabel = elemRef;
+
+        expect(component.hasCaseNameOverflowed).toBeTruthy();
+    });
+
+    it('should return true if case name has been truncated', () => {
+        component.roomTitleLabel = null;
+        expect(component.hasCaseNameOverflowed).toBeFalsy();
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -98,6 +98,7 @@ export abstract class WaitingRoomBaseDirective {
     linkedParticipantRoom: SharedParticipantRoom;
 
     @ViewChild('incomingFeed', { static: false }) videoStream: ElementRef<HTMLVideoElement>;
+    @ViewChild('roomTitleLabel', { static: false }) roomTitleLabel: ElementRef<HTMLDivElement>;
     countdownComplete: boolean;
     consultationInviteToasts: { [roomLabel: string]: VhToastComponent } = {};
 
@@ -927,6 +928,10 @@ export abstract class WaitingRoomBaseDirective {
 
     get showExtraContent(): boolean {
         return !this.showVideo && !this.isTransferringIn;
+    }
+
+    get hasCaseNameOverflowed(): boolean {
+        return this.roomTitleLabel?.nativeElement.scrollWidth > this.roomTitleLabel?.nativeElement.clientWidth;
     }
 
     executeWaitingRoomCleanup() {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -202,6 +202,7 @@ export abstract class WaitingRoomBaseDirective {
     }
 
     getCaseNameAndNumber() {
+        return 'fdsuifhidsh iudshfiudshf isfhdsiuhfdsiuhfids uisdhfdsf dskndsn kdsnf sdkjf kdsnf';
         return `${this.conference.case_name}: ${this.conference.case_number}`;
     }
 
@@ -931,7 +932,10 @@ export abstract class WaitingRoomBaseDirective {
     }
 
     get hasCaseNameOverflowed(): boolean {
-        return this.roomTitleLabel?.nativeElement.scrollWidth > this.roomTitleLabel?.nativeElement.clientWidth;
+        if (!this.roomTitleLabel) {
+            return false;
+        }
+        return this.roomTitleLabel.nativeElement.scrollWidth > this.roomTitleLabel.nativeElement.clientWidth;
     }
 
     executeWaitingRoomCleanup() {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -202,7 +202,6 @@ export abstract class WaitingRoomBaseDirective {
     }
 
     getCaseNameAndNumber() {
-        return 'fdsuifhidsh iudshfiudshf isfhdsiuhfdsiuhfids uisdhfdsf dskndsn kdsnf sdkjf kdsnf';
         return `${this.conference.case_name}: ${this.conference.case_number}`;
     }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,6 +278,9 @@ extends:
                 sonar.issue.ignore.multicriteria=e1
                 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S107
                 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
+                sonar.issue.ignore.multicriteria=e2
+                sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S1874
+                sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.ts
             StrykerBreak: 75
         ACTest: ${{ parameters.RunACTests }}
         releaseParameters:


### PR DESCRIPTION
truncate very long case names and replace them with a tooltip to see all


### JIRA link (if applicable) ###

VIH-7569

### Change description ###

* truncate long case names in hearing room screen
* optionally display a show more text with displays the full case name as a tooltip

![image](https://user-images.githubusercontent.com/41630528/114211542-ad623b80-9958-11eb-9e35-28e25824497c.png)

![image](https://user-images.githubusercontent.com/41630528/114211548-afc49580-9958-11eb-90ea-73501335a01c.png)

![image](https://user-images.githubusercontent.com/41630528/114213651-2d89a080-995b-11eb-98f3-b6c89f3289e8.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
