### PR TITLE
VIH-7612 order panel members after judge and before the rest

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/pipes/multiline.pipe.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/pipes/multiline.pipe.ts
@@ -5,6 +5,9 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class MultilinePipe implements PipeTransform {
     transform(text: string): string {
-        return text.replace(', ', '<br />');
+        return text
+            .split(',')
+            .map(x => x.trim())
+            .join('<br />');
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -335,7 +335,7 @@ export class ConferenceTestData {
             status: ParticipantStatus.NotSignedIn,
             display_name: 'Observer Doe O',
             role: Role.Individual,
-            case_type_group: 'observer',
+            case_type_group: 'Observer',
             tiled_display_name: 'CIVILIAN;Observer Doe O;6666-6666-6666-6666',
             hearing_role: HearingRole.OBSERVER,
             linked_participants: []

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
@@ -69,10 +69,10 @@ export abstract class PanelModel {
         this.displayName = displayName;
         this.role = role;
         this.caseTypeGroup = role === Role.Judge ? 'judge' : caseTypeGroup;
-        this.orderInTheList = this.setOrderInTheList();
         this.pexipDisplayName = pexipDisplayName;
         this.hearingRole = hearingRole;
         this.representee = representee;
+        this.orderInTheList = this.setOrderInTheList();
     }
 
     abstract isInHearing(): boolean;
@@ -91,6 +91,10 @@ export abstract class PanelModel {
 
     get isJudge(): boolean {
         return this.role === Role.Judge;
+    }
+
+    get isJudicialOfficeHolder(): boolean {
+        return this.role === Role.JudicialOfficeHolder;
     }
 
     get isWitness(): boolean {
@@ -146,17 +150,17 @@ export abstract class PanelModel {
     }
 
     private setOrderInTheList(): number {
-        switch (this.caseTypeGroup.toLowerCase()) {
-            case 'judge':
-                return 1;
-            case 'panelmember':
-                return 2;
-            case 'endpoint':
-                return 4;
-            case 'observer':
-                return 5;
-            default:
-                return 3;
+        let order = 3;
+        if (this.role === Role.Judge) {
+            return 1;
+        } else if (this.role === Role.JudicialOfficeHolder) {
+            return 2;
+        } else if (this.caseTypeGroup.toLowerCase() === 'endpoint') {
+            return 4;
+        } else if (this.hearingRole === HearingRole.OBSERVER) {
+            return 5;
+        } else {
+            return 3;
         }
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
@@ -150,7 +150,6 @@ export abstract class PanelModel {
     }
 
     private setOrderInTheList(): number {
-        let order = 3;
         if (this.role === Role.Judge) {
             return 1;
         } else if (this.role === Role.JudicialOfficeHolder) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/participant-panel.model.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/participant-panel.model.spec.ts
@@ -45,4 +45,16 @@ describe('ParticipantPanelModel', () => {
         model = new ParticipantPanelModel(participant);
         expect(model.isJudge).toBeFalsy();
     });
+
+    it('should return true when participant is a joh', () => {
+        participant.role = Role.JudicialOfficeHolder;
+        model = new ParticipantPanelModel(participant);
+        expect(model.isJudicialOfficeHolder).toBeTruthy();
+    });
+
+    it('should return false when participant is not a joh', () => {
+        participant.role = Role.Individual;
+        model = new ParticipantPanelModel(participant);
+        expect(model.isJudicialOfficeHolder).toBeFalsy();
+    });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.html
@@ -58,6 +58,14 @@
           <span class="fas fa-language type-icon"> </span>
           <br />
         </span>
+        <span *ngIf="participant.isJudicialOfficeHolder">
+          <img
+            src="/assets/images/UkGovCrestWhite.png"
+            class="panel-icon panel-icon-crest"
+            [attr.alt]="'participants-panel.crest' | translate"
+          />
+          <br />
+        </span>
         <span innerHtml="{{ participant.displayName | MultiLinePipe }}"></span>
       </div>
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -88,9 +88,9 @@ describe('ParticipantsPanelComponent', () => {
         component.ngOnInit();
         flushMicrotasks();
         expect(component.participants.length).toBe(expectedCount);
-        expect(component.participants[0].caseTypeGroup).toBe('judge');
-        expect(component.participants[1].caseTypeGroup).toBe('panelmember');
-        expect(component.participants[component.participants.length - 1].caseTypeGroup).toBe('observer');
+        expect(component.participants[0].caseTypeGroup.toLowerCase()).toBe('judge');
+        expect(component.participants[1].caseTypeGroup.toLowerCase()).toBe('panelmember');
+        expect(component.participants[component.participants.length - 1].caseTypeGroup.toLowerCase()).toBe('observer');
     }));
 
     it('should log error when api returns error', async () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7612 

### Change description ###

* Update participant panel order list logic to use user and hearing roles where possible
* Display the HMCTS crest icon for panel members

![image](https://user-images.githubusercontent.com/41630528/115470079-acb98700-a22d-11eb-999e-8f1824c39ad7.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
