### PR TITLE
VIH-7538 - Kinly HeartBeat API key added - pipelines

### DIFF
--- a/azure-pipelines.beta.yml
+++ b/azure-pipelines.beta.yml
@@ -219,7 +219,7 @@ stages:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate
@@ -316,7 +316,7 @@ stages:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate

--- a/azure-pipelines.nightly.yml
+++ b/azure-pipelines.nightly.yml
@@ -256,7 +256,7 @@ stages:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate
@@ -353,7 +353,7 @@ stages:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -199,7 +199,7 @@ stages:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate
@@ -296,7 +296,7 @@ stages:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ parameters:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate
@@ -176,7 +176,7 @@ parameters:
           - name: KinlyConfiguration:CallbackSecret
             value: $(CallbackKey)
           - name: KinlyConfiguration:ApiSecret
-            value: $(KinlyApiKey)
+            value: $(KinlyHeartBeatApiKey)
           - name: KinlyConfiguration:SelfTestApiSecret
             value: $(SelfTestApiKey)
           - name: KinlyConfiguration:JoinByPhoneFromDate


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7538


### Change description ###
vh-video-web requires a new kinly API key to generate jwt tokens. This will be exclusively used only vh-video-web
vh-video-api will keep the existing kinly api key


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
