### PR TITLE
VIH-7654 Get users from VHO page by display name instead of id

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingRoomSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingRoomSteps.cs
@@ -144,9 +144,9 @@ namespace VideoWeb.AcceptanceTests.Steps
 
             var user = Users.GetUserFromText(text, _c.Test.Users);
             var participant = _c.Test.ConferenceParticipants.First(x => x.Username.Equals(user.Username));
-            
-            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(AdminPanelPage.ParticipantInWaitingRoom(participant.Id)).Displayed.Should().BeTrue();
-            
+
+            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(AdminPanelPage.ParticipantInIframe(participant.DisplayName)).Displayed.Should().BeTrue();
+
             SwitchToDefaultContent();
         }
 
@@ -155,14 +155,14 @@ namespace VideoWeb.AcceptanceTests.Steps
         {
             SwitchToTheVhoIframe();
 
-            var judgeId = _c.Test.Conference.Participants.First(x => x.UserRole == UserRole.Judge).Id;
-            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(AdminPanelPage.ParticipantInHearingRoom(judgeId)).Displayed.Should().BeTrue();
+            var judge = _c.Test.Conference.Participants.First(x => x.UserRole == UserRole.Judge);
+            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(AdminPanelPage.ParticipantInIframe(judge.DisplayName)).Displayed.Should().BeTrue();
 
             var user = Users.GetUserFromText(text, _c.Test.Users);
             var participant = _c.Test.ConferenceParticipants.First(x => x.Username.Equals(user.Username));
 
-            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(AdminPanelPage.ParticipantInHearingRoom(participant.Id)).Displayed.Should().BeTrue();
-            
+            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(AdminPanelPage.ParticipantInIframe(participant.DisplayName)).Displayed.Should().BeTrue();
+
             SwitchToDefaultContent();
         }
 


### PR DESCRIPTION
This test was locating users on the VHO page by ID however, for the format of the id has changed as this comes from Kinly.

The change is to locate the user by their display name as used by other AC tests.

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7654


### Change description ###
This test was locating users on the VHO page by ID however, for the format of the id has changed as this comes from Kinly.
The change is to locate the user by their display name as used by other AC tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
