### PR TITLE
VIH-7795 Participant list not loading in Judge view during Hearing

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/linked-participant-panel-model.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/linked-participant-panel-model.ts
@@ -6,7 +6,7 @@ export class LinkedParticipantPanelModel extends PanelModel {
     public participants: PanelModel[] = [];
 
     static fromListOfPanelModels(participants: PanelModel[], pexipDisplayName: string, roomid: string): LinkedParticipantPanelModel {
-        const lip = participants.find(x => x.hearingRole === HearingRole.LITIGANT_IN_PERSON || x.hearingRole === HearingRole.WITNESS);
+        const lip = participants.find(x => x.hearingRole !== HearingRole.INTERPRETER);
         const pexipName = pexipDisplayName;
         const displayName = participants.map(x => x.displayName).join(', ');
         const role = lip.role;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7795

### Change description ###
- Changed a find to return the first non-interpreter in the group of linked participants.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
