### PR TITLE
VIH-8707 Don't play video if parent element has been destroyed

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/force-play-video.directive.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/force-play-video.directive.spec.ts
@@ -17,7 +17,7 @@ describe('ForcePlayVideoDirective', () => {
 
     beforeEach(() => {
         elementRefSpy = jasmine.createSpyObj<ElementRef>([], ['nativeElement']);
-        nativeElementSpy = jasmine.createSpyObj<HTMLVideoElement>(['play'], ['oncanplay']);
+        nativeElementSpy = jasmine.createSpyObj<HTMLVideoElement>(['play', 'pause'], ['oncanplay']);
 
         getSpiedPropertyGetter(elementRefSpy, 'nativeElement').and.returnValue(nativeElementSpy);
         getSpiedPropertySetter(nativeElementSpy, 'oncanplay').and.callFake((callback: (event: any) => void) => {
@@ -79,6 +79,18 @@ describe('ForcePlayVideoDirective', () => {
 
             // Assert
             expect(nativeElementSpy.play).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not try to play after destroyed', () => {
+            // Arrange
+            directive.ngOnInit();
+            directive.ngOnDestroy();
+
+            // Act
+            onCanPlayCallback(null);
+
+            // Assert
+            expect(nativeElementSpy.play).not.toHaveBeenCalled();
         });
     });
 
@@ -163,7 +175,7 @@ describe('ForcePlayVideoDirective', () => {
     });
 
     describe('ngOnDestroy', () => {
-        it('should unsubscribe from the event listeners', () => {
+        it('should unsubscribe from the event listeners and pause video', () => {
             // Arrange
             let touchStartCallback: (event: any) => void;
             let unsubscribedFromMouseDown = false;
@@ -198,6 +210,7 @@ describe('ForcePlayVideoDirective', () => {
             // Assert
             expect(unsubscribedFromMouseDown).toBeTrue();
             expect(unsubscribedFromTouchStart).toBeTrue();
+            expect(nativeElementSpy.pause).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/force-play-video.directive.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/force-play-video.directive.ts
@@ -10,6 +10,8 @@ export class ForcePlayVideoDirective implements OnInit, OnDestroy {
     private unsubscribeFromMouseDownCallback: () => void | null = null;
     private unsubscribeFromTouchStartCallback: () => void | null = null;
 
+    private destroyed = false;
+
     public get videoElement(): HTMLVideoElement {
         return this.elementRef.nativeElement as HTMLVideoElement;
     }
@@ -36,8 +38,12 @@ export class ForcePlayVideoDirective implements OnInit, OnDestroy {
         this.unsubscribeFromTouchStartCallback = this.renderer.listen('window', 'touchstart', this.onMouseDownOrTouchStart.bind(this));
 
         this.videoElement.oncanplay = event => {
-            this.logger.info(`${this.loggerPrefix} - videoElement.oncanplay - playing video`);
-            this.videoElement.play();
+            this.logger.info(`${this.loggerPrefix} - videoElement.oncanplay - event triggered`);
+
+            if (!this.destroyed) {
+                this.logger.info(`${this.loggerPrefix} - videoElement.oncanplay - playing video`);
+                this.videoElement.play();
+            }
         };
     }
 
@@ -67,5 +73,7 @@ export class ForcePlayVideoDirective implements OnInit, OnDestroy {
             this.unsubscribeFromTouchStartCallback();
             this.unsubscribeFromTouchStartCallback = null;
         }
+        this.videoElement.pause();
+        this.destroyed = true;
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.html
@@ -44,7 +44,7 @@
   <div class="video-wrapper">
     <video
       appForcePlayVideo
-      [muted]="shouldMuteHearing()"
+      [muted]="shouldMuteHearing"
       id="incomingFeedPrivate"
       [srcObject]="presentationStream && !streamInMain ? presentationStream : callStream"
       height="auto"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.html
@@ -65,7 +65,7 @@
           <video
             appForcePlayVideo
             id="incomingFeedJudgePrivate"
-            [muted]="shouldMuteHearing()"
+            [muted]="shouldMuteHearing"
             [srcObject]="presentationStream && !streamInMain ? presentationStream : callStream"
             height="auto"
             class="incomingFeedPrivate"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.html
@@ -61,7 +61,7 @@
     <video
       appForcePlayVideo
       id="incomingFeedPrivate"
-      [muted]="shouldMuteHearing()"
+      [muted]="shouldMuteHearing"
       [srcObject]="presentationStream && !streamInMain ? presentationStream : callStream"
       poster="/assets/images/empty_crest.jpg"
     >

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.non-event.spec.ts
@@ -683,7 +683,7 @@ describe('WaitingRoomComponent message and clock', () => {
         component.participant.status = ParticipantStatus.Available;
         spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.Suspended);
 
-        expect(component.shouldMuteHearing()).toBe(true);
+        expect(component.shouldMuteHearing).toBe(true);
     });
 
     it('should mute video stream when participant is in hearing but the hearing status is not in session', () => {
@@ -691,7 +691,7 @@ describe('WaitingRoomComponent message and clock', () => {
         component.participant.status = ParticipantStatus.InHearing;
         spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.Suspended);
 
-        expect(component.shouldMuteHearing()).toBe(true);
+        expect(component.shouldMuteHearing).toBe(true);
     });
 
     it('should mute video stream when participant is not in hearing', () => {
@@ -699,7 +699,7 @@ describe('WaitingRoomComponent message and clock', () => {
         component.participant.status = ParticipantStatus.Available;
         spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.Suspended);
 
-        expect(component.shouldMuteHearing()).toBe(true);
+        expect(component.shouldMuteHearing).toBe(true);
     });
 
     it('should mute video stream when participant is in hearing and countdown is not complete', () => {
@@ -707,7 +707,7 @@ describe('WaitingRoomComponent message and clock', () => {
         component.participant.status = ParticipantStatus.InHearing;
         spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.InSession);
 
-        expect(component.shouldMuteHearing()).toBe(true);
+        expect(component.shouldMuteHearing).toBe(true);
     });
 
     it('should not mute video stream when participant is in hearing and countdown is complete', () => {
@@ -715,7 +715,7 @@ describe('WaitingRoomComponent message and clock', () => {
         component.participant.status = ParticipantStatus.InHearing;
         spyOnProperty(component.hearing, 'status', 'get').and.returnValue(ConferenceStatus.InSession);
 
-        expect(component.shouldMuteHearing()).toBe(false);
+        expect(component.shouldMuteHearing).toBe(false);
     });
 
     it('should return false if case name has not been truncated', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -923,7 +923,7 @@ export abstract class WaitingRoomBaseDirective {
         this.videoCallService.stopScreenShare();
     }
 
-    shouldMuteHearing(): boolean {
+    get shouldMuteHearing(): boolean {
         return !(
             (this.countdownComplete &&
                 this.participant.status === ParticipantStatus.InHearing &&


### PR DESCRIPTION
### JIRA link (if applicable) ###
VIH-8707 


### Change description ###
Adding destroyed property to force play directive that prevents calling play on the element after ngOnDestroy has already been called.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
