### PR TITLE
VIH-8702 Fix for handraised icon not persisting for the 2nd host joining the hearing

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.spec.ts
@@ -82,6 +82,24 @@ describe('VideoControlCacheService', () => {
         }));
     });
 
+    describe('initHearingControlState', () => {
+        it('should load the hearing state for the current conference', fakeAsync(() => {
+            // Arrange
+            const conferenceId = 'conference-id';
+            const conference = { id: conferenceId } as ConferenceResponse;
+
+            const hearingControlsState: IHearingControlsState = { participantStates: {} };
+            // Act
+            currentConferenceSubject.next(conference);
+            flush();
+            service.initHearingControlState();
+
+            // Assert
+            expect(videoControlCacheStorageServiceSpy.loadHearingStateForConference).toHaveBeenCalledOnceWith(conferenceId);
+            expect(service['hearingControlStates']).toEqual(hearingControlsState);
+        }));
+    });
+
     describe('setSpotlightStatus', () => {
         it('should add new value in the hearingControlStates and should update the cache', () => {
             // Arrange

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
@@ -13,11 +13,7 @@ export class VideoControlCacheService {
 
     private hearingControlStates: IHearingControlsState | null = { participantStates: {} };
 
-    constructor(
-        private conferenceService: ConferenceService,
-        private storageService: DistributedVideoControlCacheService,
-        private logger: LoggerService
-    ) {
+    initHearingControlState(){
         this.conferenceService.currentConference$.subscribe(conference => {
             if (!conference) {
                 this.logger.warn(`${this.loggerPrefix} No conference loaded. Skipping loading of hearing state for conference`);
@@ -34,6 +30,14 @@ export class VideoControlCacheService {
                     });
                 });
         });
+    }
+
+    constructor(
+        private conferenceService: ConferenceService,
+        private storageService: DistributedVideoControlCacheService,
+        private logger: LoggerService
+    ) {
+        this.initHearingControlState();
     }
 
     setSpotlightStatus(participantId: string, spotlightValue: boolean, syncChanges: boolean = true) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
@@ -13,7 +13,7 @@ export class VideoControlCacheService {
 
     private hearingControlStates: IHearingControlsState | null = { participantStates: {} };
 
-    initHearingControlState(){
+    initHearingControlState() {
         this.conferenceService.currentConference$.subscribe(conference => {
             if (!conference) {
                 this.logger.warn(`${this.loggerPrefix} No conference loaded. Skipping loading of hearing state for conference`);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -148,7 +148,8 @@ describe('ParticipantsPanelComponent', () => {
             'setHandRaiseStatus',
             'getHandRaiseStatus',
             'setRemoteMutedStatus',
-            'getRemoteMutedStatus'
+            'getRemoteMutedStatus',
+            'initHearingControlState'
         ]);
         remoteMuteServiceSpy = createParticipantRemoteMuteStoreServiceSpy();
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -69,7 +69,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.conferenceId = this.route.snapshot.paramMap.get('conferenceId');
-
+        this.videoControlCacheService.initHearingControlState();
         this.getParticipantsList().then(() => {
             this.participants
                 .map(p => p.id)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8702

### Change description ###
Moved the VideoControlCacheService constructor logic inside of a function 'initHearingControlState' which can be re-invoked on the participant-panel ngOnInit; this will force the hearingControlStates object to be set to the latest cache value upon entering the hearing


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
