### PR TITLE
VIH-8340 Forcing setup client in video call service to wait on camera (#1646)

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/media-stream.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/media-stream.service.ts
@@ -28,6 +28,9 @@ export class MediaStreamService {
     }
 
     getStreamForMic(device: UserMediaDevice): Observable<MediaStream> {
+        this.logger.info(
+            `${this.loggerPrefix} getting microphone with the device label ${device.label} and ID ${device.deviceId} ${device.deviceId}`
+        );
         return from(this.navigator.mediaDevices.getUserMedia({ audio: { deviceId: { exact: device.deviceId } } }))
             .pipe(retry(3))
             .pipe(
@@ -40,6 +43,7 @@ export class MediaStreamService {
     }
 
     getStreamForCam(device: UserMediaDevice): Observable<MediaStream> {
+        this.logger.info(`${this.loggerPrefix} getting camera with the device label ${device.label} and ID ${device.deviceId}`);
         return from(this.navigator.mediaDevices.getUserMedia({ video: { deviceId: { exact: device.deviceId }, width: 1280, height: 720 } }))
             .pipe(retry(3))
             .pipe(

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -86,9 +86,9 @@ export class VideoCallService {
         this.pexipAPI.screenshare_fps = 30;
 
         this.userMediaService.initialise();
-        this.userMediaStreamService.currentStream$
-            .pipe(take(1))
-            .subscribe(currentStream => (this.pexipAPI.user_media_stream = currentStream));
+        this.logger.debug(`${this.loggerPrefix} attempting to setup user media stream`);
+        this.pexipAPI.user_media_stream = await this.userMediaStreamService.currentStream$.pipe(take(1)).toPromise();
+        this.logger.debug(`${this.loggerPrefix} set user media stream`);
 
         this.pexipAPI.onSetup = this.handleSetup.bind(this);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[VIH-8340](https://tools.hmcts.net/jira/browse/VIH-8340)

### Change description ###
- Fixed an issue where the wrong camera was loading as user_media_stream wasn't been set before pexip was ready which let it select default devices.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
