### PR TITLE
VIH-8763 Participants are not sorted by hierarchy in WR, consultation and hearing

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/mappers/participant-panel-model-mapper.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/mappers/participant-panel-model-mapper.spec.ts
@@ -86,7 +86,7 @@ describe('ParticipantPanelModelMapper', () => {
 
     it('should order johs by hearing role then display name', () => {
         // arrange
-        let participants: ParticipantForUserResponse[] = [];
+        const participants: ParticipantForUserResponse[] = [];
 
         participants.push(
             new ParticipantForUserResponse({

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/mappers/participant-panel-model-mapper.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/mappers/participant-panel-model-mapper.spec.ts
@@ -1,8 +1,9 @@
-import { Role } from 'src/app/services/clients/api-client';
+import { ParticipantForUserResponse, Role } from 'src/app/services/clients/api-client';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { LinkedParticipantPanelModel } from 'src/app/waiting-space/models/linked-participant-panel-model';
 import { ParticipantPanelModelMapper } from './participant-panel-model-mapper';
 import { HearingRole } from 'src/app/waiting-space/models/hearing-role-model';
+import { CaseTypeGroup } from 'src/app/waiting-space/models/case-type-group';
 
 describe('ParticipantPanelModelMapper', () => {
     let mapper: ParticipantPanelModelMapper;
@@ -81,5 +82,58 @@ describe('ParticipantPanelModelMapper', () => {
         });
 
         expect(linked.length).toBe(2); // two linked
+    });
+
+    it('should order johs by hearing role then display name', () => {
+        // arrange
+        let participants: ParticipantForUserResponse[] = [];
+
+        participants.push(
+            new ParticipantForUserResponse({
+                case_type_group: CaseTypeGroup.PANEL_MEMBER,
+                display_name: 'D',
+                hearing_role: HearingRole.PANEL_MEMBER,
+                role: Role.JudicialOfficeHolder
+            })
+        );
+
+        participants.push(
+            new ParticipantForUserResponse({
+                case_type_group: CaseTypeGroup.PANEL_MEMBER,
+                display_name: 'A',
+                hearing_role: HearingRole.PANEL_MEMBER,
+                role: Role.JudicialOfficeHolder
+            })
+        );
+
+        participants.push(
+            new ParticipantForUserResponse({
+                case_type_group: CaseTypeGroup.NONE,
+                display_name: 'C',
+                hearing_role: HearingRole.WINGER,
+                role: Role.JudicialOfficeHolder
+            })
+        );
+
+        participants.push(
+            new ParticipantForUserResponse({
+                case_type_group: CaseTypeGroup.PANEL_MEMBER,
+                display_name: 'B',
+                hearing_role: HearingRole.PANEL_MEMBER,
+                role: Role.JudicialOfficeHolder
+            })
+        );
+
+        // act
+        const result = mapper.mapFromParticipantUserResponseArray(participants);
+
+        // assert
+        const linked = result.filter(p => p instanceof LinkedParticipantPanelModel)[0] as LinkedParticipantPanelModel;
+
+        expect(linked.participants[0].displayName).toBe('A');
+        expect(linked.participants[1].displayName).toBe('B');
+        expect(linked.participants[2].displayName).toBe('D');
+        expect(linked.participants[3].displayName).toBe('C');
+        expect(linked.displayName).toBe('A, B, D, C');
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/mappers/participant-panel-model-mapper.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/mappers/participant-panel-model-mapper.ts
@@ -74,7 +74,10 @@ export class ParticipantPanelModelMapper {
     }
 
     private mapJohs(pats: ParticipantForUserResponse[]): ParticipantPanelModel[] {
-        const johs = pats.filter(x => x.role === Role.JudicialOfficeHolder);
+        const johs = pats
+            .filter(x => x.role === Role.JudicialOfficeHolder)
+            .sort((a, b) => a.hearing_role.localeCompare(b.hearing_role) || a.display_name.localeCompare(b.display_name));
+
         return johs.map(j => this.mapFromParticipantUserResponse(j));
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -1013,9 +1013,9 @@ export class ConferenceTestData {
         participants.push(participant1);
         participants.push(participant2);
         participants.push(participant3);
-        participants.push(participant4);
         participants.push(participant5);
         participants.push(participant6);
+        participants.push(participant4);
         participants.push(participant7);
         participants.push(participant8);
         participants.push(participant9);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -816,7 +816,7 @@ export class ConferenceTestData {
         return endpoints;
     }
 
-    getFullListOfParticipants(): ParticipantResponse[] {
+    getFullListOfNonJudgeParticipants(): ParticipantResponse[] {
         const participants: ParticipantResponse[] = [];
         const participant1 = new ParticipantResponse({
             case_type_group: null,
@@ -855,19 +855,19 @@ export class ConferenceTestData {
         const participant3 = new ParticipantResponse({
             case_type_group: null,
             current_room: undefined,
-            display_name: 'Oliver Scott StaffMember',
-            first_name: 'Oliver',
+            display_name: 'A StaffMember',
+            first_name: 'A',
             hearing_role: 'Staff Member',
             id: '68f35208-e991-48c5-a61e-9c8b542a3bb0',
             interpreter_room: undefined,
             last_name: 'StaffMember',
             linked_participants: [],
-            name: 'Oliver Scott StaffMember',
+            name: 'A StaffMember',
             representee: null,
             role: Role.StaffMember,
             status: ParticipantStatus.Disconnected,
-            tiled_display_name: 'CLERK;HEARTBEAT;Oliver Scott StaffMember;68f35208-e991-48c5-a61e-9c8b542a3bb0',
-            user_name: 'oliver.scott.staffmember@hearings.reform.hmcts.net'
+            tiled_display_name: 'CLERK;HEARTBEAT;A StaffMember;68f35208-e991-48c5-a61e-9c8b542a3bb0',
+            user_name: 'a.staffmember@hearings.reform.hmcts.net'
         });
 
         const participant4LinkedParticipants: LinkedParticipantResponse[] = [];
@@ -1020,5 +1020,271 @@ export class ConferenceTestData {
         participants.push(participant8);
         participants.push(participant9);
         return participants;
+    }
+
+    getFullListOfPanelMembers(): ParticipantResponse[] {
+        const participants: ParticipantResponse[] = [];
+        const participant1 = new ParticipantResponse({
+            case_type_group: 'PanelMember',
+            current_room: undefined,
+            display_name: 'Mr Panel Member B',
+            first_name: 'Panel',
+            hearing_role: 'Panel Member',
+            id: 'c505165b-da2a-4a53-a17e-d8f6b0c82e26',
+            interpreter_room: undefined,
+            last_name: 'Member B',
+            linked_participants: [],
+            name: 'Mr Panel Member B',
+            representee: '',
+            role: Role.JudicialOfficeHolder,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;Mr Panel Member B;c505165b-da2a-4a53-a17e-d8f6b0c82e26',
+            user_name: 'panel.memberb1@hearings.reform.hmcts.net'
+        });
+        const participant2 = new ParticipantResponse({
+            case_type_group: 'PanelMember',
+            current_room: undefined,
+            display_name: 'Mr Panel Member A',
+            first_name: 'Panel',
+            hearing_role: 'Panel Member',
+            id: 'b3de9868-3275-4e2c-9e28-fcf4d9b7898d',
+            interpreter_room: undefined,
+            last_name: 'Member A',
+            linked_participants: [],
+            name: 'Mr Panel Member A',
+            representee: '',
+            role: Role.JudicialOfficeHolder,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;Mr Panel Member A;b3de9868-3275-4e2c-9e28-fcf4d9b7898d',
+            user_name: 'panel.membera1@hearings.reform.hmcts.net'
+        });
+
+        participants.push(participant1);
+        participants.push(participant2);
+        return participants;
+    }
+
+    getFullListOfObservers(): ParticipantResponse[] {
+        const observers: ParticipantResponse[] = [];
+        const qlObserver1 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'QL Observer A',
+            first_name: null,
+            hearing_role: 'Quick link observer',
+            id: 'f565e05c-01b2-4b3a-b2d8-1d79b5d4124c',
+            interpreter_room: undefined,
+            last_name: null,
+            linked_participants: [],
+            name: 'QL Observer A',
+            representee: null,
+            role: Role.QuickLinkObserver,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'WITNESS;NO_HEARTBEAT;QL Observer A;f565e05c-01b2-4b3a-b2d8-1d79b5d4124c',
+            user_name: 'f565e05c-01b2-4b3a-b2d8-1d79b5d4124c@quick-link-participant.com'
+        });
+        const observer1 = new ParticipantResponse({
+            case_type_group: 'Observer',
+            current_room: undefined,
+            display_name: 'Mr Observer B',
+            first_name: 'Observer',
+            hearing_role: 'Observer',
+            id: '3b0ae293-1979-4d07-8a3a-b95286e5f8c0',
+            interpreter_room: undefined,
+            last_name: 'B',
+            linked_participants: [],
+            name: 'Mr Observer B',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;Mr Observer B;3b0ae293-1979-4d07-8a3a-b95286e5f8c0',
+            user_name: 'observer.b1@hearings.reform.hmcts.net'
+        });
+        const observer2 = new ParticipantResponse({
+            case_type_group: 'Observer',
+            current_room: undefined,
+            display_name: 'Mr Observer A',
+            first_name: 'Observer',
+            hearing_role: 'Observer',
+            id: '68ca1dbf-5da9-4382-bf60-8a07124be329',
+            interpreter_room: undefined,
+            last_name: 'A',
+            linked_participants: [],
+            name: 'Mr Observer A',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;Mr Observer A;68ca1dbf-5da9-4382-bf60-8a07124be329',
+            user_name: 'observer.a@hearings.reform.hmcts.net'
+        });
+        const qlObserver2 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'A QL Observer',
+            first_name: null,
+            hearing_role: 'Quick link observer',
+            id: '5f9e380b-1412-4f70-9ea4-447a5f3ae184',
+            interpreter_room: undefined,
+            last_name: null,
+            linked_participants: [],
+            name: 'A QL Observer',
+            representee: null,
+            role: Role.QuickLinkObserver,
+            status: ParticipantStatus.Joining,
+            tiled_display_name: 'WITNESS;NO_HEARTBEAT;A QL Observer;5f9e380b-1412-4f70-9ea4-447a5f3ae184',
+            user_name: '5f9e380b-1412-4f70-9ea4-447a5f3ae184@quick-link-participant.com'
+        });
+
+        observers.push(qlObserver1);
+        observers.push(observer1);
+        observers.push(observer2);
+        observers.push(qlObserver2);
+        return observers;
+    }
+
+    getFullListOfEndpoints(): VideoEndpointResponse[] {
+        const endpoints: VideoEndpointResponse[] = [];
+        const endpoint1 = new VideoEndpointResponse({
+            current_room: undefined,
+            defence_advocate_username: null,
+            display_name: 'Endpoint B',
+            id: '73a94f6c-e17d-4ce9-bb25-35d7d7192d1a',
+            is_current_user: false,
+            pexip_display_name: 'PSTN;Endpoint B;73a94f6c-e17d-4ce9-bb25-35d7d7192d1a',
+            status: EndpointStatus.NotYetJoined
+        });
+        const endpoint2 = new VideoEndpointResponse({
+            current_room: undefined,
+            defence_advocate_username: null,
+            display_name: 'Endpoint A',
+            id: '9d7b9cde-3a48-4acb-9977-34e27667604d',
+            is_current_user: false,
+            pexip_display_name: 'PSTN;Endpoint A;9d7b9cde-3a48-4acb-9977-34e27667604d',
+            status: EndpointStatus.NotYetJoined
+        });
+
+        endpoints.push(endpoint1);
+        endpoints.push(endpoint2);
+        return endpoints;
+    }
+
+    getFullListOfStaffMembers(): ParticipantResponse[] {
+        const staffMembers: ParticipantResponse[] = [];
+        const staffMember1 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'C StaffMember',
+            first_name: 'C',
+            hearing_role: 'Staff Member',
+            id: 'ef04ef31-34a5-44ce-80b0-0c7fc2b85195',
+            interpreter_room: undefined,
+            last_name: 'StaffMember',
+            linked_participants: [],
+            name: 'C StaffMember',
+            representee: null,
+            role: Role.StaffMember,
+            status: ParticipantStatus.Disconnected,
+            tiled_display_name: 'CLERK;HEARTBEAT;C StaffMember;ef04ef31-34a5-44ce-80b0-0c7fc2b85195',
+            user_name: 'c.staffmember@hearings.reform.hmcts.net'
+        });
+        const staffMember2 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'B StaffMember',
+            first_name: 'B',
+            hearing_role: 'Staff Member',
+            id: '58a8d187-7041-4a3a-b455-4d3a8570e617',
+            interpreter_room: undefined,
+            last_name: 'StaffMember',
+            linked_participants: [],
+            name: 'B StaffMember',
+            representee: null,
+            role: Role.StaffMember,
+            status: ParticipantStatus.Disconnected,
+            tiled_display_name: 'CLERK;HEARTBEAT;B StaffMember;58a8d187-7041-4a3a-b455-4d3a8570e617',
+            user_name: 'b.staffmember@hearings.reform.hmcts.net'
+        });
+        const staffMember3 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'A StaffMember',
+            first_name: 'A',
+            hearing_role: 'Staff Member',
+            id: '976cce84-218e-4bb4-9c30-f469a389a9cd',
+            interpreter_room: undefined,
+            last_name: 'StaffMember',
+            linked_participants: [],
+            name: 'A StaffMember',
+            representee: null,
+            role: Role.StaffMember,
+            status: ParticipantStatus.Disconnected,
+            tiled_display_name: 'CLERK;HEARTBEAT;A StaffMember;976cce84-218e-4bb4-9c30-f469a389a9cd',
+            user_name: 'a.staffmember@hearings.reform.hmcts.net'
+        });
+
+        staffMembers.push(staffMember1);
+        staffMembers.push(staffMember2);
+        staffMembers.push(staffMember3);
+        return staffMembers;
+    }
+
+    getFullListOfWingers(): ParticipantResponse[] {
+        const wingers: ParticipantResponse[] = [];
+        const winger1 = new ParticipantResponse({
+            case_type_group: 'None',
+            current_room: undefined,
+            display_name: 'B Winger',
+            first_name: 'B',
+            hearing_role: 'Winger',
+            id: '08584914-f944-4829-8ac7-6ed6c0870efb',
+            interpreter_room: undefined,
+            last_name: 'Winger',
+            linked_participants: [],
+            name: 'Mr B Winger',
+            representee: '',
+            role: Role.JudicialOfficeHolder,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;B Winger;08584914-f944-4829-8ac7-6ed6c0870efb',
+            user_name: 'b.winger@hearings.reform.hmcts.net'
+        });
+        const winger2 = new ParticipantResponse({
+            case_type_group: 'None',
+            current_room: undefined,
+            display_name: 'A Winger',
+            first_name: 'A',
+            hearing_role: 'Winger',
+            id: '42c7abd6-b778-4f20-94e1-8517bf30d7f2',
+            interpreter_room: undefined,
+            last_name: 'Winger',
+            linked_participants: [],
+            name: 'Mr A Winger',
+            representee: '',
+            role: Role.JudicialOfficeHolder,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;A Winger;42c7abd6-b778-4f20-94e1-8517bf30d7f2',
+            user_name: 'a.winger1@hearings.reform.hmcts.net'
+        });
+        const winger3 = new ParticipantResponse({
+            case_type_group: 'None',
+            current_room: undefined,
+            display_name: 'C Winger',
+            first_name: 'C',
+            hearing_role: 'Winger',
+            id: '6fa27d52-c94a-4d94-9dd4-f3a52f6e5f38',
+            interpreter_room: undefined,
+            last_name: 'Winger',
+            linked_participants: [],
+            name: 'Mr C Winger',
+            representee: '',
+            role: Role.JudicialOfficeHolder,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;C Winger;6fa27d52-c94a-4d94-9dd4-f3a52f6e5f38',
+            user_name: 'c.winger@hearings.reform.hmcts.net'
+        });
+
+        wingers.push(winger1);
+        wingers.push(winger2);
+        wingers.push(winger3);
+        return wingers;
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -13,6 +13,7 @@ import {
     ParticipantContactDetailsResponseVho,
     ParticipantForUserResponse,
     ParticipantHeartbeatResponse,
+    ParticipantResponse,
     ParticipantResponseVho,
     ParticipantStatus,
     Role,
@@ -813,5 +814,176 @@ export class ConferenceTestData {
         endpoints.push(point1);
         endpoints.push(point2);
         return endpoints;
+    }
+
+    getFullListOfParticipants(): ParticipantResponse[] {
+        const participants: ParticipantResponse[] = [];
+        const participant1 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'Mr C Smith',
+            first_name: null,
+            hearing_role: 'Quick link participant',
+            id: '72af1eac-9c38-4b7e-9c20-6ed00f36bd71',
+            interpreter_room: undefined,
+            last_name: null,
+            linked_participants: [],
+            name: 'Mr C Smith',
+            representee: null,
+            role: Role.QuickLinkParticipant,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'WITNESS;NO_HEARTBEAT;C;72af1eac-9c38-4b7e-9c20-6ed00f36bd71',
+            user_name: '72af1eac-9c38-4b7e-9c20-6ed00f36bd71@quick-link-participant.com'
+        });
+        const participant2 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'Mr D Smith',
+            first_name: null,
+            hearing_role: 'Quick link participant',
+            id: '0880354e-52b9-4804-8e45-969c11796a26',
+            interpreter_room: undefined,
+            last_name: null,
+            linked_participants: [],
+            name: 'Mr D Smith',
+            representee: null,
+            role: Role.QuickLinkParticipant,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'WITNESS;NO_HEARTBEAT;D;0880354e-52b9-4804-8e45-969c11796a26',
+            user_name: '0880354e-52b9-4804-8e45-969c11796a26@quick-link-participant.com'
+        });
+        const participant3 = new ParticipantResponse({
+            case_type_group: null,
+            current_room: undefined,
+            display_name: 'Oliver Scott StaffMember',
+            first_name: 'Oliver',
+            hearing_role: 'Staff Member',
+            id: '68f35208-e991-48c5-a61e-9c8b542a3bb0',
+            interpreter_room: undefined,
+            last_name: 'StaffMember',
+            linked_participants: [],
+            name: 'Oliver Scott StaffMember',
+            representee: null,
+            role: Role.StaffMember,
+            status: ParticipantStatus.Disconnected,
+            tiled_display_name: 'CLERK;HEARTBEAT;Oliver Scott StaffMember;68f35208-e991-48c5-a61e-9c8b542a3bb0',
+            user_name: 'oliver.scott.staffmember@hearings.reform.hmcts.net'
+        });
+
+        const participant4LinkedParticipants: LinkedParticipantResponse[] = [];
+        participant4LinkedParticipants.push(
+            new LinkedParticipantResponse({
+                link_type: LinkType.Interpreter,
+                linked_id: 'acf3b4c4-3e92-4937-b2b0-6e9d486efcd2'
+            })
+        );
+
+        const participant4 = new ParticipantResponse({
+            case_type_group: 'Applicant',
+            current_room: undefined,
+            display_name: 'B',
+            first_name: 'B',
+            hearing_role: 'Litigant in person',
+            id: 'c2118eec-9e62-40bc-af60-0c5898ddec29',
+            interpreter_room: undefined,
+            last_name: 'Smith',
+            linked_participants: participant4LinkedParticipants,
+            name: 'Mr B Smith',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;B;c2118eec-9e62-40bc-af60-0c5898ddec29',
+            user_name: 'applicant.litigant@hearings.reform.hmcts.net'
+        });
+
+        const participant5LinkedParticipants: LinkedParticipantResponse[] = [];
+        participant5LinkedParticipants.push(
+            new LinkedParticipantResponse({
+                link_type: LinkType.Interpreter,
+                linked_id: 'c2118eec-9e62-40bc-af60-0c5898ddec29'
+            })
+        );
+
+        const participant5 = new ParticipantResponse({
+            case_type_group: 'Applicant',
+            current_room: undefined,
+            display_name: 'A',
+            first_name: 'A',
+            hearing_role: 'Interpreter',
+            id: 'acf3b4c4-3e92-4937-b2b0-6e9d486efcd2',
+            interpreter_room: undefined,
+            last_name: 'Smith',
+            linked_participants: participant5LinkedParticipants,
+            name: 'Mr A Smith',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;A;acf3b4c4-3e92-4937-b2b0-6e9d486efcd2',
+            user_name: 'applicant.interpreter@hearings.reform.hmcts.net'
+        });
+
+        const participant6 = new ParticipantResponse({
+            case_type_group: 'Applicant',
+            current_room: undefined,
+            display_name: 'G',
+            first_name: 'G',
+            hearing_role: 'Witness',
+            id: 'adf3b4c4-3e92-4937-b2b0-6e9d486efcd2',
+            interpreter_room: undefined,
+            last_name: 'Smith',
+            linked_participants: participant5LinkedParticipants,
+            name: 'Mr G Smith',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;A;adf3b4c4-3e92-4937-b2b0-6e9d486efcd2',
+            user_name: 'applicant.witness@hearings.reform.hmcts.net'
+        });
+
+        const participant7 = new ParticipantResponse({
+            case_type_group: 'Respondent',
+            current_room: undefined,
+            display_name: 'E',
+            first_name: 'E',
+            hearing_role: 'Witness',
+            id: '0136aee3-5330-4731-8be2-a05e10234d87',
+            interpreter_room: undefined,
+            last_name: 'Witness',
+            linked_participants: [],
+            name: 'Mr E Smith',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'WITNESS;NO_HEARTBEAT;F;0136aee3-5330-4731-8be2-a05e10234d87',
+            user_name: 'respondent.witness1@hearings.reform.hmcts.net'
+        });
+
+        const participant8 = new ParticipantResponse({
+            case_type_group: 'Respondent',
+            current_room: undefined,
+            display_name: 'F',
+            first_name: 'F',
+            hearing_role: 'Litigant in person',
+            id: 'db6eb25b-1d70-46ad-8b83-355922f8e976',
+            interpreter_room: undefined,
+            last_name: 'Smith',
+            linked_participants: [],
+            name: 'Mr F Smith',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;E;db6eb25b-1d70-46ad-8b83-355922f8e976',
+            user_name: 'respondent.litigant@hearings.reform.hmcts.net'
+        });
+
+        participants.push(participant1);
+        participants.push(participant2);
+        participants.push(participant3);
+        participants.push(participant4);
+        participants.push(participant5);
+        participants.push(participant6);
+        participants.push(participant7);
+        participants.push(participant8);
+        return participants;
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -958,6 +958,14 @@ export class ConferenceTestData {
             user_name: 'respondent.witness1@hearings.reform.hmcts.net'
         });
 
+        const participant8LinkedParticipants: LinkedParticipantResponse[] = [];
+        participant8LinkedParticipants.push(
+            new LinkedParticipantResponse({
+                link_type: LinkType.Interpreter,
+                linked_id: 'dcf3b4c4-3e92-4937-b2b0-6e9d486efcd3'
+            })
+        );
+
         const participant8 = new ParticipantResponse({
             case_type_group: 'Respondent',
             current_room: undefined,
@@ -967,13 +975,39 @@ export class ConferenceTestData {
             id: 'db6eb25b-1d70-46ad-8b83-355922f8e976',
             interpreter_room: undefined,
             last_name: 'Smith',
-            linked_participants: [],
+            linked_participants: participant8LinkedParticipants,
             name: 'Mr F Smith',
             representee: '',
             role: Role.Individual,
             status: ParticipantStatus.NotSignedIn,
             tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;E;db6eb25b-1d70-46ad-8b83-355922f8e976',
             user_name: 'respondent.litigant@hearings.reform.hmcts.net'
+        });
+
+        const participant9LinkedParticipants: LinkedParticipantResponse[] = [];
+        participant9LinkedParticipants.push(
+            new LinkedParticipantResponse({
+                link_type: LinkType.Interpreter,
+                linked_id: 'db6eb25b-1d70-46ad-8b83-355922f8e976'
+            })
+        );
+
+        const participant9 = new ParticipantResponse({
+            case_type_group: 'Respondent',
+            current_room: undefined,
+            display_name: 'H',
+            first_name: 'H',
+            hearing_role: 'Interpreter',
+            id: 'dcf3b4c4-3e92-4937-b2b0-6e9d486efcd3',
+            interpreter_room: undefined,
+            last_name: 'Smith',
+            linked_participants: participant9LinkedParticipants,
+            name: 'Mr H Smith',
+            representee: '',
+            role: Role.Individual,
+            status: ParticipantStatus.NotSignedIn,
+            tiled_display_name: 'CIVILIAN;NO_HEARTBEAT;A;dcf3b4c4-3e92-4937-b2b0-6e9d486efcd3',
+            user_name: 'respondent.interpreter@hearings.reform.hmcts.net'
         });
 
         participants.push(participant1);
@@ -984,6 +1018,7 @@ export class ConferenceTestData {
         participants.push(participant6);
         participants.push(participant7);
         participants.push(participant8);
+        participants.push(participant9);
         return participants;
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -852,23 +852,6 @@ export class ConferenceTestData {
             tiled_display_name: 'WITNESS;NO_HEARTBEAT;D;0880354e-52b9-4804-8e45-969c11796a26',
             user_name: '0880354e-52b9-4804-8e45-969c11796a26@quick-link-participant.com'
         });
-        const participant3 = new ParticipantResponse({
-            case_type_group: null,
-            current_room: undefined,
-            display_name: 'A StaffMember',
-            first_name: 'A',
-            hearing_role: 'Staff Member',
-            id: '68f35208-e991-48c5-a61e-9c8b542a3bb0',
-            interpreter_room: undefined,
-            last_name: 'StaffMember',
-            linked_participants: [],
-            name: 'A StaffMember',
-            representee: null,
-            role: Role.StaffMember,
-            status: ParticipantStatus.Disconnected,
-            tiled_display_name: 'CLERK;HEARTBEAT;A StaffMember;68f35208-e991-48c5-a61e-9c8b542a3bb0',
-            user_name: 'a.staffmember@hearings.reform.hmcts.net'
-        });
 
         const participant4LinkedParticipants: LinkedParticipantResponse[] = [];
         participant4LinkedParticipants.push(
@@ -931,7 +914,7 @@ export class ConferenceTestData {
             id: 'adf3b4c4-3e92-4937-b2b0-6e9d486efcd2',
             interpreter_room: undefined,
             last_name: 'Smith',
-            linked_participants: participant5LinkedParticipants,
+            linked_participants: [],
             name: 'Mr G Smith',
             representee: '',
             role: Role.Individual,
@@ -1012,7 +995,6 @@ export class ConferenceTestData {
 
         participants.push(participant1);
         participants.push(participant2);
-        participants.push(participant3);
         participants.push(participant5);
         participants.push(participant6);
         participants.push(participant4);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/panel-model-base.ts
@@ -174,12 +174,10 @@ export abstract class PanelModel {
             return 5;
         } else if (this.caseTypeGroup?.toLowerCase() === 'endpoint') {
             return 6;
-        } else if (
-            this.caseTypeGroup === CaseTypeGroup.OBSERVER ||
-            this.hearingRole === HearingRole.OBSERVER ||
-            this.role === Role.QuickLinkObserver
-        ) {
+        } else if (this.caseTypeGroup === CaseTypeGroup.OBSERVER || this.hearingRole === HearingRole.OBSERVER) {
             return 7;
+        } else if (this.role === Role.QuickLinkObserver) {
+            return 8;
         } else {
             return 4;
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -484,6 +484,98 @@ describe('PrivateConsultationParticipantsComponent', () => {
         expect(component.trackParticipant(0, { status: ParticipantStatus.Available })).toBe(ParticipantStatus.Available);
     });
 
+    it('should filter and sort non-judge participants correctly', () => {
+        conference.participants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
+        component.initParticipants();
+        const nonJudgeParticipants = component.nonJudgeParticipants;
+
+        const applicant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr B Smith');
+        const applicant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr A Smith');
+        const applicant3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr G Smith');
+        const respondent1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr E Smith');
+        const respondent2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr F Smith');
+        const respondent3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr H Smith');
+        const quickLinkParticipant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr C Smith');
+        const quickLinkParticipant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr D Smith');
+
+        expect(applicant1Index).toEqual(0);
+        expect(applicant2Index).toEqual(1);
+        expect(applicant3Index).toEqual(2);
+        expect(respondent1Index).toEqual(3);
+        expect(respondent2Index).toEqual(4);
+        expect(respondent3Index).toEqual(5);
+        expect(quickLinkParticipant1Index).toEqual(6);
+        expect(quickLinkParticipant2Index).toEqual(7);
+    });
+
+    it('should filter and sort panel members correctly', () => {
+        conference.participants = new ConferenceTestData().getFullListOfPanelMembers();
+        component.initParticipants();
+        const panelMembers = component.panelMembers;
+
+        const panelMember1Index = panelMembers.findIndex(x => x.name === 'Mr Panel Member A');
+        const panelMember2Index = panelMembers.findIndex(x => x.name === 'Mr Panel Member B');
+
+        expect(panelMember1Index).toEqual(0);
+        expect(panelMember2Index).toEqual(1);
+    });
+
+    // it('should filter and sort observers correctly', () => {
+    //     conference.participants = new ConferenceTestData().getFullListOfObservers();
+    //     component.initParticipants();
+    //     const observers = component.getObservers();
+
+    //     const observer1Index = observers.findIndex(x => x.name === 'Mr Observer A');
+    //     const observer2Index = observers.findIndex(x => x.name === 'Mr Observer B');
+    //     const qlObserver1Index = observers.findIndex(x => x.name === 'A QL Observer');
+    //     const qlObserver2Index = observers.findIndex(x => x.name === 'QL Observer A');
+
+    //     expect(observer1Index).toEqual(0);
+    //     expect(observer2Index).toEqual(1);
+    //     expect(qlObserver1Index).toEqual(2);
+    //     expect(qlObserver2Index).toEqual(3);
+    // });
+
+    it('should filter and sort endpoints correctly', () => {
+        conference.endpoints = new ConferenceTestData().getFullListOfEndpoints();
+        component.initParticipants();
+        const endpoints = component.endpoints;
+
+        const endpoint1Index = endpoints.findIndex(x => x.display_name === 'Endpoint A');
+        const endpoint2Index = endpoints.findIndex(x => x.display_name === 'Endpoint B');
+
+        expect(endpoint1Index).toEqual(0);
+        expect(endpoint2Index).toEqual(1);
+    });
+
+    it('should filter and sort staff members correctly', () => {
+        conference.participants = new ConferenceTestData().getFullListOfStaffMembers();
+        component.initParticipants();
+        const staffMembers = component.staffMembers;
+
+        const staffMember1Index = staffMembers.findIndex(x => x.name === 'A StaffMember');
+        const staffMember2Index = staffMembers.findIndex(x => x.name === 'B StaffMember');
+        const staffMember3Index = staffMembers.findIndex(x => x.name === 'C StaffMember');
+
+        expect(staffMember1Index).toEqual(0);
+        expect(staffMember2Index).toEqual(1);
+        expect(staffMember3Index).toEqual(2);
+    });
+
+    it('should filter and sort wingers correctly', () => {
+        conference.participants = new ConferenceTestData().getFullListOfWingers();
+        component.initParticipants();
+        const wingers = component.wingers;
+
+        const winger1Index = wingers.findIndex(x => x.name === 'Mr A Winger');
+        const winger2Index = wingers.findIndex(x => x.name === 'Mr B Winger');
+        const winger3Index = wingers.findIndex(x => x.name === 'Mr C Winger');
+
+        expect(winger1Index).toEqual(0);
+        expect(winger2Index).toEqual(1);
+        expect(winger3Index).toEqual(2);
+    });
+
     describe('johGroups', () => {
         it('should return correct participants mapped to ParticipantListItem', () => {
             const testPanelMember1Data = { id: 'TestPanelMember1Id', name: 'TestPanelMember1Name' };
@@ -665,8 +757,8 @@ describe('PrivateConsultationParticipantsComponent', () => {
         const testObservers = [regularObserver, quickLinkObserver2, quickLinkObserver1];
 
         beforeEach(() => {
-            component.nonJudgeParticipants = testParticipants;
-            component.observers = testObservers;
+            conference.participants = testParticipants.concat(testObservers);
+            component.initParticipants();
         });
 
         it('should return nothing if is not joh consultation', () => {
@@ -676,18 +768,18 @@ describe('PrivateConsultationParticipantsComponent', () => {
         });
 
         it('should return list in correct order for joh consultation', () => {
-            const mappedRegularObserver: ParticipantListItem = { ...regularObserver };
-            const mappedQuickLinkObserver1: ParticipantListItem = { ...quickLinkObserver1 };
-            const mappedQuickLinkObserver2: ParticipantListItem = { ...quickLinkObserver2 };
-
             spyOn(component, 'isJohConsultation').and.returnValue(true);
             const result = component.getObservers();
 
-            const observersOrdered = [mappedRegularObserver, mappedQuickLinkObserver1, mappedQuickLinkObserver2].sort((a, b) =>
-                a.display_name.localeCompare(b.display_name)
-            );
+            const observer1Index = result.findIndex(x => x.display_name === 'regularObserver_display_name');
+            const qlObserver1Index = result.findIndex(x => x.display_name === 'quickLinkObserver1_display_name');
+            const qlObserver2Index = result.findIndex(x => x.display_name === 'quickLinkObserver2_display_name');
 
-            expect(result.length).toBe(observersOrdered.length);
+            expect(observer1Index).toEqual(0);
+            expect(qlObserver1Index).toEqual(1);
+            expect(qlObserver2Index).toEqual(2);
+
+            expect(result.length).toBe(testObservers.length);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -484,98 +484,6 @@ describe('PrivateConsultationParticipantsComponent', () => {
         expect(component.trackParticipant(0, { status: ParticipantStatus.Available })).toBe(ParticipantStatus.Available);
     });
 
-    it('should filter and sort non-judge participants correctly', () => {
-        conference.participants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
-        component.initParticipants();
-        const nonJudgeParticipants = component.nonJudgeParticipants;
-
-        const applicant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr B Smith');
-        const applicant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr A Smith');
-        const applicant3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr G Smith');
-        const respondent1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr E Smith');
-        const respondent2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr F Smith');
-        const respondent3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr H Smith');
-        const quickLinkParticipant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr C Smith');
-        const quickLinkParticipant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr D Smith');
-
-        expect(applicant1Index).toEqual(0);
-        expect(applicant2Index).toEqual(1);
-        expect(applicant3Index).toEqual(2);
-        expect(respondent1Index).toEqual(3);
-        expect(respondent2Index).toEqual(4);
-        expect(respondent3Index).toEqual(5);
-        expect(quickLinkParticipant1Index).toEqual(6);
-        expect(quickLinkParticipant2Index).toEqual(7);
-    });
-
-    it('should filter and sort panel members correctly', () => {
-        conference.participants = new ConferenceTestData().getFullListOfPanelMembers();
-        component.initParticipants();
-        const panelMembers = component.panelMembers;
-
-        const panelMember1Index = panelMembers.findIndex(x => x.name === 'Mr Panel Member A');
-        const panelMember2Index = panelMembers.findIndex(x => x.name === 'Mr Panel Member B');
-
-        expect(panelMember1Index).toEqual(0);
-        expect(panelMember2Index).toEqual(1);
-    });
-
-    // it('should filter and sort observers correctly', () => {
-    //     conference.participants = new ConferenceTestData().getFullListOfObservers();
-    //     component.initParticipants();
-    //     const observers = component.getObservers();
-
-    //     const observer1Index = observers.findIndex(x => x.name === 'Mr Observer A');
-    //     const observer2Index = observers.findIndex(x => x.name === 'Mr Observer B');
-    //     const qlObserver1Index = observers.findIndex(x => x.name === 'A QL Observer');
-    //     const qlObserver2Index = observers.findIndex(x => x.name === 'QL Observer A');
-
-    //     expect(observer1Index).toEqual(0);
-    //     expect(observer2Index).toEqual(1);
-    //     expect(qlObserver1Index).toEqual(2);
-    //     expect(qlObserver2Index).toEqual(3);
-    // });
-
-    it('should filter and sort endpoints correctly', () => {
-        conference.endpoints = new ConferenceTestData().getFullListOfEndpoints();
-        component.initParticipants();
-        const endpoints = component.endpoints;
-
-        const endpoint1Index = endpoints.findIndex(x => x.display_name === 'Endpoint A');
-        const endpoint2Index = endpoints.findIndex(x => x.display_name === 'Endpoint B');
-
-        expect(endpoint1Index).toEqual(0);
-        expect(endpoint2Index).toEqual(1);
-    });
-
-    it('should filter and sort staff members correctly', () => {
-        conference.participants = new ConferenceTestData().getFullListOfStaffMembers();
-        component.initParticipants();
-        const staffMembers = component.staffMembers;
-
-        const staffMember1Index = staffMembers.findIndex(x => x.name === 'A StaffMember');
-        const staffMember2Index = staffMembers.findIndex(x => x.name === 'B StaffMember');
-        const staffMember3Index = staffMembers.findIndex(x => x.name === 'C StaffMember');
-
-        expect(staffMember1Index).toEqual(0);
-        expect(staffMember2Index).toEqual(1);
-        expect(staffMember3Index).toEqual(2);
-    });
-
-    it('should filter and sort wingers correctly', () => {
-        conference.participants = new ConferenceTestData().getFullListOfWingers();
-        component.initParticipants();
-        const wingers = component.wingers;
-
-        const winger1Index = wingers.findIndex(x => x.name === 'Mr A Winger');
-        const winger2Index = wingers.findIndex(x => x.name === 'Mr B Winger');
-        const winger3Index = wingers.findIndex(x => x.name === 'Mr C Winger');
-
-        expect(winger1Index).toEqual(0);
-        expect(winger2Index).toEqual(1);
-        expect(winger3Index).toEqual(2);
-    });
-
     describe('johGroups', () => {
         it('should return correct participants mapped to ParticipantListItem', () => {
             const testPanelMember1Data = { id: 'TestPanelMember1Id', name: 'TestPanelMember1Name' };
@@ -780,6 +688,37 @@ describe('PrivateConsultationParticipantsComponent', () => {
             expect(qlObserver2Index).toEqual(2);
 
             expect(result.length).toBe(testObservers.length);
+        });
+    });
+
+    describe('getPrivateConsultationParticipants', () => {
+        beforeEach(() => {
+            conference.participants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
+            component.initParticipants();
+        });
+
+        it('should return list in correct order', () => {
+            const privateConsultationParticipants = component.getPrivateConsultationParticipants();
+
+            const applicant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr B Smith');
+            const applicant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr A Smith');
+            const applicant3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr G Smith');
+            const respondent1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr E Smith');
+            const respondent2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr F Smith');
+            const respondent3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr H Smith');
+            const quickLinkParticipant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr C Smith');
+            const quickLinkParticipant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr D Smith');
+
+            // Interpreters are filtered out
+            expect(applicant2Index).toEqual(-1);
+            expect(respondent3Index).toEqual(-1);
+
+            expect(applicant1Index).toEqual(0);
+            expect(applicant3Index).toEqual(1);
+            expect(respondent1Index).toEqual(2);
+            expect(respondent2Index).toEqual(3);
+            expect(quickLinkParticipant1Index).toEqual(4);
+            expect(quickLinkParticipant2Index).toEqual(5);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -185,10 +185,8 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
     }
 
     private sortAndMapToListItem(participantResponses: Array<ParticipantResponse>): Array<ParticipantListItem> {
-        return participantResponses
-            .sort((a, b) => a.display_name.localeCompare(b.display_name))
-            .map(c => {
-                return this.mapResponseToListItem(c);
-            });
+        return participantResponses.map(c => {
+            return this.mapResponseToListItem(c);
+        });
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -49,6 +49,7 @@ import {
     ConferenceResponse,
     ConferenceStatus,
     EndpointStatus,
+    ParticipantForUserResponse,
     ParticipantResponse,
     ParticipantStatus,
     Role
@@ -1546,6 +1547,94 @@ describe('ParticipantsPanelComponent', () => {
                     });
                 });
             });
+        });
+    });
+
+    describe('getParticipantsList', () => {
+        it('should list participants and endpoints in correct order', async () => {
+            const judge = new ParticipantResponse({
+                case_type_group: 'Judge',
+                current_room: undefined,
+                display_name: 'Manual Judge_26',
+                first_name: 'Manual',
+                hearing_role: 'Judge',
+                id: '85dfea9b-d8ec-477e-825f-7e4e3611db99',
+                interpreter_room: undefined,
+                last_name: 'Judge_26',
+                linked_participants: [],
+                name: null,
+                representee: null,
+                role: Role.Judge,
+                status: ParticipantStatus.NotSignedIn,
+                tiled_display_name: 'JUDGE;HEARTBEAT;Manual Judge_26;85dfea9b-d8ec-477e-825f-7e4e3611db99',
+                user_name: null
+            });
+            const staffMembers = new ConferenceTestData().getFullListOfStaffMembers();
+            const nonJudgeParticipants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
+            const panelMembers = new ConferenceTestData().getFullListOfPanelMembers();
+            const observers = new ConferenceTestData().getFullListOfObservers();
+            const endpoints = new ConferenceTestData().getFullListOfEndpoints();
+
+            const participants = [...staffMembers, ...nonJudgeParticipants, ...panelMembers, ...observers];
+            participants.push(judge);
+            const mappedParticipants = participants.map(p => new ParticipantForUserResponse(p));
+
+            videoWebServiceSpy.getParticipantsByConferenceId.and.returnValue(Promise.resolve(mappedParticipants));
+            videoWebServiceSpy.getEndpointsForConference.and.returnValue(Promise.resolve(endpoints));
+
+            const mappedPanelParticipants = mapper.mapFromParticipantUserResponseArray(participants);
+            participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedPanelParticipants);
+
+            await component.getParticipantsList();
+
+            const participantList = component.participants;
+            const endpointList = component.endpointParticipants;
+
+            // Judge
+            const judgeIndex = participantList.findIndex(x => x.displayName === 'Manual Judge_26');
+            expect(judgeIndex).toEqual(0);
+
+            // Panel members
+            const panelMembersIndex = participantList.findIndex(x => x.displayName === 'Mr Panel Member A, Mr Panel Member B');
+            expect(panelMembersIndex).toEqual(1);
+
+            // Staff members
+            const staffMember1Index = participantList.findIndex(x => x.displayName === 'A StaffMember');
+            const staffMember2Index = participantList.findIndex(x => x.displayName === 'B StaffMember');
+            const staffMember3Index = participantList.findIndex(x => x.displayName === 'C StaffMember');
+            expect(staffMember1Index).toEqual(2);
+            expect(staffMember2Index).toEqual(3);
+            expect(staffMember3Index).toEqual(4);
+
+            // Non-judge participants
+            const applicant1Index = participantList.findIndex(x => x.displayName === 'Mr B Smith, Mr A Smith'); // Litigant in person + Interpreter
+            const applicant2Index = participantList.findIndex(x => x.displayName === 'Mr G Smith');
+            const respondent1Index = participantList.findIndex(x => x.displayName === 'Mr E Smith');
+            const respondent2Index = participantList.findIndex(x => x.displayName === 'Mr F Smith, Mr H Smith');
+            const quickLinkParticipant1Index = participantList.findIndex(x => x.displayName === 'Mr C Smith');
+            const quickLinkParticipant2Index = participantList.findIndex(x => x.displayName === 'Mr D Smith');
+            expect(applicant1Index).toEqual(5);
+            expect(applicant2Index).toEqual(6);
+            expect(respondent1Index).toEqual(7);
+            expect(respondent2Index).toEqual(8);
+            expect(quickLinkParticipant1Index).toEqual(9);
+            expect(quickLinkParticipant2Index).toEqual(10);
+
+            // Endpoints
+            const endpoint1Index = endpointList.findIndex(x => x.displayName === 'Endpoint A');
+            const endpoint2Index = endpointList.findIndex(x => x.displayName === 'Endpoint B');
+            expect(endpoint1Index).toEqual(0);
+            expect(endpoint2Index).toEqual(1);
+
+            // Observers
+            const observer1Index = participantList.findIndex(x => x.displayName === 'Mr Observer A');
+            const observer2Index = participantList.findIndex(x => x.displayName === 'Mr Observer B');
+            const qlObserver1Index = participantList.findIndex(x => x.displayName === 'A QL Observer');
+            const qlObserver2Index = participantList.findIndex(x => x.displayName === 'QL Observer A');
+            expect(observer1Index).toEqual(11);
+            expect(observer2Index).toEqual(12);
+            expect(qlObserver1Index).toEqual(13);
+            expect(qlObserver2Index).toEqual(14);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1573,16 +1573,16 @@ describe('ParticipantsPanelComponent', () => {
             const nonJudgeParticipants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
             const panelMembers = new ConferenceTestData().getFullListOfPanelMembers();
             const observers = new ConferenceTestData().getFullListOfObservers();
-            const endpoints = new ConferenceTestData().getFullListOfEndpoints();
+            const fullListOfEndpoints = new ConferenceTestData().getFullListOfEndpoints();
 
-            const participants = [...staffMembers, ...nonJudgeParticipants, ...panelMembers, ...observers];
-            participants.push(judge);
-            const mappedParticipants = participants.map(p => new ParticipantForUserResponse(p));
+            const fullListOfParticipants = [...staffMembers, ...nonJudgeParticipants, ...panelMembers, ...observers];
+            fullListOfParticipants.push(judge);
+            const mappedParticipants = fullListOfParticipants.map(p => new ParticipantForUserResponse(p));
 
             videoWebServiceSpy.getParticipantsByConferenceId.and.returnValue(Promise.resolve(mappedParticipants));
-            videoWebServiceSpy.getEndpointsForConference.and.returnValue(Promise.resolve(endpoints));
+            videoWebServiceSpy.getEndpointsForConference.and.returnValue(Promise.resolve(fullListOfEndpoints));
 
-            const mappedPanelParticipants = mapper.mapFromParticipantUserResponseArray(participants);
+            const mappedPanelParticipants = mapper.mapFromParticipantUserResponseArray(fullListOfParticipants);
             participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedPanelParticipants);
 
             await component.getParticipantsList();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1607,10 +1607,10 @@ describe('ParticipantsPanelComponent', () => {
             expect(staffMember3Index).toEqual(4);
 
             // Non-judge participants
-            const applicant1Index = participantList.findIndex(x => x.displayName === 'Mr B Smith, Mr A Smith'); // Litigant in person + Interpreter
-            const applicant2Index = participantList.findIndex(x => x.displayName === 'Mr G Smith');
-            const respondent1Index = participantList.findIndex(x => x.displayName === 'Mr E Smith');
-            const respondent2Index = participantList.findIndex(x => x.displayName === 'Mr F Smith, Mr H Smith');
+            const applicant1Index = participantList.findIndex(x => x.displayName === 'B, A'); // Litigant in person + Interpreter
+            const applicant2Index = participantList.findIndex(x => x.displayName === 'G');
+            const respondent1Index = participantList.findIndex(x => x.displayName === 'E');
+            const respondent2Index = participantList.findIndex(x => x.displayName === 'F, H');
             const quickLinkParticipant1Index = participantList.findIndex(x => x.displayName === 'Mr C Smith');
             const quickLinkParticipant2Index = participantList.findIndex(x => x.displayName === 'Mr D Smith');
             expect(applicant1Index).toEqual(5);
@@ -1621,20 +1621,20 @@ describe('ParticipantsPanelComponent', () => {
             expect(quickLinkParticipant2Index).toEqual(10);
 
             // Endpoints
-            const endpoint1Index = endpointList.findIndex(x => x.displayName === 'Endpoint A');
-            const endpoint2Index = endpointList.findIndex(x => x.displayName === 'Endpoint B');
-            expect(endpoint1Index).toEqual(0);
-            expect(endpoint2Index).toEqual(1);
+            const endpoint1Index = participantList.findIndex(x => x.displayName === 'Endpoint A');
+            const endpoint2Index = participantList.findIndex(x => x.displayName === 'Endpoint B');
+            expect(endpoint1Index).toEqual(11);
+            expect(endpoint2Index).toEqual(12);
 
             // Observers
             const observer1Index = participantList.findIndex(x => x.displayName === 'Mr Observer A');
             const observer2Index = participantList.findIndex(x => x.displayName === 'Mr Observer B');
             const qlObserver1Index = participantList.findIndex(x => x.displayName === 'A QL Observer');
             const qlObserver2Index = participantList.findIndex(x => x.displayName === 'QL Observer A');
-            expect(observer1Index).toEqual(11);
-            expect(observer2Index).toEqual(12);
-            expect(qlObserver1Index).toEqual(13);
-            expect(qlObserver2Index).toEqual(14);
+            expect(observer1Index).toEqual(13);
+            expect(observer2Index).toEqual(14);
+            expect(qlObserver1Index).toEqual(15);
+            expect(qlObserver2Index).toEqual(16);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -740,8 +740,8 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
     private getOrderedParticipants(combined: PanelModel[]) {
         combined.sort((x, z) => {
             if (x.orderInTheList === z.orderInTheList) {
-                // 3 here means regular participants and should be grouped by caseTypeGroup
-                if (x.orderInTheList !== 3 || x.caseTypeGroup === z.caseTypeGroup) {
+                // 4 here means regular participants and should be grouped by caseTypeGroup
+                if (x.orderInTheList !== 4 || x.caseTypeGroup === z.caseTypeGroup) {
                     return x.displayName.localeCompare(z.displayName);
                 }
                 return x.caseTypeGroup.localeCompare(z.caseTypeGroup);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.spec.ts
@@ -434,7 +434,7 @@ describe('WaitingRoom ParticipantList Base', () => {
 
     describe('initParticipants', () => {
         it('should filter and sort non-judge participants correctly', () => {
-            conference.participants = new ConferenceTestData().getFullListOfParticipants();
+            conference.participants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
             component.initParticipants();
             const nonJudgeParticipants = component.nonJudgeParticipants;
 
@@ -455,6 +455,74 @@ describe('WaitingRoom ParticipantList Base', () => {
             expect(respondent3Index).toEqual(5);
             expect(quickLinkParticipant1Index).toEqual(6);
             expect(quickLinkParticipant2Index).toEqual(7);
+        });
+
+        it('should filter and sort panel members correctly', () => {
+            conference.participants = new ConferenceTestData().getFullListOfPanelMembers();
+            component.initParticipants();
+            const panelMembers = component.panelMembers;
+
+            const panelMember1Index = panelMembers.findIndex(x => x.name === 'Mr Panel Member A');
+            const panelMember2Index = panelMembers.findIndex(x => x.name === 'Mr Panel Member B');
+
+            expect(panelMember1Index).toEqual(0);
+            expect(panelMember2Index).toEqual(1);
+        });
+
+        it('should filter and sort observers correctly', () => {
+            conference.participants = new ConferenceTestData().getFullListOfObservers();
+            component.initParticipants();
+            const observers = component.observers;
+
+            const observer1Index = observers.findIndex(x => x.name === 'Mr Observer A');
+            const observer2Index = observers.findIndex(x => x.name === 'Mr Observer B');
+            const qlObserver1Index = observers.findIndex(x => x.name === 'A QL Observer');
+            const qlObserver2Index = observers.findIndex(x => x.name === 'QL Observer A');
+
+            expect(observer1Index).toEqual(0);
+            expect(observer2Index).toEqual(1);
+            expect(qlObserver1Index).toEqual(2);
+            expect(qlObserver2Index).toEqual(3);
+        });
+
+        it('should filter and sort endpoints correctly', () => {
+            conference.endpoints = new ConferenceTestData().getFullListOfEndpoints();
+            component.initParticipants();
+            const endpoints = component.endpoints;
+
+            const endpoint1Index = endpoints.findIndex(x => x.display_name === 'Endpoint A');
+            const endpoint2Index = endpoints.findIndex(x => x.display_name === 'Endpoint B');
+
+            expect(endpoint1Index).toEqual(0);
+            expect(endpoint2Index).toEqual(1);
+        });
+
+        it('should filter and sort staff members correctly', () => {
+            conference.participants = new ConferenceTestData().getFullListOfStaffMembers();
+            component.initParticipants();
+            const staffMembers = component.staffMembers;
+
+            const staffMember1Index = staffMembers.findIndex(x => x.name === 'A StaffMember');
+            const staffMember2Index = staffMembers.findIndex(x => x.name === 'B StaffMember');
+            const staffMember3Index = staffMembers.findIndex(x => x.name === 'C StaffMember');
+
+            expect(staffMember1Index).toEqual(0);
+            expect(staffMember2Index).toEqual(1);
+            expect(staffMember3Index).toEqual(2);
+        });
+
+        it('should filter and sort wingers correctly', () => {
+            conference.participants = new ConferenceTestData().getFullListOfWingers();
+            component.initParticipants();
+            const wingers = component.wingers;
+
+            const winger1Index = wingers.findIndex(x => x.name === 'Mr A Winger');
+            const winger2Index = wingers.findIndex(x => x.name === 'Mr B Winger');
+            const winger3Index = wingers.findIndex(x => x.name === 'Mr C Winger');
+
+            expect(winger1Index).toEqual(0);
+            expect(winger2Index).toEqual(1);
+            expect(winger3Index).toEqual(2);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.spec.ts
@@ -24,7 +24,6 @@ import { WRParticipantStatusListDirective } from './wr-participant-list-shared.c
 import { HearingRole } from '../models/hearing-role-model';
 import { TranslateService } from '@ngx-translate/core';
 import { translateServiceSpy } from 'src/app/testing/mocks/mock-translation.service';
-import { Participant } from 'src/app/shared/models/participant';
 
 class WrParticipantStatusListTest extends WRParticipantStatusListDirective implements OnInit, OnDestroy {
     constructor(
@@ -430,6 +429,30 @@ describe('WaitingRoom ParticipantList Base', () => {
             const hearingRoleText = component.getHearingRole(participant);
 
             expect(hearingRoleText).toEqual('hearing-role.quick-link-observer');
+        });
+    });
+
+    describe('initParticipants', () => {
+        it('should filter and sort non-judge participants correctly', () => {
+            conference.participants = new ConferenceTestData().getFullListOfParticipants();
+            component.initParticipants();
+            const nonJudgeParticipants = component.nonJudgeParticipants;
+
+            const applicant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr A Smith');
+            const applicant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr B Smith');
+            const applicant3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr G Smith');
+            const respondent1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr E Smith');
+            const respondent2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr F Smith');
+            const quickLinkParticipant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr C Smith');
+            const quickLinkParticipant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr D Smith');
+
+            expect(applicant1Index).toEqual(0);
+            expect(applicant2Index).toEqual(1);
+            expect(applicant3Index).toEqual(2);
+            expect(respondent1Index).toEqual(3);
+            expect(respondent2Index).toEqual(4);
+            expect(quickLinkParticipant1Index).toEqual(5);
+            expect(quickLinkParticipant2Index).toEqual(6);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.spec.ts
@@ -438,11 +438,12 @@ describe('WaitingRoom ParticipantList Base', () => {
             component.initParticipants();
             const nonJudgeParticipants = component.nonJudgeParticipants;
 
-            const applicant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr A Smith');
-            const applicant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr B Smith');
+            const applicant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr B Smith');
+            const applicant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr A Smith');
             const applicant3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr G Smith');
             const respondent1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr E Smith');
             const respondent2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr F Smith');
+            const respondent3Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr H Smith');
             const quickLinkParticipant1Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr C Smith');
             const quickLinkParticipant2Index = nonJudgeParticipants.findIndex(x => x.name === 'Mr D Smith');
 
@@ -451,8 +452,9 @@ describe('WaitingRoom ParticipantList Base', () => {
             expect(applicant3Index).toEqual(2);
             expect(respondent1Index).toEqual(3);
             expect(respondent2Index).toEqual(4);
-            expect(quickLinkParticipant1Index).toEqual(5);
-            expect(quickLinkParticipant2Index).toEqual(6);
+            expect(respondent3Index).toEqual(5);
+            expect(quickLinkParticipant1Index).toEqual(6);
+            expect(quickLinkParticipant2Index).toEqual(7);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -118,16 +118,18 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
     }
 
     protected filterNonJudgeParticipants(): void {
-        let nonJudgeParts = this.conference.participants.filter(
-            x =>
-                x.role !== Role.Judge &&
-                x.role !== Role.JudicialOfficeHolder &&
-                x.case_type_group !== CaseTypeGroup.OBSERVER &&
-                x.hearing_role !== HearingRole.OBSERVER &&
-                x.role !== Role.QuickLinkObserver &&
-                x.role !== Role.QuickLinkParticipant &&
-                x.hearing_role !== HearingRole.STAFF_MEMBER
-        );
+        let nonJudgeParts = this.conference.participants
+            .filter(
+                x =>
+                    x.role !== Role.Judge &&
+                    x.role !== Role.JudicialOfficeHolder &&
+                    x.case_type_group !== CaseTypeGroup.OBSERVER &&
+                    x.hearing_role !== HearingRole.OBSERVER &&
+                    x.role !== Role.QuickLinkObserver &&
+                    x.role !== Role.QuickLinkParticipant &&
+                    x.hearing_role !== HearingRole.STAFF_MEMBER
+            )
+            .sort((a, b) => a.case_type_group.localeCompare(b.case_type_group) || a.name.localeCompare(b.name));
 
         nonJudgeParts = [
             ...nonJudgeParts,
@@ -136,18 +138,7 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
                 .sort((a, b) => a.display_name.localeCompare(b.display_name))
         ];
 
-        const interpreterList = nonJudgeParts.filter(
-            x =>
-                x.role === Role.Individual &&
-                x.hearing_role === HearingRole.INTERPRETER &&
-                Array.isArray(x.linked_participants) &&
-                x.linked_participants.length > 0
-        );
-        if (!interpreterList) {
-            this.nonJudgeParticipants = nonJudgeParts;
-        } else {
-            this.nonJudgeParticipants = this.orderForInterpreter(nonJudgeParts, interpreterList);
-        }
+        this.nonJudgeParticipants = nonJudgeParts;
     }
 
     hasInterpreterLink(participant: ParticipantResponse) {
@@ -176,23 +167,6 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
     getInterpreteeName(interpreterId: string) {
         const interpreter = this.nonJudgeParticipants.find(x => x.id === interpreterId);
         return this.nonJudgeParticipants.find(x => x.id === interpreter.linked_participants[0].linked_id).name;
-    }
-
-    private orderForInterpreter(
-        nonJudgeParticipants: ParticipantResponse[],
-        interpreterList: ParticipantResponse[]
-    ): ParticipantResponse[] {
-        const sortedParticipants = [];
-        const linkedParticipantIds = [];
-        interpreterList.forEach(interpreter => {
-            const linkDetails = interpreter.linked_participants[0];
-            const interpretee = nonJudgeParticipants.find(x => x.id === linkDetails.linked_id);
-            sortedParticipants.push(interpretee);
-            linkedParticipantIds.push(interpretee.id);
-            sortedParticipants.push(interpreter);
-            linkedParticipantIds.push(interpreter.id);
-        });
-        return [...nonJudgeParticipants.filter(p => !linkedParticipantIds.includes(p.id)), ...sortedParticipants];
     }
 
     protected filterObservers(): void {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -196,7 +196,7 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
             const interpreterIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpreter.id);
             const interpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id);
 
-            if (interpreterIndex != interpreteeIndex + 1) {
+            if (interpreterIndex !== interpreteeIndex + 1) {
                 const interpreterToMove = sortedNonJudgeParticipants[interpreterIndex];
 
                 sortedNonJudgeParticipants.splice(interpreteeIndex + 1, 0, interpreterToMove);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -129,7 +129,15 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
                     x.role !== Role.QuickLinkParticipant &&
                     x.hearing_role !== HearingRole.STAFF_MEMBER
             )
-            .sort((a, b) => a.case_type_group.localeCompare(b.case_type_group) || a.name.localeCompare(b.name));
+            .sort((a, b) => {
+                if (a.case_type_group.localeCompare(b.case_type_group)) {
+                    return 1;
+                }
+                if ((a.name || a.display_name).localeCompare(b.name || b.display_name)) {
+                    return 1;
+                }
+                return 0;
+            });
 
         nonJudgeParts = [
             ...nonJudgeParts,
@@ -190,13 +198,14 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
             const linkDetails = interpreter.linked_participants[0];
             const interpretee = nonJudgeParticipants.find(x => x.id === linkDetails.linked_id);
 
-            const interpeterIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpreter.id);
+            const interpreterIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpreter.id);
             const interpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id);
 
-            if (interpeterIndex < interpreteeIndex) {
-                const interpreterToMove = sortedNonJudgeParticipants[interpeterIndex];
-                sortedNonJudgeParticipants.splice(interpeterIndex, 1);
-                sortedNonJudgeParticipants.splice(interpreteeIndex, 0, interpreterToMove);
+            if (interpreterIndex != interpreteeIndex + 1) {
+                const interpreterToMove = sortedNonJudgeParticipants[interpreterIndex];
+
+                sortedNonJudgeParticipants.splice(interpreteeIndex + 1, 0, interpreterToMove);
+                sortedNonJudgeParticipants.splice(interpreterIndex, 1);
             }
         });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -63,7 +63,7 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
         this.filterPanelMembers();
         this.filterObservers();
         this.filterWingers();
-        this.endpoints = this.conference.endpoints;
+        this.sortEndpoints();
     }
 
     get participantCount(): number {
@@ -213,22 +213,34 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
     }
 
     protected filterObservers(): void {
-        this.observers = this.conference.participants
+        let observers = this.conference.participants
             .filter(
                 x =>
                     x.case_type_group === CaseTypeGroup.OBSERVER ||
-                    x.hearing_role === HearingRole.OBSERVER ||
-                    x.role === Role.QuickLinkObserver
+                    (x.hearing_role === HearingRole.OBSERVER && x.role !== Role.QuickLinkObserver)
             )
             .sort((a, b) => a.display_name.localeCompare(b.display_name));
+
+        observers = [
+            ...observers,
+            ...this.conference.participants
+                .filter(x => x.role === Role.QuickLinkObserver)
+                .sort((a, b) => a.display_name.localeCompare(b.display_name))
+        ];
+
+        this.observers = observers;
     }
 
     private filterWingers(): void {
-        this.wingers = this.conference.participants.filter(x => x.hearing_role === HearingRole.WINGER);
+        this.wingers = this.conference.participants
+            .filter(x => x.hearing_role === HearingRole.WINGER)
+            .sort((a, b) => a.name.localeCompare(b.name));
     }
 
     protected filterPanelMembers(): void {
-        this.panelMembers = this.conference.participants.filter(x => this.isParticipantPanelMember(x.hearing_role));
+        this.panelMembers = this.conference.participants
+            .filter(x => this.isParticipantPanelMember(x.hearing_role))
+            .sort((a, b) => a.display_name.localeCompare(b.display_name));
     }
     protected isParticipantPanelMember(hearingRole: string): boolean {
         return HearingRoleHelper.isPanelMember(hearingRole);
@@ -239,7 +251,13 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
     }
 
     protected filterStaffMember(): void {
-        this.staffMembers = this.conference.participants.filter(x => x.role === Role.StaffMember);
+        this.staffMembers = this.conference.participants
+            .filter(x => x.role === Role.StaffMember)
+            .sort((a, b) => a.display_name.localeCompare(b.display_name));
+    }
+
+    private sortEndpoints(): void {
+        this.endpoints = this.conference.endpoints.sort((a, b) => a.display_name.localeCompare(b.display_name));
     }
 
     get canInvite(): boolean {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -129,15 +129,10 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
                     x.role !== Role.QuickLinkParticipant &&
                     x.hearing_role !== HearingRole.STAFF_MEMBER
             )
-            .sort((a, b) => {
-                if (a.case_type_group.localeCompare(b.case_type_group)) {
-                    return 1;
-                }
-                if ((a.name || a.display_name).localeCompare(b.name || b.display_name)) {
-                    return 1;
-                }
-                return 0;
-            });
+            .sort(
+                (a, b) =>
+                    a.case_type_group.localeCompare(b.case_type_group) || (a.name || a.display_name).localeCompare(b.name || b.display_name)
+            );
 
         nonJudgeParts = [
             ...nonJudgeParts,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -252,7 +252,7 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
     }
 
     private sortEndpoints(): void {
-        this.endpoints = this.conference.endpoints.sort((a, b) => a.display_name.localeCompare(b.display_name));
+        this.endpoints = [...this.conference.endpoints].sort((a, b) => a.display_name.localeCompare(b.display_name));
     }
 
     get canInvite(): boolean {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8763


### Change description ###
Updates the sorting of participants within video web and makes it consistent across all rooms (waiting room, consultation room and hearing room).

- For each group in the hierarchy (panel members, staff members etc) order by display name
- Order non-judge participants by case group type (applicant, respondent etc) then by name, or if not available, display name. Keep interpretee above the interpreter, and QL participants at the bottom
- For the hearing room, order panel members by hearing role then name, to keep panel members together, and wingers together
- Display QL observers below observers
- Add test coverage for all rooms and test cases


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
