### PR TITLE
VIH-7917 iPad users on Safari are seeing the "unsupported device" page

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.spec.ts
@@ -1,7 +1,7 @@
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { DeviceTypeService } from './device-type.service';
 
-fdescribe('DeviceType', () => {
+describe('DeviceType', () => {
     let service: DeviceTypeService;
     let deviceDetectorService: jasmine.SpyObj<DeviceDetectorService>;
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.spec.ts
@@ -1,7 +1,7 @@
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { DeviceTypeService } from './device-type.service';
 
-describe('DeviceType', () => {
+fdescribe('DeviceType', () => {
     let service: DeviceTypeService;
     let deviceDetectorService: jasmine.SpyObj<DeviceDetectorService>;
 
@@ -55,6 +55,8 @@ describe('DeviceType', () => {
         { isTablet: true, os: 'Mac', browser: 'Firefox', expected: false },
         { isTablet: false, os: 'Mac', browser: 'Chrome', expected: false },
         { isTablet: false, os: 'Mac', browser: 'Firefox', expected: false },
+        { isTablet: true, os: 'ios', browser: 'Safari', expected: true },
+        { isTablet: true, os: 'ios', browser: 'Chrome', expected: false },
         { isTablet: false, os: 'Windows', browser: 'Firefox', expected: false },
         { isTablet: false, os: 'Windows', browser: 'Chrome', expected: false },
         { isTablet: false, os: 'Windows', browser: 'MS-Edge-Chromium', expected: false }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/device-type.service.ts
@@ -22,7 +22,7 @@ export class DeviceTypeService {
     isIpad(): boolean {
         return (
             this.deviceDetectorService.isTablet() &&
-            this.deviceDetectorService.os.toLowerCase() === 'mac' &&
+            (this.deviceDetectorService.os.toLowerCase() === 'mac' || this.deviceDetectorService.os.toLowerCase() === 'ios') &&
             this.deviceDetectorService.browser.toLowerCase() === 'safari'
         );
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7917

### Change description ###

we are looking for "mac" os rather than "ios" in isIpad method, but I think we still need "mac" for some other apple devices so I added "ios"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
