### PR TITLE
VIH-8599 Welsh translations for SSCS types and roles

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
@@ -1003,7 +1003,12 @@
     "family-member": "Aelod o'r Teulu",
     "friend": "Ffrind",
     "joint-party": "Parti ar y Cyd",
-    "dwp-presenting-officer": "Swyddog Cyflwyno'r DWP"
+    "dwp-presenting-officer": "Swyddog Cyflwyno'r DWP",
+    "appraiser": "Gwerthuswr",
+    "disability-member-(dqm)": "Aelod Anabledd (DQM)",
+    "medical-member": "Aelod Meddygol",
+    "legal-member": "Aelod Cyfreithiol",
+    "financial-member": "Aelod Cyllidol"
   },
   "case-type-group": {
     "respondent": "Atebydd",

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
@@ -998,7 +998,12 @@
     "solicitor": "Cyfreithiwr",
     "barrister": "Bargyfreithiwr",
     "quick-link-participant": "Cyfranogwr",
-    "quick-link-observer": "Sylwedydd"
+    "quick-link-observer": "Sylwedydd",
+    "support-worker": "Gweithiwr Cymorth",
+    "family-member": "Aelod o'r Teulu",
+    "friend": "Ffrind",
+    "joint-party": "Parti ar y Cyd",
+    "dwp-presenting-officer": "Swyddog Cyflwyno'r DWP"
   },
   "case-type-group": {
     "respondent": "Atebydd",
@@ -1053,7 +1058,8 @@
     "private-law": "Cyfraith Breifat",
     "divorce": "Ysgariad",
     "adoption": "Mabwysiadu",
-    "upper-tribunal-tax": "Uwch Dribiwnlys (Treth)"
+    "upper-tribunal-tax": "Uwch Dribiwnlys (Treth)",
+    "sscs-tribunal": "Tribiwnlys SSCS"
   },
   "case-role": {
     "state": "Y Wladwriaeth",

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
@@ -693,7 +693,12 @@
     "family-member": "Family Member",
     "friend": "Friend",
     "joint-party": "Joint Party",
-    "dwp-presenting-officer": "DWP Presenting Officer"
+    "dwp-presenting-officer": "DWP Presenting Officer",
+    "appraiser": "Appraiser",
+    "disability-member-(dqm)": "Disability Member (DQM)",
+    "medical-member": "Medical Member",
+    "legal-member": "Legal Member",
+    "financial-member": "Financial Member"
   },
   "case-role": {
     "appellant": "Appellant",

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
@@ -688,7 +688,12 @@
     "intermediary": "Intermediary",
     "video-access-point": "Video access point",
     "quick-link-participant": "Participant",
-    "quick-link-observer": "Observer"
+    "quick-link-observer": "Observer",
+    "support-worker": "Support Worker",
+    "family-member": "Family Member",
+    "friend": "Friend",
+    "joint-party": "Joint Party",
+    "dwp-presenting-officer": "DWP Presenting Officer"
   },
   "case-role": {
     "appellant": "Appellant",
@@ -742,7 +747,8 @@
     "right-to-buy": "Right to buy",
     "tax": "Tax",
     "tribunal": "Tribunal",
-    "upper-tribunal-tax": "Upper Tribunal Tax"
+    "upper-tribunal-tax": "Upper Tribunal Tax",
+    "sscs-tribunal": "SSCS Tribunal"
   },
   "case-type-group": {
     "state": "State",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8599

### Change description ###
Add missing translations for SSCS types and roles:

SSCS Tribunal	- Tribiwnlys SSCS
Support Worker -Gweithiwr Cymorth
Family Member - Aelod o'r Teulu
Friend - Ffrind
Joint Party - Parti ar y Cyd
Appraiser - Gwerthuswr
Disability Member (DQM) - Aelod Anabledd (DQM)
Financial Member - Aelod Cyllidol
Legal Member - Aelod Cyfreithiol
Medical Member - Aelod Meddygol
DWP Presenting Officer - Swyddog Cyflwyno'r DWP

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
