### PR TITLE
VIH-8054 remove in session hearing status check

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/Features/JudgePrivateConsultation.feature
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Features/JudgePrivateConsultation.feature
@@ -14,7 +14,6 @@ Scenario: Judge Can Enter The Consultation Room
 Scenario: Panel Member Can Enter The Consultation Room
   Given I have a hearing with a Panel Member
   And the Panel Member user has progressed to the Judge Waiting Room page for the existing hearing
-  And the hearing status changes to In Session
   When they enter the private consultation room
   Then they will be transferred to the private consultation room
   And they can leave the private consultation room

--- a/VideoWeb/VideoWeb.AcceptanceTests/Steps/JudgePrivateConsultationSteps.cs
+++ b/VideoWeb/VideoWeb.AcceptanceTests/Steps/JudgePrivateConsultationSteps.cs
@@ -83,7 +83,7 @@ namespace VideoWeb.AcceptanceTests.Steps
 
         [When(@"(?:he|she|they) (?:enter|enters) the private consultation room")]
         public void WhenTheyEnterPrivateConsultationRoom()
-        {;
+        {
             _browsers[_c.CurrentUser].Driver.WaitUntilVisible(JudgeWaitingRoomPage.HearingTitle).Displayed.Should().BeTrue();
             WaitForUserStatusToBe(ParticipantState.Available);
             _browsers[_c.CurrentUser].ClickToProgress(JudgeWaitingRoomPage.EnterPrivateConsultationButton, PrivateConsultationRoomPage.LeavePrivateConsultationButton, 10);


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8054


### Change description ###
I have removed the line to check if the hearing is "In session" since its incorrect according to the original jira it was based on. See jira for more details.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
