### PR TITLE
VIH-7670 participant status and name overlapping in VHO CC

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/participant-status/participant-status.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/participant-status/participant-status.component.scss
@@ -85,6 +85,7 @@
 
 .status-box-display {
   display: flex;
+  word-break: break-all;
 }
 
 .vh-participant-icon {


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7670

### Change description ###

break all for the participant list in the VHO Command Centreto stop the name and status from overlapping

**Does this PR introduce a breaking change?** (check one with "x")

![image](https://user-images.githubusercontent.com/41630528/117472206-8fd0c380-af50-11eb-9150-1ac001ce075b.png)

```
[ ] Yes
[x] No
```
