### PR TITLE
VIH-7699 - Specflow expects that the backing method has the same set of parameters

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/DataSetupSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/DataSetupSteps.cs
@@ -99,15 +99,20 @@ namespace VideoWeb.AcceptanceTests.Steps
         }
 
         [Given(@"I have a hearing in (.*) minutes time")]
+        public void GivenIHaveAHearingAndAConferenceInMinutesTime(int minutes)
+        {
+            GivenIHaveAHearingAndAConferenceInMinutesTime(minutes, false);
+        }
         public void GivenIHaveAHearingAndAConferenceInMinutesTime(int minutes, bool interpreter = false)
         {
             CheckThatTheHearingWillBeCreatedForToday(_c.TimeZone.Adjust(DateTime.Now.ToUniversalTime().AddMinutes(minutes)));
-            var userTypes = interpreter ? CreateUserTypes(1,0,0,0,1) : CreateUserTypes();
+            var userTypes = interpreter ? CreateUserTypes(1, 0, 0, 0, 1) : CreateUserTypes();
             AllocateUsers(userTypes);
             delayMinutes = minutes;
             GivenIHaveAnotherHearingAndAConference();
         }
-        
+
+
         [Given(@"I have another hearing in (.*) minutes time")]
         public void GivenIHaveAnotherHearingAndAConferenceInMinutesTime(int minutes)
         {            


### PR DESCRIPTION
VIH-7699 - Specflow expects that the backing method has the same set of parameters as the Gherkin, so if the backing method has additional parameters it will not be recognised.

Example:
Given I have a hearing in (.*) minutes time
requires a method with the same
method(int minutes)

It's a **Specflow issue** that it does not recognise that method(int minutes, bool value = false ) can be called.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-7699

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
