### PR TITLE
VIH-8706 Reset remote mute in local store when host joins paused hearing

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -203,7 +203,6 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
                             participantId: participantId
                         });
 
-                        this.videoControlCacheService.setRemoteMutedStatus(participantId, false);
                         this.participantRemoteMuteStoreService.updateLocalMuteStatus(participantId, audio, video);
                     });
             });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -246,10 +246,10 @@ describe('ParticipantsPanelComponent', () => {
     });
 
     const conferenceStatusStatuses = [
-        { status: ConferenceStatus.NotStarted},
-        { status: ConferenceStatus.InSession},
-        { status: ConferenceStatus.Suspended},
-        { status: ConferenceStatus.Paused}
+        { status: ConferenceStatus.NotStarted },
+        { status: ConferenceStatus.InSession },
+        { status: ConferenceStatus.Suspended },
+        { status: ConferenceStatus.Paused }
     ];
     conferenceStatusStatuses.forEach(c => {
         it(`should reset the remote mute status of the participants in the component store for a ${c.status} hearing`, fakeAsync(() => {
@@ -262,7 +262,11 @@ describe('ParticipantsPanelComponent', () => {
 
             component.ngOnInit();
             flushMicrotasks();
-            component.participants.map(p => p.id).forEach(participantId => expect(videoControlCacheServiceSpy.setRemoteMutedStatus).toHaveBeenCalledWith(participantId, false));
+            component.participants
+                .map(p => p.id)
+                .forEach(participantId =>
+                    expect(videoControlCacheServiceSpy.setRemoteMutedStatus).toHaveBeenCalledWith(participantId, false)
+                );
         }));
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -252,7 +252,7 @@ describe('ParticipantsPanelComponent', () => {
         { status: ConferenceStatus.Paused}
     ];
     conferenceStatusStatuses.forEach(c => {
-        fit(`should reset the remote mute status of the participants in the component store for a ${c.status} hearing`, fakeAsync(() => {
+        it(`should reset the remote mute status of the participants in the component store for a ${c.status} hearing`, fakeAsync(() => {
             const response = new ConferenceResponse({ status: c.status });
             videoWebServiceSpy.getConferenceById.and.returnValue(Promise.resolve(response));
             videoWebServiceSpy.getParticipantsByConferenceId.and.returnValue(Promise.resolve(participants));

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -245,6 +245,27 @@ describe('ParticipantsPanelComponent', () => {
         component.ngOnDestroy();
     });
 
+    const conferenceStatusStatuses = [
+        { status: ConferenceStatus.NotStarted},
+        { status: ConferenceStatus.InSession},
+        { status: ConferenceStatus.Suspended},
+        { status: ConferenceStatus.Paused}
+    ];
+    conferenceStatusStatuses.forEach(c => {
+        fit(`should reset the remote mute status of the participants in the component store for a ${c.status} hearing`, fakeAsync(() => {
+            const response = new ConferenceResponse({ status: c.status });
+            videoWebServiceSpy.getConferenceById.and.returnValue(Promise.resolve(response));
+            videoWebServiceSpy.getParticipantsByConferenceId.and.returnValue(Promise.resolve(participants));
+            videoWebServiceSpy.getEndpointsForConference.and.returnValue(Promise.resolve(endpoints));
+            const mappedParticipants = mapper.mapFromParticipantUserResponseArray(participants);
+            participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedParticipants);
+
+            component.ngOnInit();
+            flushMicrotasks();
+            component.participants.map(p => p.id).forEach(participantId => expect(videoControlCacheServiceSpy.setRemoteMutedStatus).toHaveBeenCalledWith(participantId, false));
+        }));
+    });
+
     it('should get participant sorted list, the judge is first, then panel members and finally observers are the last one', fakeAsync(() => {
         const response = new ConferenceResponse({ status: ConferenceStatus.NotStarted });
         videoWebServiceSpy.getConferenceById.and.returnValue(Promise.resolve(response));

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -71,6 +71,8 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         this.conferenceId = this.route.snapshot.paramMap.get('conferenceId');
 
         this.getParticipantsList().then(() => {
+            this.participants.map(p => p.id)
+                .forEach(participantId => this.videoControlCacheService.setRemoteMutedStatus(participantId, false));
             this.participantRemoteMuteStoreService.conferenceParticipantsStatus$.pipe(take(1)).subscribe(state => {
                 this.participants.forEach(participant => {
                     if (state.hasOwnProperty(participant.id)) {
@@ -700,9 +702,9 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     private showCaseRole(participant: PanelModel) {
         return participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.NONE.toLowerCase() ||
-            participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.OBSERVER.toLowerCase() ||
-            participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
-            participant.caseTypeGroup.toLowerCase() === 'endpoint'
+        participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.OBSERVER.toLowerCase() ||
+        participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
+        participant.caseTypeGroup.toLowerCase() === 'endpoint'
             ? false
             : true;
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -71,7 +71,8 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         this.conferenceId = this.route.snapshot.paramMap.get('conferenceId');
 
         this.getParticipantsList().then(() => {
-            this.participants.map(p => p.id)
+            this.participants
+                .map(p => p.id)
                 .forEach(participantId => this.videoControlCacheService.setRemoteMutedStatus(participantId, false));
             this.participantRemoteMuteStoreService.conferenceParticipantsStatus$.pipe(take(1)).subscribe(state => {
                 this.participants.forEach(participant => {
@@ -702,9 +703,9 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     private showCaseRole(participant: PanelModel) {
         return participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.NONE.toLowerCase() ||
-        participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.OBSERVER.toLowerCase() ||
-        participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
-        participant.caseTypeGroup.toLowerCase() === 'endpoint'
+            participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.OBSERVER.toLowerCase() ||
+            participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
+            participant.caseTypeGroup.toLowerCase() === 'endpoint'
             ? false
             : true;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-8706

### Change description ###

- Reset remote mute in local store when host joins paused hearing when other host started the hearing.
- Resetting the remote mute status in the component store when the participant panel loans instead of reloading the waiting room.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
