### PR TITLE
VIH-8756 - Hand raised status persisted when QL/Witness is dismissed

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/linked-participant-panel-model.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/linked-participant-panel-model.spec.ts
@@ -35,14 +35,6 @@ describe('LinkedParticipantPanelModel', () => {
         expect(updatedParticipant.isLocalCameraOff()).toBeTruthy();
     });
 
-    it('should dismiss all participants', () => {
-        createLinkedModel();
-        model.participants.forEach(p => p.updateParticipant(false, true, true));
-        model.dimissed();
-        expect(model.hasHandRaised()).toBeFalsy();
-        expect(model.hasSpotlight()).toBeFalsy();
-    });
-
     it('should return isInHearing: true when at least one participant is in hearing', () => {
         createLinkedModel();
         model.participants[0].updateStatus(ParticipantStatus.InHearing);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/linked-participant-panel-model.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/linked-participant-panel-model.ts
@@ -151,8 +151,4 @@ export class LinkedParticipantPanelModel extends PanelModel {
             this.handRaised = handRaised;
         }
     }
-
-    dimissed() {
-        this.participants.forEach(p => p.dimissed());
-    }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
@@ -120,11 +120,6 @@ export abstract class PanelModel {
         this._transferringIn = isTransferringIn;
     }
 
-    dimissed() {
-        this.handRaised = false;
-        this.isSpotlighted = false;
-    }
-
     assignPexipId(pexipId: string) {
         this.pexipId = pexipId ?? this.pexipId;
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -663,6 +663,51 @@ describe('ParticipantsPanelComponent', () => {
             await component.dismissParticipantFromHearing(pat);
             expect(videocallService.dismissParticipantFromHearing).toHaveBeenCalledTimes(0);
         });
+
+        it('should lower hand when hand raised for a participant when dismissed from a hearing', async () => {
+            videocallService.dismissParticipantFromHearing.calls.reset();
+            const pat = component.participants.find(p => p.isWitness);
+            const hasHandRaised = true;
+            pat.updateParticipant(pat.isMicRemoteMuted(), hasHandRaised, pat.hasSpotlight(), pat.id, pat.isLocalMicMuted());
+            spyOnProperty(pat, 'isCallableAndReadyToBeDismissed').and.returnValue(true);
+            await component.dismissParticipantFromHearing(pat);
+            expect(videocallService.lowerHandById).toHaveBeenCalledWith(pat.pexipId, component.conferenceId, pat.id);
+            expect(videocallService.dismissParticipantFromHearing).toHaveBeenCalledWith(component.conferenceId, pat.id);
+        });
+
+        it('should not lower hand when hand not raised for a participant when dismissed from a hearing', async () => {
+            videocallService.dismissParticipantFromHearing.calls.reset();
+            videocallService.lowerHandById.calls.reset();
+            const pat = component.participants.find(p => p.isWitness);
+            const hasHandRaised = false;
+            pat.updateParticipant(pat.isMicRemoteMuted(), hasHandRaised, pat.hasSpotlight(), pat.id, pat.isLocalMicMuted());
+            spyOnProperty(pat, 'isCallableAndReadyToBeDismissed').and.returnValue(true);
+            await component.dismissParticipantFromHearing(pat);
+            expect(videocallService.lowerHandById).toHaveBeenCalledTimes(0);
+            expect(videocallService.dismissParticipantFromHearing).toHaveBeenCalledWith(component.conferenceId, pat.id);
+        });
+
+        it('should remove from spotlight when in spotlight for a participant when dismissed from a hearing', async () => {
+            videocallService.dismissParticipantFromHearing.calls.reset();
+            const pat = component.participants.find(p => p.isWitness);
+            const hasSpotlight = true;
+            pat.updateParticipant(pat.isMicRemoteMuted(), pat.hasHandRaised(), hasSpotlight, pat.id, pat.isLocalMicMuted());
+            spyOnProperty(pat, 'isCallableAndReadyToBeDismissed').and.returnValue(true);
+            await component.dismissParticipantFromHearing(pat);
+            expect(videoControlServiceSpy.setSpotlightStatusById).toHaveBeenCalledWith(pat.id, pat.pexipId, !hasSpotlight);
+            expect(videocallService.dismissParticipantFromHearing).toHaveBeenCalledWith(component.conferenceId, pat.id);
+        });
+
+        it('should not remove from spotlight when not in spotlight for a participant when dismissed from a hearing', async () => {
+            videocallService.dismissParticipantFromHearing.calls.reset();
+            const pat = component.participants.find(p => p.isWitness);
+            const hasSpotlight = false;
+            pat.updateParticipant(pat.isMicRemoteMuted(), pat.hasHandRaised(), hasSpotlight, pat.id, pat.isLocalMicMuted());
+            spyOnProperty(pat, 'isCallableAndReadyToBeDismissed').and.returnValue(true);
+            await component.dismissParticipantFromHearing(pat);
+            expect(videoControlServiceSpy.setSpotlightStatusById).toHaveBeenCalledTimes(0);
+            expect(videocallService.dismissParticipantFromHearing).toHaveBeenCalledWith(component.conferenceId, pat.id);
+        });
     });
 
     it('should update conference mute all true', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -597,7 +597,12 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
             participant: participant.id
         });
 
-        participant.dimissed();
+        if (participant.hasHandRaised()) {
+            this.lowerParticipantHand(participant);
+        }
+        if (participant.hasSpotlight()) {
+            this.toggleSpotlightParticipant(participant);
+        }
 
         try {
             let participantId = participant.id;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8756


### Change description ###
Fixes an issue where if a participant is dismissed from a hearing with their hand raised, the hand is lowered but only visible to the host that dismissed them - the second host still sees their hand raised.

Currently the hand is lowered and spotlight removed through the dismissed() function, which sets the handRaised and isSpotlighted properties to false. These are only applied to the person doing the dismissal.

To fix the issue, instead of setting the flags, we lower the hand and remove from spotlight using the pexip API calls. This streams an event to all observers and also ensures that the hand raised and spotlighted states are persisted if the participant is to re-join after being dismissed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
