### PR TITLE
VIH-8788 - Update applicationinsights-web package to 2.7.3

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/package-lock.json
+++ b/VideoWeb/VideoWeb/ClientApp/package-lock.json
@@ -29,7 +29,7 @@
                 "@mediapipe/control_utils": "0.6.1629159505",
                 "@mediapipe/drawing_utils": "0.3.1620248257",
                 "@mediapipe/selfie_segmentation": "0.1.1632777926",
-                "@microsoft/applicationinsights-web": "^2.5.10",
+                "@microsoft/applicationinsights-web": "^2.7.3",
                 "@microsoft/signalr": "^3.1.20",
                 "@ministryofjustice/frontend": "^1.0.0",
                 "@ng-select/ng-select": "^5.0.15",
@@ -3156,90 +3156,113 @@
             "integrity": "sha512-OSGhYaZsdOXKyY0JCueOflq3ICLNMrBekI2V8vShum8wuoH3xjfEM6NnIujwJ5SlTdZEXi7Up2koOILDgQbWyg=="
         },
         "node_modules/@microsoft/applicationinsights-analytics-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.10.tgz",
-            "integrity": "sha512-NhqPLVv068xOgq6TcU2oo3xOSJc90/aFHFBOpzfm4v2aQdskspLjhrEfIPxbAVnw4DBf+LfQMC82oi0aV3iqrA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.7.3.tgz",
+            "integrity": "sha512-2MF3finxqyMDUzJDZwIkl/FUdOmIdYJg4A556bS3ILtPptsoAE6CvmenBL4qmIlscPIpwhjZ/qFEnxNHplH9OA==",
             "dependencies": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-channel-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.10.tgz",
-            "integrity": "sha512-Uq8lZ3M5oHcRYL31PZO5nRyS+iNQkPHXyjAxiNF1W8dtIfGC0Z3Du2N0LQPImq2vsQn5LmrTjMYtePPGYaozMw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.3.tgz",
+            "integrity": "sha512-LMrRycKHYKLYAxJeaKVvHrElslgGQqMyX43Q80qY6Wy8fY/g/RwPSDr3sbFaxZ4G2J7N74mjOR4wYsKfk4YNYA==",
             "dependencies": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-common": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.10.tgz",
-            "integrity": "sha512-5PKfFXAphA21qeUe0fcUYUi7e4UyN9EEddji1uHophJl0x4/xGWsSo/t4y30a4yd2h0X3sY2BpXUcRjK+abvNA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.7.3.tgz",
+            "integrity": "sha512-gbEbxCnpEJlFQeVG9DLpHYOgY2AYxczUSccaDicVMu/f8ci2NHxZylvBEfjPM3cVc+Ra2V/Bj4mqLH5fqSRW9A==",
             "dependencies": {
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3"
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.10.tgz",
-            "integrity": "sha512-Ie6bTfpiqXMxmt2b1qTdkpwhGmKl9w2aMMOh0cKOR3QDSK3UifrAMTcJ2gjlHV2CZSb9ib5FGcuLWcMV82OvmA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.7.3.tgz",
+            "integrity": "sha512-mJ2n86rwjVPiOoKDt7YcxKKSlg4S5ZCQSGMv2KNl5glL66mhMFxgZbYUakO39ZEkEXCsqk7Yi5jSfr7LMvQwtA==",
             "dependencies": {
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-dependencies-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.10.tgz",
-            "integrity": "sha512-nAXOywEDfwBtmO6zvYqc12SwPEC4wYH5GP4ofQV7e0c218cz32vjg8to5T5MqAbyyCPgPZTvcOCugqVx3UmG3g==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.7.3.tgz",
+            "integrity": "sha512-pq9obyTfkG5tGt0BQcBjSUUc1imLZ/N8UXQ6l8tfinKukTFk+X9BtajCkrXNA8xT7kMwAmlztgrY6ZWqahRj3A==",
             "dependencies": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-properties-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.10.tgz",
-            "integrity": "sha512-oCv1qU+kzTkDNBeZK9ApPmYE1n8psHXc7VitqAKF23u5dzYEi2u5UC4GwOBeWZDSS7tQ10fSjDtEMOWMd2k7vQ==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.7.3.tgz",
+            "integrity": "sha512-LdQ3kH8o+bqalMLBWIv/J4Jx3niuDzdcYF1kjRv45SouU7iredRkH8M9rBn6+FesVC0t2cDmqooJBWOuPb7PfA==",
             "dependencies": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-shims": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-1.0.3.tgz",
-            "integrity": "sha512-+S17aqEkOYpyBpmclhgwcEplwnxSo5AxYBdRg38GBobI1GKPSpZfnLssLzcjJ6XZCS5tqB5xjyTZs6gHj7ZJWQ=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
+            "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
         },
         "node_modules/@microsoft/applicationinsights-web": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.10.tgz",
-            "integrity": "sha512-uaY+Q8Tw1yKxVkBF144BE9l+fiexL+tMwRxgNTKoxKQiEgXHR5FoPqMhUfJ2kxCVJDVHa4LHdyQNXRZYtWsAQw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.7.3.tgz",
+            "integrity": "sha512-rHlFEQvW0KbAn4o2JcuJE2Qt73UeL7boKy4CGx5ixm3Lg/fEGQlu+b6r6wQvtuKOhGN563qe3PG2pUStcQPjbw==",
             "dependencies": {
-                "@microsoft/applicationinsights-analytics-js": "2.5.10",
-                "@microsoft/applicationinsights-channel-js": "2.5.10",
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-dependencies-js": "2.5.10",
-                "@microsoft/applicationinsights-properties-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-analytics-js": "2.7.3",
+                "@microsoft/applicationinsights-channel-js": "2.7.3",
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-dependencies-js": "2.7.3",
+                "@microsoft/applicationinsights-properties-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/dynamicproto-js": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.0.tgz",
-            "integrity": "sha512-pjcr+A6wTQHl/S4b5zQzeDMC6+9ekojCFHQAEYI4a8u9ZjWwbg4jmtO22CWEuRWWN/lBMjay9FKanlODWk5wqQ=="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz",
+            "integrity": "sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og=="
         },
         "node_modules/@microsoft/signalr": {
             "version": "3.1.20",
@@ -21008,90 +21031,92 @@
             "integrity": "sha512-OSGhYaZsdOXKyY0JCueOflq3ICLNMrBekI2V8vShum8wuoH3xjfEM6NnIujwJ5SlTdZEXi7Up2koOILDgQbWyg=="
         },
         "@microsoft/applicationinsights-analytics-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.10.tgz",
-            "integrity": "sha512-NhqPLVv068xOgq6TcU2oo3xOSJc90/aFHFBOpzfm4v2aQdskspLjhrEfIPxbAVnw4DBf+LfQMC82oi0aV3iqrA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.7.3.tgz",
+            "integrity": "sha512-2MF3finxqyMDUzJDZwIkl/FUdOmIdYJg4A556bS3ILtPptsoAE6CvmenBL4qmIlscPIpwhjZ/qFEnxNHplH9OA==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/applicationinsights-channel-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.10.tgz",
-            "integrity": "sha512-Uq8lZ3M5oHcRYL31PZO5nRyS+iNQkPHXyjAxiNF1W8dtIfGC0Z3Du2N0LQPImq2vsQn5LmrTjMYtePPGYaozMw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.7.3.tgz",
+            "integrity": "sha512-LMrRycKHYKLYAxJeaKVvHrElslgGQqMyX43Q80qY6Wy8fY/g/RwPSDr3sbFaxZ4G2J7N74mjOR4wYsKfk4YNYA==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/applicationinsights-common": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.10.tgz",
-            "integrity": "sha512-5PKfFXAphA21qeUe0fcUYUi7e4UyN9EEddji1uHophJl0x4/xGWsSo/t4y30a4yd2h0X3sY2BpXUcRjK+abvNA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.7.3.tgz",
+            "integrity": "sha512-gbEbxCnpEJlFQeVG9DLpHYOgY2AYxczUSccaDicVMu/f8ci2NHxZylvBEfjPM3cVc+Ra2V/Bj4mqLH5fqSRW9A==",
             "requires": {
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3"
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/applicationinsights-core-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.10.tgz",
-            "integrity": "sha512-Ie6bTfpiqXMxmt2b1qTdkpwhGmKl9w2aMMOh0cKOR3QDSK3UifrAMTcJ2gjlHV2CZSb9ib5FGcuLWcMV82OvmA==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.7.3.tgz",
+            "integrity": "sha512-mJ2n86rwjVPiOoKDt7YcxKKSlg4S5ZCQSGMv2KNl5glL66mhMFxgZbYUakO39ZEkEXCsqk7Yi5jSfr7LMvQwtA==",
             "requires": {
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/applicationinsights-dependencies-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.10.tgz",
-            "integrity": "sha512-nAXOywEDfwBtmO6zvYqc12SwPEC4wYH5GP4ofQV7e0c218cz32vjg8to5T5MqAbyyCPgPZTvcOCugqVx3UmG3g==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.7.3.tgz",
+            "integrity": "sha512-pq9obyTfkG5tGt0BQcBjSUUc1imLZ/N8UXQ6l8tfinKukTFk+X9BtajCkrXNA8xT7kMwAmlztgrY6ZWqahRj3A==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/applicationinsights-properties-js": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.10.tgz",
-            "integrity": "sha512-oCv1qU+kzTkDNBeZK9ApPmYE1n8psHXc7VitqAKF23u5dzYEi2u5UC4GwOBeWZDSS7tQ10fSjDtEMOWMd2k7vQ==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.7.3.tgz",
+            "integrity": "sha512-LdQ3kH8o+bqalMLBWIv/J4Jx3niuDzdcYF1kjRv45SouU7iredRkH8M9rBn6+FesVC0t2cDmqooJBWOuPb7PfA==",
             "requires": {
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3"
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/applicationinsights-shims": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-1.0.3.tgz",
-            "integrity": "sha512-+S17aqEkOYpyBpmclhgwcEplwnxSo5AxYBdRg38GBobI1GKPSpZfnLssLzcjJ6XZCS5tqB5xjyTZs6gHj7ZJWQ=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
+            "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
         },
         "@microsoft/applicationinsights-web": {
-            "version": "2.5.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.10.tgz",
-            "integrity": "sha512-uaY+Q8Tw1yKxVkBF144BE9l+fiexL+tMwRxgNTKoxKQiEgXHR5FoPqMhUfJ2kxCVJDVHa4LHdyQNXRZYtWsAQw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.7.3.tgz",
+            "integrity": "sha512-rHlFEQvW0KbAn4o2JcuJE2Qt73UeL7boKy4CGx5ixm3Lg/fEGQlu+b6r6wQvtuKOhGN563qe3PG2pUStcQPjbw==",
             "requires": {
-                "@microsoft/applicationinsights-analytics-js": "2.5.10",
-                "@microsoft/applicationinsights-channel-js": "2.5.10",
-                "@microsoft/applicationinsights-common": "2.5.10",
-                "@microsoft/applicationinsights-core-js": "2.5.10",
-                "@microsoft/applicationinsights-dependencies-js": "2.5.10",
-                "@microsoft/applicationinsights-properties-js": "2.5.10",
-                "@microsoft/applicationinsights-shims": "1.0.3",
-                "@microsoft/dynamicproto-js": "^1.1.0"
+                "@microsoft/applicationinsights-analytics-js": "2.7.3",
+                "@microsoft/applicationinsights-channel-js": "2.7.3",
+                "@microsoft/applicationinsights-common": "2.7.3",
+                "@microsoft/applicationinsights-core-js": "2.7.3",
+                "@microsoft/applicationinsights-dependencies-js": "2.7.3",
+                "@microsoft/applicationinsights-properties-js": "2.7.3",
+                "@microsoft/applicationinsights-shims": "2.0.1",
+                "@microsoft/dynamicproto-js": "^1.1.4"
             }
         },
         "@microsoft/dynamicproto-js": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.0.tgz",
-            "integrity": "sha512-pjcr+A6wTQHl/S4b5zQzeDMC6+9ekojCFHQAEYI4a8u9ZjWwbg4jmtO22CWEuRWWN/lBMjay9FKanlODWk5wqQ=="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz",
+            "integrity": "sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og=="
         },
         "@microsoft/signalr": {
             "version": "3.1.20",

--- a/VideoWeb/VideoWeb/ClientApp/package.json
+++ b/VideoWeb/VideoWeb/ClientApp/package.json
@@ -48,7 +48,7 @@
         "@mediapipe/control_utils": "0.6.1629159505",
         "@mediapipe/drawing_utils": "0.3.1620248257",
         "@mediapipe/selfie_segmentation": "0.1.1632777926",
-        "@microsoft/applicationinsights-web": "^2.5.10",
+        "@microsoft/applicationinsights-web": "^2.7.3",
         "@microsoft/signalr": "^3.1.20",
         "@ministryofjustice/frontend": "^1.0.0",
         "@ng-select/ng-select": "^5.0.15",

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
@@ -100,7 +100,7 @@ export class AppInsightsLoggerService implements LogAdapter {
 
         this.appInsights.trackTrace({ message, severityLevel: SeverityLevel.Error }, properties);
         this.appInsights.trackException({
-            error: err,
+            exception: err,
             properties: properties
         });
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8788

### Change description ###
Updates the microsoft/applicationinsights-web package to the latest version. This contains bug fixes to fix issues with the application insights logs not being fully populated for exceptions.

We also now pass "exception" rather than "error" to trackException as "error" has been deprecated.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
