### PR TITLE
VIH-8720 witness interpreter vmr incorrect mic status

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -352,7 +352,7 @@ describe('ParticipantsPanelComponent', () => {
             // Act
             component.readVideoControlStatusesFromCache(state, linkedParticipant);
             // Assert
-            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalled();
+            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalledWith(linkedParticipant.participants[0].id);
             expect(videoControlCacheServiceSpy.getLocalVideoMuted).toHaveBeenCalled();
             expect(videoControlCacheServiceSpy.getRemoteMutedStatus).toHaveBeenCalled();
             expect(videoControlCacheServiceSpy.getHandRaiseStatus).toHaveBeenCalled();
@@ -387,7 +387,7 @@ describe('ParticipantsPanelComponent', () => {
             // Act
             component.readVideoControlStatusesFromCache(state, participant);
             // Assert
-            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalled();
+            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalledWith(participant.id);
             expect(videoControlCacheServiceSpy.getLocalVideoMuted).toHaveBeenCalled();
             expect(videoControlCacheServiceSpy.getRemoteMutedStatus).toHaveBeenCalled();
             expect(videoControlCacheServiceSpy.getHandRaiseStatus).toHaveBeenCalled();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -622,6 +622,18 @@ describe('ParticipantsPanelComponent', () => {
             tick(10000);
             expect(videoCallServiceSpy.callParticipantIntoHearing).toHaveBeenCalledWith(component.conferenceId, pat.witnessParticipant.id);
         }));
+
+        it('should update local mute status to true prior to calling participant into a hearing', fakeAsync(async () => {
+            const pat = component.participants.find(
+                p => p instanceof LinkedParticipantPanelModel && p.isWitness
+            ) as LinkedParticipantPanelModel;
+            const isLocalVideoMuted = true;
+            pat.participants.forEach(linkedParticipant => {
+                component.updateLocalAudioMutedForWitnessInterpreterVmr(linkedParticipant, pat.id, isLocalVideoMuted);
+                pat.updateParticipant(false, false, false, pat.id, isLocalVideoMuted, false);
+                expect(remoteMuteServiceSpy.updateLocalMuteStatus).toHaveBeenCalledWith(linkedParticipant.id, isLocalVideoMuted, null);
+            });
+        }));
     });
 
     describe('dismiss', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -134,13 +134,14 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     readVideoControlStatusesFromCache(state: IConferenceParticipantsStatus, participant: PanelModel) {
         if (this.isCountdownCompleted) {
-            const localAudioMuted = this.videoControlCacheService.getLocalAudioMuted(participant.id);
             const localVideoMuted = this.videoControlCacheService.getLocalVideoMuted(participant.id);
             const remoteMutedStatus = this.videoControlCacheService.getRemoteMutedStatus(participant.id);
             const handRaise = this.videoControlCacheService.getHandRaiseStatus(participant.id);
+            let localAudioMuted: boolean;
 
             if (participant instanceof LinkedParticipantPanelModel) {
                 participant.participants.forEach(async linkedParticipant => {
+                    localAudioMuted = this.videoControlCacheService.getLocalAudioMuted(linkedParticipant.id);
                     this.logger.info(`${this.loggerPrefix} Updating store with audio and video from cache lp`, {
                         audio: localAudioMuted,
                         video: localVideoMuted,
@@ -161,6 +162,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     );
                 });
             } else {
+                localAudioMuted = this.videoControlCacheService.getLocalAudioMuted(participant.id);
                 this.participantRemoteMuteStoreService.updateRemoteMuteStatus(participant.id, remoteMutedStatus);
                 this.participantRemoteMuteStoreService.updateLocalMuteStatus(participant.id, localAudioMuted, localVideoMuted);
                 participant.updateParticipant(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8720


### Change description ###
This addresses an issue when a judge calls the witness and interpreter into a hearing. A staff member then joins the hearing. The vmr unmutes locally. The judge then leaves the hearing. The vmr then mutes locally again. When the judge re-joins the hearing the vmr should be muted.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
