### PR TITLE
VIH-8405 prevents disconnection from pexip when eventhub connection is lost

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -10,7 +10,8 @@ import {
     ParticipantResponse,
     ParticipantStatus,
     RoomSummaryResponse,
-    HearingLayout
+    HearingLayout,
+    Role
 } from 'src/app/services/clients/api-client';
 import { ConsultationRequestResponseMessage } from 'src/app/services/models/consultation-request-response-message';
 import { ConferenceStatusMessage } from 'src/app/services/models/conference-status-message';
@@ -347,6 +348,7 @@ describe('WaitingRoomComponent EventHub Call', () => {
         spyOn(component, 'disconnect');
         component.participant.status = ParticipantStatus.InHearing;
         component.conference.status = ConferenceStatus.InSession;
+        component.participant.role = Role.None;
 
         const newParticipantStatus = ParticipantStatus.InConsultation;
         const newConferenceStatus = ConferenceStatus.Paused;
@@ -373,6 +375,24 @@ describe('WaitingRoomComponent EventHub Call', () => {
         expect(component.conference.status).toBe(newConferenceStatus);
         expect(component.conference).toEqual(newConference);
     }));
+
+    it('does not disconnect judge from pexip before the first attempt to reconnect to event hub has been made', () => {
+        component.participant.role = Role.Judge;
+        spyOn(component, 'disconnect');
+
+        component.handleEventHubDisconnection(1);
+
+        expect(component.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('disconnects judge from pexip after the first attempt to reconnect to event hub has been un successful', () => {
+        component.participant.role = Role.Judge;
+        spyOn(component, 'disconnect');
+
+        component.handleEventHubDisconnection(2);
+
+        expect(component.disconnect).toHaveBeenCalledTimes(1);
+    });
 
     it('should go to service error when disconnected from eventhub more than 7 times', () => {
         eventHubDisconnectSubject.next(8);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -585,7 +585,9 @@ export abstract class WaitingRoomBaseDirective {
     }
 
     async handleEventHubDisconnection(reconnectionAttempt: number) {
-        this.disconnect();
+        if (this.participant.role !== Role.Judge || reconnectionAttempt > 1) {
+            this.disconnect();
+        }
 
         const logPayload = {
             conference: this.conferenceId,


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/VIH-8405


### Change description ###
prevent pexip from disconnecting until atleast one attempt has been made to connect back to eventhub


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
