### PR TITLE
VIH-7967 PM video feed is duplicated in hearing when user refresh on iPad

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
@@ -1,0 +1,97 @@
+import { Renderer2, RendererFactory2 } from "@angular/core";
+import { fakeAsync } from "@angular/core/testing";
+import { DeviceDetectorService } from "ngx-device-detector";
+import { UnloadDetectorService } from "./unload-detector.service";
+
+class Renderer2Mock {
+  beforeUnloadCallback: (event : any) => boolean | void;
+  visibiltyChangeCallback: (event : any) => boolean | void;
+
+  listen(target: 'window' | 'document' | 'body' | any, eventName: string, callback: (event: any) => boolean | void) {
+    if (target === 'window' && eventName === 'beforeunload')
+    {
+      this.beforeUnloadCallback = callback;
+    } else if (target === 'document' && eventName === 'visibilitychange') {
+      this.visibiltyChangeCallback = callback;
+    }
+  }
+}
+
+describe('UnloadDetectorService', () => {
+  let service: UnloadDetectorService;
+  let deviceDetectorServiceSpy : jasmine.SpyObj<DeviceDetectorService>;
+  let renderer2FactorySpy : jasmine.SpyObj<RendererFactory2>;
+  let renderer2Mock : Renderer2Mock;
+
+  beforeEach(() => {
+    deviceDetectorServiceSpy = jasmine.createSpyObj<DeviceDetectorService>('DeviceDetectorService', ['isDesktop']);
+    renderer2FactorySpy = jasmine.createSpyObj<RendererFactory2>('RendererFactory2', ['createRenderer']);
+
+    renderer2Mock = new Renderer2Mock();
+    spyOn(renderer2Mock, 'listen').and.callThrough();
+
+    renderer2FactorySpy.createRenderer.withArgs(null, null).and.returnValue(renderer2Mock as unknown as Renderer2);
+  });
+
+  describe('when on desktop', () => {
+    beforeEach(() => {
+      deviceDetectorServiceSpy.isDesktop.and.returnValue(true);
+      service = new UnloadDetectorService(deviceDetectorServiceSpy, renderer2FactorySpy);
+    });
+
+    it('should create', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should initialise the isDesktop value', () => {
+      expect(service.isDesktop).toBeTrue();
+    });
+
+    it('should listen to the before unload event', () => {
+      expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('window', 'beforeunload', jasmine.anything());
+    });
+
+    it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
+      // Arrange
+      let wasCalled = false;
+      service.shouldUnload.subscribe(() => wasCalled = true);
+
+      // Act
+      renderer2Mock.beforeUnloadCallback(undefined);
+
+      // Assert
+      expect(wasCalled).toBeTrue();
+    }));
+  });
+
+  describe('when NOT on desktop', () => {
+    beforeEach(() => {
+      deviceDetectorServiceSpy.isDesktop.and.returnValue(false);
+      service = new UnloadDetectorService(deviceDetectorServiceSpy, renderer2FactorySpy);
+    });
+
+    it('should create', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should initialise the isDesktop value', () => {
+      expect(service.isDesktop).toBeFalse();
+    });
+
+    it('should listen to the visibility change event', () => {
+      expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('document', 'visibilitychange', jasmine.anything());
+    });
+
+    it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
+      // Arrange
+      let wasCalled = false;
+      service.shouldUnload.subscribe(() => wasCalled = true);
+
+      // Act
+      renderer2Mock.visibiltyChangeCallback(undefined);
+
+      // Assert
+      expect(wasCalled).toBeTrue();
+    }));
+  });
+});

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
@@ -17,7 +17,7 @@ class Renderer2Mock {
     }
 }
 
-describe('UnloadDetectorService', () => {
+fdescribe('UnloadDetectorService', () => {
     let service: UnloadDetectorService;
     let deviceDetectorServiceSpy: jasmine.SpyObj<DeviceDetectorService>;
     let renderer2FactorySpy: jasmine.SpyObj<RendererFactory2>;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
@@ -1,5 +1,5 @@
 import { Renderer2, RendererFactory2 } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { fakeAsync, flush } from '@angular/core/testing';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { Logger } from './logging/logger-base';
 import { UnloadDetectorService } from './unload-detector.service';
@@ -17,7 +17,7 @@ class Renderer2Mock {
     }
 }
 
-fdescribe('UnloadDetectorService', () => {
+describe('UnloadDetectorService', () => {
     let service: UnloadDetectorService;
     let deviceDetectorServiceSpy: jasmine.SpyObj<DeviceDetectorService>;
     let renderer2FactorySpy: jasmine.SpyObj<RendererFactory2>;
@@ -60,6 +60,7 @@ fdescribe('UnloadDetectorService', () => {
 
             // Act
             renderer2Mock.beforeUnloadCallback(undefined);
+            flush();
 
             // Assert
             expect(wasCalled).toBeTrue();
@@ -91,6 +92,7 @@ fdescribe('UnloadDetectorService', () => {
 
             // Act
             renderer2Mock.visibiltyChangeCallback(undefined);
+            flush();
 
             // Assert
             expect(wasCalled).toBeTrue();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
@@ -1,97 +1,99 @@
-import { Renderer2, RendererFactory2 } from "@angular/core";
-import { fakeAsync } from "@angular/core/testing";
-import { DeviceDetectorService } from "ngx-device-detector";
-import { UnloadDetectorService } from "./unload-detector.service";
+import { Renderer2, RendererFactory2 } from '@angular/core';
+import { fakeAsync } from '@angular/core/testing';
+import { DeviceDetectorService } from 'ngx-device-detector';
+import { Logger } from './logging/logger-base';
+import { UnloadDetectorService } from './unload-detector.service';
 
 class Renderer2Mock {
-  beforeUnloadCallback: (event : any) => boolean | void;
-  visibiltyChangeCallback: (event : any) => boolean | void;
+    beforeUnloadCallback: (event: any) => boolean | void;
+    visibiltyChangeCallback: (event: any) => boolean | void;
 
-  listen(target: 'window' | 'document' | 'body' | any, eventName: string, callback: (event: any) => boolean | void) {
-    if (target === 'window' && eventName === 'beforeunload')
-    {
-      this.beforeUnloadCallback = callback;
-    } else if (target === 'document' && eventName === 'visibilitychange') {
-      this.visibiltyChangeCallback = callback;
+    listen(target: 'window' | 'document' | 'body' | any, eventName: string, callback: (event: any) => boolean | void) {
+        if (target === 'window' && eventName === 'beforeunload') {
+            this.beforeUnloadCallback = callback;
+        } else if (target === 'document' && eventName === 'visibilitychange') {
+            this.visibiltyChangeCallback = callback;
+        }
     }
-  }
 }
 
 describe('UnloadDetectorService', () => {
-  let service: UnloadDetectorService;
-  let deviceDetectorServiceSpy : jasmine.SpyObj<DeviceDetectorService>;
-  let renderer2FactorySpy : jasmine.SpyObj<RendererFactory2>;
-  let renderer2Mock : Renderer2Mock;
+    let service: UnloadDetectorService;
+    let deviceDetectorServiceSpy: jasmine.SpyObj<DeviceDetectorService>;
+    let renderer2FactorySpy: jasmine.SpyObj<RendererFactory2>;
+    let renderer2Mock: Renderer2Mock;
+    let loggerSpy: jasmine.SpyObj<Logger>;
 
-  beforeEach(() => {
-    deviceDetectorServiceSpy = jasmine.createSpyObj<DeviceDetectorService>('DeviceDetectorService', ['isDesktop']);
-    renderer2FactorySpy = jasmine.createSpyObj<RendererFactory2>('RendererFactory2', ['createRenderer']);
-
-    renderer2Mock = new Renderer2Mock();
-    spyOn(renderer2Mock, 'listen').and.callThrough();
-
-    renderer2FactorySpy.createRenderer.withArgs(null, null).and.returnValue(renderer2Mock as unknown as Renderer2);
-  });
-
-  describe('when on desktop', () => {
     beforeEach(() => {
-      deviceDetectorServiceSpy.isDesktop.and.returnValue(true);
-      service = new UnloadDetectorService(deviceDetectorServiceSpy, renderer2FactorySpy);
+        deviceDetectorServiceSpy = jasmine.createSpyObj<DeviceDetectorService>('DeviceDetectorService', ['isDesktop']);
+        renderer2FactorySpy = jasmine.createSpyObj<RendererFactory2>('RendererFactory2', ['createRenderer']);
+        loggerSpy = jasmine.createSpyObj<Logger>('Logger', ['info']);
+
+        renderer2Mock = new Renderer2Mock();
+        spyOn(renderer2Mock, 'listen').and.callThrough();
+
+        renderer2FactorySpy.createRenderer.withArgs(null, null).and.returnValue((renderer2Mock as unknown) as Renderer2);
     });
 
-    it('should create', () => {
-      expect(service).toBeTruthy();
+    describe('when on desktop', () => {
+        beforeEach(() => {
+            deviceDetectorServiceSpy.isDesktop.and.returnValue(true);
+            service = new UnloadDetectorService(deviceDetectorServiceSpy, renderer2FactorySpy, loggerSpy);
+        });
+
+        it('should create', () => {
+            expect(service).toBeTruthy();
+        });
+
+        it('should initialise the isDesktop value', () => {
+            expect(service.isDesktop).toBeTrue();
+        });
+
+        it('should listen to the before unload event', () => {
+            expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('window', 'beforeunload', jasmine.anything());
+        });
+
+        it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
+            // Arrange
+            let wasCalled = false;
+            service.shouldUnload.subscribe(() => (wasCalled = true));
+
+            // Act
+            renderer2Mock.beforeUnloadCallback(undefined);
+
+            // Assert
+            expect(wasCalled).toBeTrue();
+        }));
     });
 
-    it('should initialise the isDesktop value', () => {
-      expect(service.isDesktop).toBeTrue();
+    describe('when NOT on desktop', () => {
+        beforeEach(() => {
+            deviceDetectorServiceSpy.isDesktop.and.returnValue(false);
+            service = new UnloadDetectorService(deviceDetectorServiceSpy, renderer2FactorySpy, loggerSpy);
+        });
+
+        it('should create', () => {
+            expect(service).toBeTruthy();
+        });
+
+        it('should initialise the isDesktop value', () => {
+            expect(service.isDesktop).toBeFalse();
+        });
+
+        it('should listen to the visibility change event', () => {
+            expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('document', 'visibilitychange', jasmine.anything());
+        });
+
+        it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
+            // Arrange
+            let wasCalled = false;
+            service.shouldUnload.subscribe(() => (wasCalled = true));
+
+            // Act
+            renderer2Mock.visibiltyChangeCallback(undefined);
+
+            // Assert
+            expect(wasCalled).toBeTrue();
+        }));
     });
-
-    it('should listen to the before unload event', () => {
-      expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('window', 'beforeunload', jasmine.anything());
-    });
-
-    it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
-      // Arrange
-      let wasCalled = false;
-      service.shouldUnload.subscribe(() => wasCalled = true);
-
-      // Act
-      renderer2Mock.beforeUnloadCallback(undefined);
-
-      // Assert
-      expect(wasCalled).toBeTrue();
-    }));
-  });
-
-  describe('when NOT on desktop', () => {
-    beforeEach(() => {
-      deviceDetectorServiceSpy.isDesktop.and.returnValue(false);
-      service = new UnloadDetectorService(deviceDetectorServiceSpy, renderer2FactorySpy);
-    });
-
-    it('should create', () => {
-      expect(service).toBeTruthy();
-    });
-
-    it('should initialise the isDesktop value', () => {
-      expect(service.isDesktop).toBeFalse();
-    });
-
-    it('should listen to the visibility change event', () => {
-      expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('document', 'visibilitychange', jasmine.anything());
-    });
-
-    it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
-      // Arrange
-      let wasCalled = false;
-      service.shouldUnload.subscribe(() => wasCalled = true);
-
-      // Act
-      renderer2Mock.visibiltyChangeCallback(undefined);
-
-      // Assert
-      expect(wasCalled).toBeTrue();
-    }));
-  });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.spec.ts
@@ -53,7 +53,7 @@ describe('UnloadDetectorService', () => {
             expect(renderer2Mock.listen).toHaveBeenCalledOnceWith('window', 'beforeunload', jasmine.anything());
         });
 
-        it('should emit an event when the visibilitychange event is recieved with the isHidden as true', fakeAsync(() => {
+        it('should emit an event when the before unload callback is recieved', fakeAsync(() => {
             // Arrange
             let wasCalled = false;
             service.shouldUnload.subscribe(() => (wasCalled = true));
@@ -90,12 +90,29 @@ describe('UnloadDetectorService', () => {
             let wasCalled = false;
             service.shouldUnload.subscribe(() => (wasCalled = true));
 
+            spyOnProperty(document, 'hidden', 'get').and.returnValue(true);
+
             // Act
             renderer2Mock.visibiltyChangeCallback(undefined);
             flush();
 
             // Assert
             expect(wasCalled).toBeTrue();
+        }));
+
+        it('should NOT emit an event when the visibilitychange event is recieved with the isHidden as false', fakeAsync(() => {
+            // Arrange
+            let wasCalled = false;
+            service.shouldUnload.subscribe(() => (wasCalled = true));
+
+            spyOnProperty(document, 'hidden', 'get').and.returnValue(false);
+
+            // Act
+            renderer2Mock.visibiltyChangeCallback(undefined);
+            flush();
+
+            // Assert
+            expect(wasCalled).toBeFalse();
         }));
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { DeviceDetectorService } from 'ngx-device-detector';
+import { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class UnloadDetectorService {
+    private visibilityChangeSubject = new Subject<boolean>();
+    private shouldUnloadSubject = new Subject<void>();
+    private beforeUnloadSubject = new Subject<void>();
+
+    private renderer: Renderer2;
+    isDesktop: boolean;
+
+    constructor(private deviceDetectorService: DeviceDetectorService, renderer2Factor: RendererFactory2) {
+        this.renderer = renderer2Factor.createRenderer(null, null);
+        this.initialise();
+    }
+
+    private initialise() {
+        this.isDesktop = this.deviceDetectorService.isDesktop();
+
+        if (this.isDesktop) {
+            this.renderer.listen('window', 'beforeunload', () => this.beforeUnloadSubject.next());
+            this.beforeUnload.subscribe(() => this.shouldUnloadSubject.next());
+        } else {
+            this.renderer.listen('document', 'visibilitychange', () => this.visibilityChangeSubject.next(document.hidden));
+            this.visibilityChangedToHidden.subscribe(() => this.shouldUnloadSubject.next());
+        }
+    }
+
+    get shouldUnload(): Observable<void> {
+        return this.shouldUnloadSubject.asObservable();
+    }
+
+    private get visibilityChangedToHidden() {
+        return this.visibilityChange.pipe(filter(value => value === true));
+    }
+
+    private get visibilityChange(): Observable<boolean> {
+        return this.visibilityChangeSubject.asObservable();
+    }
+
+    private get beforeUnload(): Observable<void> {
+        return this.beforeUnloadSubject.asObservable();
+    }
+}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
@@ -2,12 +2,14 @@ import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, tap } from 'rxjs/operators';
+import { Logger } from './logging/logger-base';
 
 @Injectable({
     providedIn: 'root'
 })
 export class UnloadDetectorService {
+    private loggerPrefix = '[UnloadDetectorService] -';
     private visibilityChangeSubject = new Subject<boolean>();
     private shouldUnloadSubject = new Subject<void>();
     private beforeUnloadSubject = new Subject<void>();
@@ -15,7 +17,7 @@ export class UnloadDetectorService {
     private renderer: Renderer2;
     isDesktop: boolean;
 
-    constructor(private deviceDetectorService: DeviceDetectorService, renderer2Factor: RendererFactory2) {
+    constructor(private deviceDetectorService: DeviceDetectorService, renderer2Factor: RendererFactory2, private logger: Logger) {
         this.renderer = renderer2Factor.createRenderer(null, null);
         this.initialise();
     }
@@ -24,11 +26,27 @@ export class UnloadDetectorService {
         this.isDesktop = this.deviceDetectorService.isDesktop();
 
         if (this.isDesktop) {
+            this.logger.info(`${this.loggerPrefix} Desktop device detected. Will raise unload event when window:beforeunload is raised!`);
             this.renderer.listen('window', 'beforeunload', () => this.beforeUnloadSubject.next());
-            this.beforeUnload.subscribe(() => this.shouldUnloadSubject.next());
+            this.beforeUnload
+                .pipe(
+                    tap(() => {
+                        this.logger.info(`${this.loggerPrefix} window:beforeunload recieved. Emitting the should unload event!`);
+                    })
+                )
+                .subscribe(() => this.shouldUnloadSubject.next());
         } else {
+            this.logger.info(
+                `${this.loggerPrefix} Mobile device detected. Will raise unload event when document:visibilitychange is raised!`
+            );
             this.renderer.listen('document', 'visibilitychange', () => this.visibilityChangeSubject.next(document.hidden));
-            this.visibilityChangedToHidden.subscribe(() => this.shouldUnloadSubject.next());
+            this.visibilityChangedToHidden
+                .pipe(
+                    tap(() => {
+                        this.logger.info(`${this.loggerPrefix} Visibility changed to hidden. Emitting the should unload event!`);
+                    })
+                )
+                .subscribe(() => this.shouldUnloadSubject.next());
         }
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
-import { filter, tap } from 'rxjs/operators';
+import { filter, map, tap } from 'rxjs/operators';
 import { Logger } from './logging/logger-base';
 
 @Injectable({
@@ -17,8 +17,8 @@ export class UnloadDetectorService {
     private renderer: Renderer2;
     isDesktop: boolean;
 
-    constructor(private deviceDetectorService: DeviceDetectorService, renderer2Factor: RendererFactory2, private logger: Logger) {
-        this.renderer = renderer2Factor.createRenderer(null, null);
+    constructor(private deviceDetectorService: DeviceDetectorService, renderer2Factory: RendererFactory2, private logger: Logger) {
+        this.renderer = renderer2Factory.createRenderer(null, null);
         this.initialise();
     }
 
@@ -54,8 +54,13 @@ export class UnloadDetectorService {
         return this.shouldUnloadSubject.asObservable();
     }
 
-    private get visibilityChangedToHidden() {
-        return this.visibilityChange.pipe(filter(value => value === true));
+    private get visibilityChangedToHidden(): Observable<void> {
+        return this.visibilityChange.pipe(
+            filter(value => value === true),
+            map(() => {
+                return;
+            })
+        );
     }
 
     private get visibilityChange(): Observable<boolean> {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/unload-detector.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { DeviceDetectorService } from 'ngx-device-detector';
-import { Observable } from 'rxjs';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 import { Logger } from './logging/logger-base';
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.eventhub.events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.eventhub.events.spec.ts
@@ -28,9 +28,15 @@ import {
 } from '../waiting-room-shared/tests/waiting-room-base-setup';
 import { JohWaitingRoomComponent } from './joh-waiting-room.component';
 import { translateServiceSpy } from 'src/app/testing/mocks/mock-translation.service';
+import { UnloadDetectorService } from 'src/app/services/unload-detector.service';
+import { Subject } from 'rxjs';
+import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 
 describe('JohWaitingRoomComponent eventhub events', () => {
     let component: JohWaitingRoomComponent;
+    let unloadDetectorServiceSpy: jasmine.SpyObj<UnloadDetectorService>;
+    let shouldUnloadSubject: Subject<void>;
+
     const hearingStatusSubject = hearingStatusSubjectMock;
     const translateService = translateServiceSpy;
 
@@ -39,6 +45,10 @@ describe('JohWaitingRoomComponent eventhub events', () => {
     });
 
     beforeEach(async () => {
+        unloadDetectorServiceSpy = jasmine.createSpyObj<UnloadDetectorService>('UnloadDetectorService', [], ['shouldUnload']);
+        shouldUnloadSubject = new Subject<void>();
+        getSpiedPropertyGetter(unloadDetectorServiceSpy, 'shouldUnload').and.returnValue(shouldUnloadSubject.asObservable());
+
         component = new JohWaitingRoomComponent(
             activatedRoute,
             videoWebService,
@@ -57,7 +67,8 @@ describe('JohWaitingRoomComponent eventhub events', () => {
             roomClosingToastrService,
             clockService,
             translateService,
-            consultationInvitiationService
+            consultationInvitiationService,
+            unloadDetectorServiceSpy
         );
         const conference = new ConferenceResponse(Object.assign({}, globalConference));
         const participant = new ParticipantResponse(Object.assign({}, globalParticipant));

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.spec.ts
@@ -26,11 +26,17 @@ import {
 } from '../waiting-room-shared/tests/waiting-room-base-setup';
 import { JohWaitingRoomComponent } from './joh-waiting-room.component';
 import { translateServiceSpy } from 'src/app/testing/mocks/mock-translation.service';
+import { UnloadDetectorService } from 'src/app/services/unload-detector.service';
+import { Subject } from 'rxjs';
+import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 
 describe('JohWaitingRoomComponent', () => {
     let component: JohWaitingRoomComponent;
     const conferenceTestData = new ConferenceTestData();
     let activatedRoute: ActivatedRoute;
+    let unloadDetectorServiceSpy: jasmine.SpyObj<UnloadDetectorService>;
+    let shouldUnloadSubject: Subject<void>;
+
     beforeAll(() => {
         initAllWRDependencies();
     });
@@ -44,6 +50,10 @@ describe('JohWaitingRoomComponent', () => {
     };
 
     const translateService = translateServiceSpy;
+
+    unloadDetectorServiceSpy = jasmine.createSpyObj<UnloadDetectorService>('UnloadDetectorService', [], ['shouldUnload']);
+    shouldUnloadSubject = new Subject<void>();
+    getSpiedPropertyGetter(unloadDetectorServiceSpy, 'shouldUnload').and.returnValue(shouldUnloadSubject.asObservable());
 
     beforeEach(async () => {
         translateService.instant.calls.reset();
@@ -65,7 +75,8 @@ describe('JohWaitingRoomComponent', () => {
             roomClosingToastrService,
             clockService,
             translateService,
-            consultationInvitiationService
+            consultationInvitiationService,
+            unloadDetectorServiceSpy
         );
         const conference = new ConferenceResponse(Object.assign({}, globalConference));
         const participant = new ParticipantResponse(Object.assign({}, globalParticipant));

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { merge, Subject, Subscription } from 'rxjs';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/tests/judge-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/tests/judge-waiting-room.component.spec.ts
@@ -45,10 +45,11 @@ import { VideoControlService } from 'src/app/services/conference/video-control.s
 import { ConferenceService } from 'src/app/services/conference/conference.service';
 import { VideoControlCacheService } from 'src/app/services/conference/video-control-cache.service';
 import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { ParticipantModel } from 'src/app/shared/models/participant';
 import { VirtualMeetingRoomModel } from 'src/app/services/conference/models/virtual-meeting-room.model';
 import { HearingRole } from '../../models/hearing-role-model';
+import { UnloadDetectorService } from 'src/app/services/unload-detector.service';
 
 describe('JudgeWaitingRoomComponent when conference exists', () => {
     const participantOneId = Guid.create().toString();
@@ -136,6 +137,8 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
     let participantServiceSpy: jasmine.SpyObj<ParticipantService>;
     let videoControlServiceSpy: jasmine.SpyObj<VideoControlService>;
     let videoControlCacheServiceSpy: jasmine.SpyObj<VideoControlCacheService>;
+    let unloadDetectorServiceSpy: jasmine.SpyObj<UnloadDetectorService>;
+    let shouldUnloadSubject: Subject<void>;
 
     beforeAll(() => {
         initAllWRDependencies();
@@ -143,6 +146,10 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
     });
 
     beforeEach(async () => {
+        unloadDetectorServiceSpy = jasmine.createSpyObj<UnloadDetectorService>('UnloadDetectorService', [], ['shouldUnload']);
+        shouldUnloadSubject = new Subject<void>();
+        getSpiedPropertyGetter(unloadDetectorServiceSpy, 'shouldUnload').and.returnValue(shouldUnloadSubject.asObservable());
+
         consultationInvitiation = {} as ConsultationInvitation;
         logged = new LoggedParticipantResponse({
             participant_id: globalParticipant.id,
@@ -221,7 +228,8 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
             conferenceServiceSpy,
             participantServiceSpy,
             videoControlServiceSpy,
-            videoControlCacheServiceSpy
+            videoControlCacheServiceSpy,
+            unloadDetectorServiceSpy
         );
 
         consultationInvitiationService.getInvitation.and.returnValue(consultationInvitiation);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject, Subscription } from 'rxjs';
 import { ConsultationService } from 'src/app/services/api/consultation.service';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.analogue-time.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.analogue-time.spec.ts
@@ -24,16 +24,25 @@ import {
 } from '../../waiting-room-shared/tests/waiting-room-base-setup';
 import { ParticipantWaitingRoomComponent } from '../participant-waiting-room.component';
 import { translateServiceSpy } from 'src/app/testing/mocks/mock-translation.service';
+import { UnloadDetectorService } from 'src/app/services/unload-detector.service';
+import { Subject } from 'rxjs';
+import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 
 describe('ParticipantWaitingRoomComponent message and clock', () => {
     let component: ParticipantWaitingRoomComponent;
     const translateService = translateServiceSpy;
+    let unloadDetectorServiceSpy: jasmine.SpyObj<UnloadDetectorService>;
+    let shouldUnloadSubject: Subject<void>;
 
     beforeAll(() => {
         initAllWRDependencies();
     });
 
     beforeEach(() => {
+        unloadDetectorServiceSpy = jasmine.createSpyObj<UnloadDetectorService>('UnloadDetectorService', [], ['shouldUnload']);
+        shouldUnloadSubject = new Subject<void>();
+        getSpiedPropertyGetter(unloadDetectorServiceSpy, 'shouldUnload').and.returnValue(shouldUnloadSubject.asObservable());
+
         component = new ParticipantWaitingRoomComponent(
             activatedRoute,
             videoWebService,
@@ -52,7 +61,8 @@ describe('ParticipantWaitingRoomComponent message and clock', () => {
             roomClosingToastrService,
             clockService,
             translateService,
-            consultationInvitiationService
+            consultationInvitiationService,
+            unloadDetectorServiceSpy
         );
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.eventhub.events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.eventhub.events.spec.ts
@@ -29,17 +29,26 @@ import {
 } from '../../waiting-room-shared/tests/waiting-room-base-setup';
 import { ParticipantWaitingRoomComponent } from '../participant-waiting-room.component';
 import { translateServiceSpy } from 'src/app/testing/mocks/mock-translation.service';
+import { UnloadDetectorService } from 'src/app/services/unload-detector.service';
+import { Subject } from 'rxjs';
+import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 
 describe('ParticipantWaitingRoomComponent event hub events', () => {
     let component: ParticipantWaitingRoomComponent;
     const hearingStatusSubject = hearingStatusSubjectMock;
     const translateService = translateServiceSpy;
+    let unloadDetectorServiceSpy: jasmine.SpyObj<UnloadDetectorService>;
+    let shouldUnloadSubject: Subject<void>;
 
     beforeAll(() => {
         initAllWRDependencies();
     });
 
     beforeEach(() => {
+        unloadDetectorServiceSpy = jasmine.createSpyObj<UnloadDetectorService>('UnloadDetectorService', [], ['shouldUnload']);
+        shouldUnloadSubject = new Subject<void>();
+        getSpiedPropertyGetter(unloadDetectorServiceSpy, 'shouldUnload').and.returnValue(shouldUnloadSubject.asObservable());
+
         component = new ParticipantWaitingRoomComponent(
             activatedRoute,
             videoWebService,
@@ -58,7 +67,8 @@ describe('ParticipantWaitingRoomComponent event hub events', () => {
             roomClosingToastrService,
             clockService,
             translateService,
-            consultationInvitiationService
+            consultationInvitiationService,
+            unloadDetectorServiceSpy
         );
 
         const conference = new ConferenceResponse(Object.assign({}, globalConference));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7967
https://tools.hmcts.net/jira/browse/VIH-7968
https://tools.hmcts.net/jira/browse/VIH-7976

### Change description ###
- Added a "unload detector" service which detects events (window / document) that should cause the application to unload resource i.e. disconnect from pexip.
- Refactored the three waiting rooms to consume the new service.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
