### PR TITLE
VIH-8578 clean up pex rtc when disconnecting from Pexip

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -174,10 +174,13 @@ describe('VideoCallService', () => {
     });
 
     it('should disconnect from pexip when call is disconnected', () => {
+        const setupClientSpy = spyOn(service, 'setupClient');
+
         service.pexipAPI = pexipSpy;
         service.disconnectFromCall();
         expect(pexipSpy.disconnect).toHaveBeenCalled();
         expect(kinlyHeartbeatServiceSpy.stopHeartbeat).toHaveBeenCalledTimes(1);
+        expect(setupClientSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should not disconnect from pexip when api has not been initialised', () => {
@@ -414,6 +417,26 @@ describe('VideoCallService', () => {
             expect(service.pexipAPI.turn_server.url).toContain(config.kinly_turn_server);
             expect(service.pexipAPI.turn_server.username).toContain(config.kinly_turn_server_user);
             expect(service.pexipAPI.turn_server.credential).toContain(config.kinly_turn_server_credential);
+        });
+
+        it('should setup the client again when an error occurs', () => {
+            // Arrange
+            const setupClientSpy = spyOn(service, 'setupClient');
+            // Act
+            service.pexipAPI.onError('reason');
+
+            // Assert
+            expect(setupClientSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should setup the client again when a server disconnect occurs', () => {
+            // Arrange
+            const setupClientSpy = spyOn(service, 'setupClient');
+            // Act
+            service.pexipAPI.onDisconnect('reason');
+
+            // Assert
+            expect(setupClientSpy).toHaveBeenCalledTimes(1);
         });
 
         describe('set encoder', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[VIH-8578](https://tools.hmcts.net/jira/browse/VIH-8578)

### Change description ###
- As suggested by Alan (from Pexip) we have implemented a method to clean up and recreate the PexRtc instance when the server disconnects, the client disconnects or a (pexip) error is raised. This should hopefully resolve the "Invalid Token" issue. Pexip is not designed to use the same client instance when reconnecting a call the was previously closed.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
