### PR TITLE
VIH-8273 changed logic to only show share screen for desktop devices

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -56,15 +56,7 @@ describe('HearingControlsBaseComponent', () => {
     const onParticipantUpdatedSubject = onParticipantUpdatedMock;
     const translateService = translateServiceSpy;
 
-    const deviceTypeService = jasmine.createSpyObj<DeviceTypeService>('DeviceTypeService', [
-        'getBrowserName',
-        'getBrowserVersion',
-        'isSupportedBrowser',
-        'isIpad',
-        'isTablet',
-        'isDesktop',
-        'isMobile'
-    ]);
+    const deviceTypeService = jasmine.createSpyObj<DeviceTypeService>('DeviceTypeService', ['isDesktop']);
 
     const logger: Logger = new MockLogger();
 
@@ -648,8 +640,8 @@ describe('HearingControlsBaseComponent', () => {
         HearingRole.QUICK_LINK_PARTICIPANT
     ];
     allowedHearingRoles.forEach(hearingRole => {
-        it(`canShowScreenShareButton() should return "true" when device is not a tablet and user has the '${hearingRole}' HearingRole`, () => {
-            deviceTypeService.isTablet.and.returnValue(false);
+        it(`canShowScreenShareButton() should return "true" when device is a desktop device and user has the '${hearingRole}' HearingRole`, () => {
+            deviceTypeService.isDesktop.and.returnValue(true);
             component.participant.hearing_role = hearingRole;
             component.ngOnInit();
             expect(component.canShowScreenShareButton).toBeTruthy();
@@ -658,8 +650,8 @@ describe('HearingControlsBaseComponent', () => {
 
     const nonAllowedHearingRoles = [HearingRole.WITNESS];
     nonAllowedHearingRoles.forEach(hearingRole => {
-        it(`canShowScreenShareButton() should return "false" when device is not a tablet and user has the '${hearingRole}' HearingRole`, () => {
-            deviceTypeService.isTablet.and.returnValue(false);
+        it(`canShowScreenShareButton() should return "false" when device is a desktop device and user has the '${hearingRole}' HearingRole`, () => {
+            deviceTypeService.isDesktop.and.returnValue(true);
             component.participant.hearing_role = hearingRole;
             component.ngOnInit();
             expect(component.canShowScreenShareButton).toBeFalsy();
@@ -668,8 +660,8 @@ describe('HearingControlsBaseComponent', () => {
 
     const nonAllowedRoles = [Role.QuickLinkObserver];
     nonAllowedRoles.forEach(role => {
-        it(`canShowScreenShareButton() should return "false" when device is not a tablet and user has the '${role}'Role`, () => {
-            deviceTypeService.isTablet.and.returnValue(false);
+        it(`canShowScreenShareButton() should return "false" when device is a desktop device and user has the '${role}'Role`, () => {
+            deviceTypeService.isDesktop.and.returnValue(true);
             component.participant.role = role;
             component.ngOnInit();
             expect(component.canShowScreenShareButton).toBeFalsy();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -604,67 +604,69 @@ describe('HearingControlsBaseComponent', () => {
         expect(component.isJOHConsultation).toBe(true);
     });
 
-    it(`canShowScreenShareButton() should return "false" when device is not desktop`, () => {
-        deviceTypeService.isDesktop.and.returnValue(false);
-        component.ngOnInit();
-        expect(component.canShowScreenShareButton).toBe(false);
-    });
-
-    it(`canShowScreenShareButton() returns "true" when it is a desktop device`, () => {
-        deviceTypeService.isDesktop.and.returnValue(true);
-        component.ngOnInit();
-        expect(component.canShowScreenShareButton).toBe(true);
-    });
-
-    it(`canShowScreenShareButton() should cover all HearingRole's when showing/hiding the "share screen" button`, () => {
-        const enumCount = Object.keys(HearingRole).length;
-        const numberBeingTested = allowedHearingRoles.length + nonAllowedHearingRoles.length + nonAllowedRoles.length;
-        expect(numberBeingTested).toBe(enumCount);
-    });
-
-    const allowedHearingRoles = [
-        HearingRole.APPELLANT,
-        HearingRole.DEFENCE_ADVOCATE,
-        HearingRole.EXPERT,
-        HearingRole.INTERPRETER,
-        HearingRole.JUDGE,
-        HearingRole.MACKENZIE_FRIEND,
-        HearingRole.OBSERVER,
-        HearingRole.PANEL_MEMBER,
-        HearingRole.PROSECUTION,
-        HearingRole.PROSECUTION_ADVOCATE,
-        HearingRole.REPRESENTATIVE,
-        HearingRole.WINGER,
-        HearingRole.LITIGANT_IN_PERSON,
-        HearingRole.STAFF_MEMBER,
-        HearingRole.QUICK_LINK_PARTICIPANT
-    ];
-    allowedHearingRoles.forEach(hearingRole => {
-        it(`canShowScreenShareButton() should return "true" when device is a desktop device and user has the '${hearingRole}' HearingRole`, () => {
-            deviceTypeService.isDesktop.and.returnValue(true);
-            component.participant.hearing_role = hearingRole;
+    describe('canShowScreenShareButton()', () => {
+        it(`returns "false" when device is not desktop`, () => {
+            deviceTypeService.isDesktop.and.returnValue(false);
             component.ngOnInit();
-            expect(component.canShowScreenShareButton).toBeTruthy();
+            expect(component.canShowScreenShareButton).toBe(false);
         });
-    });
 
-    const nonAllowedHearingRoles = [HearingRole.WITNESS];
-    nonAllowedHearingRoles.forEach(hearingRole => {
-        it(`canShowScreenShareButton() should return "false" when device is a desktop device and user has the '${hearingRole}' HearingRole`, () => {
+        it(`returns "true" when it is a desktop device`, () => {
             deviceTypeService.isDesktop.and.returnValue(true);
-            component.participant.hearing_role = hearingRole;
             component.ngOnInit();
-            expect(component.canShowScreenShareButton).toBeFalsy();
+            expect(component.canShowScreenShareButton).toBe(true);
         });
-    });
 
-    const nonAllowedRoles = [Role.QuickLinkObserver];
-    nonAllowedRoles.forEach(role => {
-        it(`canShowScreenShareButton() should return "false" when device is a desktop device and user has the '${role}'Role`, () => {
-            deviceTypeService.isDesktop.and.returnValue(true);
-            component.participant.role = role;
-            component.ngOnInit();
-            expect(component.canShowScreenShareButton).toBeFalsy();
+        it(`covers all HearingRole's when showing/hiding the "share screen" button`, () => {
+            const enumCount = Object.keys(HearingRole).length;
+            const numberBeingTested = allowedHearingRoles.length + nonAllowedHearingRoles.length + nonAllowedRoles.length;
+            expect(numberBeingTested).toBe(enumCount);
+        });
+
+        const allowedHearingRoles = [
+            HearingRole.APPELLANT,
+            HearingRole.DEFENCE_ADVOCATE,
+            HearingRole.EXPERT,
+            HearingRole.INTERPRETER,
+            HearingRole.JUDGE,
+            HearingRole.MACKENZIE_FRIEND,
+            HearingRole.OBSERVER,
+            HearingRole.PANEL_MEMBER,
+            HearingRole.PROSECUTION,
+            HearingRole.PROSECUTION_ADVOCATE,
+            HearingRole.REPRESENTATIVE,
+            HearingRole.WINGER,
+            HearingRole.LITIGANT_IN_PERSON,
+            HearingRole.STAFF_MEMBER,
+            HearingRole.QUICK_LINK_PARTICIPANT
+        ];
+        allowedHearingRoles.forEach(hearingRole => {
+            it(`returns "true" when device is a desktop device and user has the '${hearingRole}' HearingRole`, () => {
+                deviceTypeService.isDesktop.and.returnValue(true);
+                component.participant.hearing_role = hearingRole;
+                component.ngOnInit();
+                expect(component.canShowScreenShareButton).toBeTruthy();
+            });
+        });
+
+        const nonAllowedHearingRoles = [HearingRole.WITNESS];
+        nonAllowedHearingRoles.forEach(hearingRole => {
+            it(`returns "false" when device is a desktop device and user has the '${hearingRole}' HearingRole`, () => {
+                deviceTypeService.isDesktop.and.returnValue(true);
+                component.participant.hearing_role = hearingRole;
+                component.ngOnInit();
+                expect(component.canShowScreenShareButton).toBeFalsy();
+            });
+        });
+
+        const nonAllowedRoles = [Role.QuickLinkObserver];
+        nonAllowedRoles.forEach(role => {
+            it(`returns "false" when device is a desktop device and user has the '${role}'Role`, () => {
+                deviceTypeService.isDesktop.and.returnValue(true);
+                component.participant.role = role;
+                component.ngOnInit();
+                expect(component.canShowScreenShareButton).toBeFalsy();
+            });
         });
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -612,22 +612,13 @@ describe('HearingControlsBaseComponent', () => {
         expect(component.isJOHConsultation).toBe(true);
     });
 
-    it(`canShowScreenShareButton() should return "false" when device is a tablet`, () => {
+    it(`canShowScreenShareButton() should return "false" when device is not desktop`, () => {
         deviceTypeService.isDesktop.and.returnValue(false);
-        deviceTypeService.isTablet.and.returnValue(true);
-        component.ngOnInit();
-        expect(component.canShowScreenShareButton).toBe(false);
-    });
-
-    it(`canShowScreenShareButton() returns "false" when it is a mobile device`, () => {
-        deviceTypeService.isDesktop.and.returnValue(false);
-        deviceTypeService.isMobile.and.returnValue(true);
         component.ngOnInit();
         expect(component.canShowScreenShareButton).toBe(false);
     });
 
     it(`canShowScreenShareButton() returns "true" when it is a desktop device`, () => {
-        deviceTypeService.isTablet.and.returnValue(false);
         deviceTypeService.isDesktop.and.returnValue(true);
         component.ngOnInit();
         expect(component.canShowScreenShareButton).toBe(true);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -66,9 +66,8 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     get canShowScreenShareButton(): boolean {
-        const isNotTablet = !this.deviceTypeService.isTablet();
         const isAllowedRole = this.participant?.hearing_role !== HearingRole.WITNESS && this.participant?.role !== Role.QuickLinkObserver;
-        return isNotTablet && isAllowedRole;
+        return this.deviceTypeService.isDesktop() && isAllowedRole;
     }
 
     get isJudge(): boolean {


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/VIH-8273


### Change description ###
- hiding screen share button for all devices other than desktop/mac


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

mobile devices:

![share_screen_mobile_view](https://user-images.githubusercontent.com/84961314/135835102-eb806d03-90d0-42e4-a56d-5533d8214cad.JPG)

ipad:

![share_screen_tablet_view](https://user-images.githubusercontent.com/84961314/135835118-a6adf82a-f35c-4a1b-a97e-648cbfad91e0.jpg)


desktop: 

![share_screen_desktop_view](https://user-images.githubusercontent.com/84961314/135835138-39eb19a8-7a24-4630-8110-db9a8495c8cd.jpg)


