### PR TITLE
VIH-8405 update signalr config

### DIFF
--- a/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
+++ b/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
@@ -81,7 +81,7 @@ namespace VideoWeb.EventHub.Hub
             }
             else
             {
-                _logger.LogWarning(exception,
+                _logger.LogError(exception,
                     "There was an error when disconnecting from chat hub server-side: {Username}", userName);
             }
 

--- a/VideoWeb/VideoWeb.UnitTests/Hub/DisconnectionTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Hub/DisconnectionTests.cs
@@ -46,7 +46,7 @@ namespace VideoWeb.UnitTests.Hub
 
             LoggerMock.Verify(
                 x => x.Log(
-                    LogLevel.Warning,
+                    LogLevel.Error,
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("There was an error when disconnecting from chat hub server-side")),
                     exception,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/events-hub.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/events-hub.service.ts
@@ -33,7 +33,7 @@ export class EventsHubService implements OnDestroy {
         return this._reconnectionTimes;
     }
 
-    private _serverTimeoutTime = 300000;
+    private _serverTimeoutTime = 60000;
     get serverTimeoutTime() {
         return this._serverTimeoutTime;
     }

--- a/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
+++ b/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
@@ -146,26 +146,26 @@ namespace VideoWeb.Extensions
             };
 
             var connectionStrings = container.GetService<ConnectionStrings>();
-            services.AddSignalR(hubOptions =>
-            {
-                hubOptions.EnableDetailedErrors = true;
-                hubOptions.ClientTimeoutInterval = TimeSpan.FromMilliseconds(60000);
-                hubOptions.KeepAliveInterval = TimeSpan.FromMilliseconds(30000);
-            })
-            .AddAzureSignalR(options =>
-            {
-                options.ConnectionString = connectionStrings.SignalR;
-                options.ClaimsProvider = context => context.User.Claims;
-            })
-            .AddNewtonsoftJsonProtocol(options =>
-            {
-                options.PayloadSerializerSettings.Formatting = Formatting.None;
-                options.PayloadSerializerSettings.ContractResolver = contractResolver;
-                options.PayloadSerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
-                options.PayloadSerializerSettings.Converters.Add(
-                    new StringEnumConverter());
-            })
-            .AddHubOptions<EventHub.Hub.EventHub>(options => { options.EnableDetailedErrors = true; });
+            services.AddSignalR()
+                .AddAzureSignalR(options =>
+                {
+                    options.ConnectionString = connectionStrings.SignalR;
+                    options.ClaimsProvider = context => context.User.Claims;
+                })
+                .AddNewtonsoftJsonProtocol(options =>
+                {
+                    options.PayloadSerializerSettings.Formatting = Formatting.None;
+                    options.PayloadSerializerSettings.ContractResolver = contractResolver;
+                    options.PayloadSerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
+                    options.PayloadSerializerSettings.Converters.Add(
+                        new StringEnumConverter());
+                })
+                .AddHubOptions<EventHub.Hub.EventHub>(options => 
+                { 
+                    options.EnableDetailedErrors = true;
+                    options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(60000);
+                    options.KeepAliveInterval = TimeSpan.FromMilliseconds(30000);
+                });
 
             services.AddStackExchangeRedisCache(options => { options.Configuration = connectionStrings.RedisCache; });
             return services;

--- a/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
+++ b/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
@@ -146,21 +146,26 @@ namespace VideoWeb.Extensions
             };
 
             var connectionStrings = container.GetService<ConnectionStrings>();
-            services.AddSignalR()
-                .AddAzureSignalR(options =>
-                {
-                    options.ConnectionString = connectionStrings.SignalR;
-                    options.ClaimsProvider = context => context.User.Claims;
-                })
-                .AddNewtonsoftJsonProtocol(options =>
-                {
-                    options.PayloadSerializerSettings.Formatting = Formatting.None;
-                    options.PayloadSerializerSettings.ContractResolver = contractResolver;
-                    options.PayloadSerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
-                    options.PayloadSerializerSettings.Converters.Add(
-                        new StringEnumConverter());
-                })
-                .AddHubOptions<EventHub.Hub.EventHub>(options => { options.EnableDetailedErrors = true; });
+            services.AddSignalR(hubOptions =>
+            {
+                hubOptions.EnableDetailedErrors = true;
+                hubOptions.ClientTimeoutInterval = TimeSpan.FromMilliseconds(60000);
+                hubOptions.KeepAliveInterval = TimeSpan.FromMilliseconds(30000);
+            })
+            .AddAzureSignalR(options =>
+            {
+                options.ConnectionString = connectionStrings.SignalR;
+                options.ClaimsProvider = context => context.User.Claims;
+            })
+            .AddNewtonsoftJsonProtocol(options =>
+            {
+                options.PayloadSerializerSettings.Formatting = Formatting.None;
+                options.PayloadSerializerSettings.ContractResolver = contractResolver;
+                options.PayloadSerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
+                options.PayloadSerializerSettings.Converters.Add(
+                    new StringEnumConverter());
+            })
+            .AddHubOptions<EventHub.Hub.EventHub>(options => { options.EnableDetailedErrors = true; });
 
             services.AddStackExchangeRedisCache(options => { options.Configuration = connectionStrings.RedisCache; });
             return services;


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/VIH-8405


### Change description ###
- amending signalr configuration for the server time out. Currently its set to 5 mins, however its recommended to have the keep alive timeout set to half of what the server time out is. Also reducing the timeout to 1 minute
- Updated the log level for when an exception occurs disconnecting from eventhub

**Does this PR introduce a breaking change?** 

```
[ ] Yes
[x] No
```