### PR TITLE
VIH-7672 incorrect toast message when vmr not accepting the private consultation

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-toastr.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-toastr.service.ts
@@ -102,7 +102,7 @@ export class NotificationToastrService {
         };
 
         const toast = this.toastr.show('', '', {
-            timeOut: 120000,
+            timeOut: 12000,
             extendedTimeOut: 0,
             toastClass: 'vh-no-pointer',
             tapToDismiss: false,
@@ -152,6 +152,7 @@ export class NotificationToastrService {
         invitedByName: string,
         inHearing: boolean
     ): VhToastComponent {
+        console.log(' linked participant rejected', invitedByName);
         const inviteKey = this.getInviteKey(conferenceId, roomLabel);
         if (this.activeLinkedParticipantRejectionToasts[inviteKey]) {
             this.activeLinkedParticipantRejectionToasts[inviteKey].remove();
@@ -199,7 +200,7 @@ export class NotificationToastrService {
 
     createConsultationNotificationToast(message: string, inHearing: boolean): VhToastComponent {
         const toast = this.toastr.show('', '', {
-            timeOut: 120000,
+            timeOut: 12000,
             extendedTimeOut: 0,
             toastClass: 'vh-no-pointer',
             tapToDismiss: false,
@@ -245,7 +246,7 @@ export class NotificationToastrService {
         )}</span>`;
         message += `<br/>${this.translateService.instant('notification-toastr.poor-connection.message')}<br/>`;
         const toast = this.toastr.show('', '', {
-            timeOut: 120000,
+            timeOut: 12000,
             tapToDismiss: false,
             toastComponent: VhToastComponent
         });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-toastr.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-toastr.service.ts
@@ -102,7 +102,7 @@ export class NotificationToastrService {
         };
 
         const toast = this.toastr.show('', '', {
-            timeOut: 12000,
+            timeOut: 120000,
             extendedTimeOut: 0,
             toastClass: 'vh-no-pointer',
             tapToDismiss: false,
@@ -200,7 +200,7 @@ export class NotificationToastrService {
 
     createConsultationNotificationToast(message: string, inHearing: boolean): VhToastComponent {
         const toast = this.toastr.show('', '', {
-            timeOut: 12000,
+            timeOut: 120000,
             extendedTimeOut: 0,
             toastClass: 'vh-no-pointer',
             tapToDismiss: false,
@@ -246,7 +246,7 @@ export class NotificationToastrService {
         )}</span>`;
         message += `<br/>${this.translateService.instant('notification-toastr.poor-connection.message')}<br/>`;
         const toast = this.toastr.show('', '', {
-            timeOut: 12000,
+            timeOut: 120000,
             tapToDismiss: false,
             toastComponent: VhToastComponent
         });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -653,11 +653,11 @@ describe('WaitingRoomComponent EventHub Call', () => {
         });
     });
 
-    fdescribe('onLinkedParticiantRejectedConsultationInvite', () => {
+    describe('onLinkedParticiantRejectedConsultationInvite', () => {
         const linkedParticipant = participantsLinked[1];
         const expectedConsultationRoomLabel = 'ConsultationRoom';
         const expectedInvitedByName = 'invited by';
-        const expectedInvitationId = 'expected invitation id'
+        const expectedInvitationId = 'expected invitation id';
         const toastSpy = jasmine.createSpyObj<VhToastComponent>('VhToastComponent', ['remove']);
         const invitation = {} as ConsultationInvitation;
 
@@ -759,20 +759,34 @@ describe('WaitingRoomComponent EventHub Call', () => {
         const primaryParticipant = participantsLinked[0];
         const linkedParticipant = participantsLinked[1];
         const expectedConsultationRoomLabel = 'ConsultationRoom';
+        const invitation = {} as ConsultationInvitation;
 
         beforeEach(() => {
             notificationToastrService.showWaitingForLinkedParticipantsToAccept.calls.reset();
             consultationInvitiationService.getInvitation.calls.reset();
+
+            invitation.invitationId = 'invitation id';
+            invitation.answer = ConsultationAnswer.Accepted;
+        });
+
+        it('should NOT make any calls and should return when the invitation does NOT have an invitation id', () => {
+            // Arrange
+            invitation.invitationId = null;
+            invitation.linkedParticipantStatuses = { lp1: true, lp2: true, lp3: true, lp4: true };
+            consultationInvitiationService.getInvitation.and.returnValue(invitation);
+
+            spyOn(component, 'createOrUpdateWaitingOnLinkedParticipantsNotification');
+
+            // Act
+            component.onLinkedParticiantAcceptedConsultationInvite(expectedConsultationRoomLabel, linkedParticipant.id);
+
+            // Assert
+            expect(invitation.linkedParticipantStatuses[linkedParticipant.id]).toBeFalsy();
+            expect(component.createOrUpdateWaitingOnLinkedParticipantsNotification).not.toHaveBeenCalled();
         });
 
         it('should update the participant status and the toast notification for the invitation if there are still linked participants who havent accepted and the active participant has accepted', () => {
             // Arrange
-            const invitation = {
-                linkedParticipantStatuses: {},
-                activeToast: null,
-                answer: ConsultationAnswer.Accepted,
-                invitedByName: null
-            } as ConsultationInvitation;
             invitation.linkedParticipantStatuses = { lp1: true, lp2: true, lp3: true, lp4: true };
             consultationInvitiationService.getInvitation.and.returnValue(invitation);
 
@@ -789,13 +803,8 @@ describe('WaitingRoomComponent EventHub Call', () => {
 
         it('should NOT update the toast notification for the invitation if the active participant has NOT accepted', () => {
             // Arrange
-            const invitation = {
-                linkedParticipantStatuses: {},
-                activeToast: null,
-                answer: ConsultationAnswer.None,
-                invitedByName: null
-            } as ConsultationInvitation;
             invitation.linkedParticipantStatuses = { lp1: true, lp2: true, lp3: true, lp4: true };
+            invitation.answer = ConsultationAnswer.None;
             consultationInvitiationService.getInvitation.and.returnValue(invitation);
 
             spyOn(component, 'createOrUpdateWaitingOnLinkedParticipantsNotification');

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -653,10 +653,11 @@ describe('WaitingRoomComponent EventHub Call', () => {
         });
     });
 
-    describe('onLinkedParticiantRejectedConsultationInvite', () => {
+    fdescribe('onLinkedParticiantRejectedConsultationInvite', () => {
         const linkedParticipant = participantsLinked[1];
         const expectedConsultationRoomLabel = 'ConsultationRoom';
         const expectedInvitedByName = 'invited by';
+        const expectedInvitationId = 'expected invitation id'
         const toastSpy = jasmine.createSpyObj<VhToastComponent>('VhToastComponent', ['remove']);
         const invitation = {} as ConsultationInvitation;
 
@@ -669,7 +670,24 @@ describe('WaitingRoomComponent EventHub Call', () => {
             toastSpy.declinedByThirdParty = false;
             invitation.activeToast = toastSpy;
             invitation.invitedByName = expectedInvitedByName;
+            invitation.invitationId = expectedInvitationId;
             consultationInvitiationService.getInvitation.and.returnValue(invitation);
+        });
+
+        it('should NOT make any calls and should return when the invitation does NOT have an invitation id', () => {
+            // Arrange
+            const expectedIsParticipantInHearing = true;
+            component.participant.status = ParticipantStatus.InHearing;
+            invitation.invitationId = null;
+
+            // Act
+            component.onLinkedParticiantRejectedConsultationInvite(linkedParticipant, expectedConsultationRoomLabel);
+
+            // Assert
+            expect(notificationToastrService.showConsultationRejectedByLinkedParticipant).not.toHaveBeenCalled();
+            expect(consultationInvitiationService.linkedParticipantRejectedInvitation).not.toHaveBeenCalled();
+            expect(toastSpy.remove).not.toHaveBeenCalled();
+            expect(toastSpy.declinedByThirdParty).toBeFalse();
         });
 
         it('should reject the invitation for a room and set the inital toast to rejectedByThirdParty to true if it exists when is in hearing', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -217,7 +217,9 @@ export abstract class WaitingRoomBaseDirective {
 
     onLinkedParticiantRejectedConsultationInvite(linkedParticipant: ParticipantResponse, consulationRoomLabel: string) {
         const invitation = this.consultationInvitiationService.getInvitation(consulationRoomLabel);
-        console.log('[ROB] linked rejected', invitation);
+        if (!invitation.invitationId)
+            return;
+
         if (invitation.activeToast) {
             invitation.activeToast.declinedByThirdParty = true;
             invitation.activeToast.remove();
@@ -239,7 +241,6 @@ export abstract class WaitingRoomBaseDirective {
     }
 
     onConsultationRejected(roomLabel: string) {
-        console.log('[ROB] I rejected');
         this.consultationInvitiationService.removeInvitation(roomLabel);
     }
 
@@ -509,7 +510,6 @@ export abstract class WaitingRoomBaseDirective {
         }
 
         const invitation = this.consultationInvitiationService.getInvitation(roomLabel);
-        console.log('[ROB] I accepted', invitation);
         if (invitation.answer === ConsultationAnswer.Rejected) {
             return;
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -208,6 +208,10 @@ export abstract class WaitingRoomBaseDirective {
 
     onLinkedParticiantAcceptedConsultationInvite(roomLabel: string, id: string) {
         const invitation = this.consultationInvitiationService.getInvitation(roomLabel);
+        if (!invitation.invitationId) {
+            return;
+        }
+
         invitation.linkedParticipantStatuses[id] = true;
 
         if (invitation.answer === ConsultationAnswer.Accepted) {
@@ -217,8 +221,9 @@ export abstract class WaitingRoomBaseDirective {
 
     onLinkedParticiantRejectedConsultationInvite(linkedParticipant: ParticipantResponse, consulationRoomLabel: string) {
         const invitation = this.consultationInvitiationService.getInvitation(consulationRoomLabel);
-        if (!invitation.invitationId)
+        if (!invitation.invitationId) {
             return;
+        }
 
         if (invitation.activeToast) {
             invitation.activeToast.declinedByThirdParty = true;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7672


### Change description ###
- Fixed an issue which caused an incorrect toast message to be display.
- Fixed an issue which would prevent the "waiting for linked participant to accept message from showing"

```
[ ] Yes
[x ] No
```
