### PR TITLE
VIH-8745 Endpoint is displayed before witness in JOH consultation

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
@@ -89,7 +89,7 @@
             </div>
         </ng-container>
         <ng-container *ngIf="isJohConsultation()">
-            <ng-container *ngFor="let participant of getWitnessesAndObservers(); trackBy: trackParticipant">
+            <ng-container *ngFor="let participant of getObservers(); trackBy: trackParticipant">
                 <div class="member-group">
                     <app-participant-item 
                                     [participant]="participant" 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -379,6 +379,20 @@ describe('PrivateConsultationParticipantsComponent', () => {
         expect(component.getPrivateConsultationParticipants().length).toBe(1);
     });
 
+    it('should sort quick link participants', () => {
+        const testData = new ConferenceTestData();
+        component.conference.participants = [testData.quickLinkParticipant2, testData.quickLinkParticipant1];
+        component.initParticipants();
+        const participants = component.getPrivateConsultationParticipants();
+
+        expect(participants.length).toBe(2);
+        expect(participants.find(x => x.display_name === testData.quickLinkParticipant1.display_name)).toBeTruthy();
+        expect(participants.find(x => x.display_name === testData.quickLinkParticipant2.display_name)).toBeTruthy();
+        expect(participants.findIndex(x => x.display_name === testData.quickLinkParticipant1.display_name)).toBeLessThan(
+            participants.findIndex(x => x.display_name === testData.quickLinkParticipant2.display_name)
+        );
+    });
+
     it('should return can call endpoint', () => {
         // Not in current room
         component.roomLabel = 'test-room';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -679,7 +679,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
 
         it('should return nothing if is not joh consultation', () => {
             spyOn(component, 'isJohConsultation').and.returnValue(false);
-            const result = component.getWitnessesAndObservers();
+            const result = component.getObservers();
             expect(result).toEqual([]);
         });
 
@@ -691,7 +691,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
             const mappedQuickLinkObserver2: ParticipantListItem = { ...quickLinkObserver2 };
 
             spyOn(component, 'isJohConsultation').and.returnValue(true);
-            const result = component.getWitnessesAndObservers();
+            const result = component.getObservers();
             const witnessesOrdered = [mappedWitness1, mappedWitness2].sort((a, b) => a.display_name.localeCompare(b.display_name));
 
             const observersOrdered = [mappedRegularObserver, mappedQuickLinkObserver1, mappedQuickLinkObserver2].sort((a, b) =>

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -370,15 +370,6 @@ describe('PrivateConsultationParticipantsComponent', () => {
         expect(result).toBeFalse();
     });
 
-    it('should not get witnesses', () => {
-        const participants = new ConferenceTestData().getListOfParticipants();
-        const witness = participants[0];
-        witness.hearing_role = HearingRole.WITNESS;
-        const representative = participants[1];
-        component.nonJudgeParticipants = [witness, representative];
-        expect(component.getPrivateConsultationParticipants().length).toBe(1);
-    });
-
     it('should not get interpreter', () => {
         const participants = new ConferenceTestData().getListOfParticipants();
         const interpreter = participants[0];
@@ -386,19 +377,6 @@ describe('PrivateConsultationParticipantsComponent', () => {
         const representative = participants[1];
         component.nonJudgeParticipants = [interpreter, representative];
         expect(component.getPrivateConsultationParticipants().length).toBe(1);
-    });
-
-    it('should sort quick link participants', () => {
-        const testData = new ConferenceTestData();
-        component.nonJudgeParticipants = [testData.quickLinkParticipant2, testData.quickLinkParticipant1];
-        const participants = component.getPrivateConsultationParticipants();
-
-        expect(participants.length).toBe(2);
-        expect(participants.find(x => x.display_name === testData.quickLinkParticipant1.display_name)).toBeTruthy();
-        expect(participants.find(x => x.display_name === testData.quickLinkParticipant2.display_name)).toBeTruthy();
-        expect(participants.findIndex(x => x.display_name === testData.quickLinkParticipant1.display_name)).toBeLessThan(
-            participants.findIndex(x => x.display_name === testData.quickLinkParticipant2.display_name)
-        );
     });
 
     it('should return can call endpoint', () => {
@@ -596,7 +574,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
         }));
     });
 
-    describe('getWitnessesAndObservers', () => {
+    describe('getObservers', () => {
         const litigantInPerson = new ParticipantResponse({
             id: 'litigantInPerson_id',
             status: ParticipantStatus.Available,
@@ -684,23 +662,18 @@ describe('PrivateConsultationParticipantsComponent', () => {
         });
 
         it('should return list in correct order for joh consultation', () => {
-            const mappedWitness1: ParticipantListItem = { ...witness1 };
-            const mappedWitness2: ParticipantListItem = { ...witness2 };
             const mappedRegularObserver: ParticipantListItem = { ...regularObserver };
             const mappedQuickLinkObserver1: ParticipantListItem = { ...quickLinkObserver1 };
             const mappedQuickLinkObserver2: ParticipantListItem = { ...quickLinkObserver2 };
 
             spyOn(component, 'isJohConsultation').and.returnValue(true);
             const result = component.getObservers();
-            const witnessesOrdered = [mappedWitness1, mappedWitness2].sort((a, b) => a.display_name.localeCompare(b.display_name));
 
             const observersOrdered = [mappedRegularObserver, mappedQuickLinkObserver1, mappedQuickLinkObserver2].sort((a, b) =>
                 a.display_name.localeCompare(b.display_name)
             );
 
-            expect(result.length).toBe(witnessesOrdered.length + observersOrdered.length);
-            expect(result.slice(0, witnessesOrdered.length)).toEqual(witnessesOrdered);
-            expect(result.slice(witnessesOrdered.length)).toEqual(observersOrdered);
+            expect(result.length).toBe(observersOrdered.length);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -116,9 +116,10 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
     }
 
     getPrivateConsultationParticipants(): ParticipantListItem[] {
-        return this.sortAndMapToListItem(
-            this.nonJudgeParticipants.filter(x => x.hearing_role !== HearingRole.WITNESS && x.hearing_role !== HearingRole.INTERPRETER)
-        );
+        const participants = this.nonJudgeParticipants.filter(x => x.hearing_role !== HearingRole.INTERPRETER);
+        return participants.map(c => {
+            return this.mapResponseToListItem(c);
+        });
     }
 
     setJohGroupResult(): void {
@@ -135,15 +136,12 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
         this.setJohGroupResult();
     }
 
-    getWitnessesAndObservers(): ParticipantListItem[] {
+    getObservers(): ParticipantListItem[] {
         if (!this.isJohConsultation()) {
             return [];
         }
-        const witnesses = this.sortAndMapToListItem(
-            this.nonJudgeParticipants.filter(participant => participant.hearing_role === HearingRole.WITNESS)
-        );
         const observers = this.sortAndMapToListItem(this.observers);
-        return [...witnesses, ...observers];
+        return [...observers];
     }
 
     getParticipantStatus(participant: any): string {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8745

### Change description ###
Fixes an issue where the endpoint participants are displayed before witnesses in the JOH consultation.
Also updates the ordering of the participants in the JOH consultation to match those in the waiting room.
This involves splitting up of witnesses and observers, so that observers can be displayed at the bottom.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
