### PR TITLE
VIH-7657 toastr style issues

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-toastr.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-toastr.service.ts
@@ -294,16 +294,19 @@ export class NotificationToastrService {
     }
 
     showParticipantAdded(participant: ParticipantResponse, inHearing: boolean = false): VhToastComponent {
-        let message = `<span class="govuk-!-font-weight-bold">${this.translateService.instant(
+        let message = `<span class="govuk-!-font-weight-bold toast-content toast-header">${this.translateService.instant(
             'notification-toastr.participant-added.title',
             {
                 name: participant.name
             }
         )}</span>`;
-        message += `<br/>${this.translateService.instant('notification-toastr.participant-added.message', {
-            role: this.translateHearingRole(participant.hearing_role),
-            party: this.translateCaseRole(participant.case_type_group)
-        })}<br/>`;
+        message += `<span class="toast-content toast-body">${this.translateService.instant(
+            'notification-toastr.participant-added.message',
+            {
+                role: this.translateHearingRole(participant.hearing_role),
+                party: this.translateCaseRole(participant.case_type_group)
+            }
+        )}</span>`;
 
         const toast = this.toastr.show('', '', {
             timeOut: 0,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -1500,7 +1500,18 @@ describe('WaitingRoomComponent EventHub Call', () => {
             expect(notificationToastrService.showParticipantAdded).toHaveBeenCalledWith(testParticipant, true);
         });
 
-        it('should show toast for not in hearing', () => {
+        it('should show toast for in consultation', () => {
+            // Arrange
+            component.participant.status = ParticipantStatus.InConsultation;
+
+            // Act
+            getParticipantsUpdatedSubjectMock.next(testParticipantMessage);
+
+            // Assert
+            expect(notificationToastrService.showParticipantAdded).toHaveBeenCalledWith(testParticipant, true);
+        });
+
+        it('should show toast for not in hearing or consultation', () => {
             // Arrange
             component.participant.status = ParticipantStatus.Available;
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -466,7 +466,8 @@ export abstract class WaitingRoomBaseDirective {
                     this.logger.debug(`[WR] - Participant added, showing notification`, participant);
                     this.notificationToastrService.showParticipantAdded(
                         participant,
-                        this.participant.status === ParticipantStatus.InHearing
+                        this.participant.status === ParticipantStatus.InHearing ||
+                            this.participant.status === ParticipantStatus.InConsultation
                     );
                 });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
@@ -560,7 +560,7 @@
     },
     "participant-added": {
       "title": "Mae {{name}}",
-      "message": "{{role}}({{party}}) wedi cael ei (h)ychwanegu at y gwrandawiad.",
+      "message": "{{role}} ({{party}}) wedi cael ei (h)ychwanegu at y gwrandawiad.",
       "dismiss": "Gwrthod"
     }
   },

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
@@ -1015,7 +1015,7 @@
     },
     "participant-added": {
       "title": "{{name}}",
-      "message": "{{role}}({{party}}) has been added to the hearing.",
+      "message": "{{role}} ({{party}}) has been added to the hearing.",
       "dismiss": "Dismiss"
     }
   },

--- a/VideoWeb/VideoWeb/ClientApp/src/styles.css
+++ b/VideoWeb/VideoWeb/ClientApp/src/styles.css
@@ -2,5 +2,10 @@
 
 .toast-top-right {
     top: 70px !important;
-    right: 15px !important;
+    right: 20px !important;
+}
+
+.toast-content {
+    display: block;
+    word-wrap: break-word;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
VIH-7657


### Change description ###
Change toastr to display as white when in consultation. Put a space between role and party for a natural breakpoint. Also adding a word wrap in case of particularly long words


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
