### PR TITLE
VIH-7729 fix for panel member scripts that are unable to locate case number element

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/Features/HearingsList.feature
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Features/HearingsList.feature
@@ -115,8 +115,8 @@ Scenario: Panel Member has 1 or more hearings
 	And a new browser is open for a PanelMember
 	When they attempt to login with valid credentials
 	Then the user is on the Hearing List page
-	And the participant can see a list of hearings including the new hearing
-	And contact us details are available
+	And the participant can see a list of hearings including the new hearing whilst url contains the word Judge
+	And contact us details for the Panel Member are available
 	When the user clicks on the Start Hearing button
 	Then the user is on the Waiting Room page
 
@@ -136,8 +136,8 @@ Scenario: Panel Member has a hearing more than 30 minutes in the future
 	And a new browser is open for a Winger
 	When they attempt to login with valid credentials
 	Then the user is on the Hearing List page
-	And the participant can see a list of hearings including the new hearing
-	And contact us details are available
+	And the participant can see a list of hearings including the new hearing whilst url contains the word Judge
+	And contact us details for the Panel Member are available
 	When the user clicks on the Start Hearing button
 	Then the user is on the Waiting Room page
 

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingsListSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/HearingsListSteps.cs
@@ -106,6 +106,23 @@ namespace VideoWeb.AcceptanceTests.Steps
             _browsers[_c.CurrentUser].TextOf(ParticipantHearingListPage.HearingTime(_c.Test.Conference.Id)).Should().Be($"{_c.TimeZone.Adjust(_c.Test.Hearing.ScheduledDateTime):HH:mm}");
         }
 
+        [Then(@"the participant can see a list of hearings including the new hearing whilst url contains the word Judge")]
+        public void ThenTheParticipantCanSeeAListOfHearingsIncludingTheNewHearingWhilstUrlContainsTheWordJudge()
+        {
+            var scheduledDateTime = _c.TimeZone.Adjust(_c.Test.Hearing.ScheduledDateTime);
+            var scheduledDuration = _c.Test.Hearing.ScheduledDuration;
+
+            var rowData = new GetHearingRow()
+                .WithConferenceId(_c.Test.Conference.Id)
+                .WithDriver(_browsers[_c.CurrentUser])
+                .Fetch();
+
+            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(JudgeHearingListPage.Date(scheduledDateTime.ToString(DateFormats.JudgeHearingListDate))).Displayed.Should().BeTrue();
+            rowData.StartTime.Should().Be(scheduledDateTime.ToString(DateFormats.JudgeHearingListTime));
+            rowData.EndTime.Should().Be(scheduledDateTime.AddMinutes(scheduledDuration).ToString(DateFormats.JudgeHearingListTime));
+            rowData.CaseNumber.Trim().Should().Be(_c.Test.Case.Number);
+        }
+
         [Then(@"the user can see their details at the top of the hearing list")]
         public void ThenTheUserCanSeeTheirDetailsAtTheTopOfTheHearingList()
         {
@@ -135,6 +152,13 @@ namespace VideoWeb.AcceptanceTests.Steps
 
         [Then(@"contact us details for the Judge are available")]
         public void ThenContactUsDetailsForTheJudgeAreAvailable()
+        {
+            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(JudgeHearingListPage.ContactUs).Displayed.Should().BeTrue();
+            _browsers[_c.CurrentUser].Driver.WaitUntilVisible(JudgeHearingListPage.PhoneNumber(_c.Test.CommonData.CommonOnScreenData.VhoPhone)).Displayed.Should().BeTrue();
+        }
+
+        [Then(@"contact us details for the Panel Member are available")]
+        public void ThenContactUsDetailsForThePanelMemberAreAvailable()
         {
             _browsers[_c.CurrentUser].Driver.WaitUntilVisible(JudgeHearingListPage.ContactUs).Displayed.Should().BeTrue();
             _browsers[_c.CurrentUser].Driver.WaitUntilVisible(JudgeHearingListPage.PhoneNumber(_c.Test.CommonData.CommonOnScreenData.VhoPhone)).Displayed.Should().BeTrue();


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7729


### Change description ###
The hearing list page for the Panel Member is a shared member component with the Judge, therefore the elements on the page are defined in the Judge class.

The fix was to use these same definitions for Panel Member assertions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
