### PR TITLE
Added additional condition and setting countdown complete to false on…

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
@@ -621,6 +621,7 @@ describe('WaitingRoomComponent message and clock', () => {
     it('should mute video stream when participant is not in hearing', () => {
         component.countdownComplete = false;
         component.participant.status = ParticipantStatus.Available;
+        spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.Suspended);
 
         expect(component.shouldMuteHearing()).toBe(true);
     });
@@ -628,6 +629,7 @@ describe('WaitingRoomComponent message and clock', () => {
     it('should mute video stream when participant is in hearing and countdown is not complete', () => {
         component.countdownComplete = false;
         component.participant.status = ParticipantStatus.InHearing;
+        spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.InSession);
 
         expect(component.shouldMuteHearing()).toBe(true);
     });
@@ -635,6 +637,7 @@ describe('WaitingRoomComponent message and clock', () => {
     it('should not mute video stream when participant is in hearing and countdown is complete', () => {
         component.countdownComplete = true;
         component.participant.status = ParticipantStatus.InHearing;
+        spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.InSession);
 
         expect(component.shouldMuteHearing()).toBe(false);
     });


### PR DESCRIPTION
### JIRA link (if applicable) ###
[VIH-8348](https://tools.hmcts.net/jira/browse/VIH-8348)

### Change description ###
This is a workaround where the root cause is still unidentified. Despite the video element not rendering on the browser, the telephone participant message is still playing.

**Does this PR introduce a breaking change?** (check one with "x")
We have instead updated the logic for muting the video stream so that the stream is muted when the participant is not in the hearing.

```
[ ] Yes
[x] No
```
