### PR TITLE
VIH-8136 updated sonar cloud property for typescript files code coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -296,7 +296,7 @@ extends:
                 sonar.typescript.exclusions=**/node_modules/**,**/typings.d.ts,**/main.ts,**/environments/environment*.ts,**/*routing.module.ts,**/api-client.ts,**/app-insights-logger.service.ts
                 sonar.coverage.exclusions= **/Testing.Common/**, VideoWeb/Views/*,VideoWeb/Pages/*,VideoWeb.AcceptanceTests/*,**/ClientApp/src/scripts/*.js,**/ClientApp/src/app/testing/**,**/ClientApp/src/app/vh-officer/helper.ts,**/ClientApp/src/app/services/events.service.ts, **/ClientApp/src/app/send-video-events/send-video-events.component.ts,**/ClientApp/src/app/services/api/video-web.service.ts,**/ClientApp/src/app/waiting-space/analogue-clock/analogue-clock.component.ts,**/app-insights-logger.service.ts
                 sonar.cs.opencover.reportsPaths=$(Common.TestResultsDirectory)/Coverage/coverage.opencover.xml
-                sonar.typescript.lcov.reportPaths=$(System.DefaultWorkingDirectory)/VideoWeb/VideoWeb/ClientApp/coverage/lcov.info
+                sonar.javascript.lcov.reportPaths=$(System.DefaultWorkingDirectory)/VideoWeb/VideoWeb/ClientApp/coverage/lcov.info
                 sonar.cpd.exclusions=**/tests/WRTestComponent.ts,**/joh-waiting-room/**
                 sonar.issue.ignore.multicriteria=e1,e2
                 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S107


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/VIH-8136


### Change description ###
- updated the sonarcloud parameter used for code coverage analysis


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
