### PR TITLE
VIH-8702 Fix for handraised status not persisting for 2nd host

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.spec.ts
@@ -82,26 +82,13 @@ describe('VideoControlCacheService', () => {
         }));
     });
 
-    describe('initHearingControlState', () => {
-        it('should load the hearing state for the current conference', fakeAsync(() => {
-            // Arrange
-            const conferenceId = 'conference-id';
-            const conference = { id: conferenceId } as ConferenceResponse;
-
-            const hearingControlsState: IHearingControlsState = { participantStates: {} };
-            // Act
-            currentConferenceSubject.next(conference);
-            flush();
-            service.initHearingControlState();
-
-            // Assert
-            expect(videoControlCacheStorageServiceSpy.loadHearingStateForConference).toHaveBeenCalledOnceWith(conferenceId);
-            expect(service['hearingControlStates']).toEqual(hearingControlsState);
-        }));
-    });
-
     describe('setSpotlightStatus', () => {
-        it('should add new value in the hearingControlStates and should update the cache', () => {
+        beforeEach(() => {
+            const dummyState: IHearingControlsState = { participantStates: {} };
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(dummyState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+        });
+        it('should add new value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -117,7 +104,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setSpotlightStatus(participantId, spotlight);
+            await service.setSpotlightStatus(participantId, spotlight);
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
             expect(videoControlCacheStorageServiceSpy.saveHearingStateForConference).toHaveBeenCalledOnceWith(
@@ -126,7 +113,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache', () => {
+        it('should update the value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -143,7 +130,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setSpotlightStatus(participantId, spotlight);
+            await service.setSpotlightStatus(participantId, spotlight);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -153,7 +140,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache and should retain existing property values', () => {
+        it('should update the value in the hearingControlStates and should update the cache and should retain existing property values', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -170,6 +157,9 @@ describe('VideoControlCacheService', () => {
                 isRemoteMuted: isRemoteMuted
             };
 
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(initialHearingControlsState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+
             const expectedHearingControlsState: IHearingControlsState = { participantStates: {} };
             expectedHearingControlsState.participantStates[participantId] = {
                 isLocalAudioMuted: isLocalAudioMuted,
@@ -180,10 +170,8 @@ describe('VideoControlCacheService', () => {
 
             getSpiedPropertyGetter(conferenceServiceSpy, 'currentConferenceId').and.returnValue(conferenceId);
 
-            service['hearingControlStates'] = initialHearingControlsState;
-
             // Act
-            service.setSpotlightStatus(participantId, isSpotlighted);
+            await service.setSpotlightStatus(participantId, isSpotlighted);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -193,7 +181,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should do nothing if the hearing control state is not initialised', () => {
+        it('should do nothing if the hearing control state is not initialised', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -204,7 +192,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = null;
 
             // Act
-            service.setSpotlightStatus(participantId, spotlight);
+            await service.setSpotlightStatus(participantId, spotlight);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(null);
@@ -272,7 +260,13 @@ describe('VideoControlCacheService', () => {
     });
 
     describe('setRemoteMuteStatus', () => {
-        it('should add new value in the hearingControlStates and should update the cache', () => {
+        beforeEach(() => {
+            const dummyState: IHearingControlsState = { participantStates: {} };
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(dummyState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+        });
+
+        it('should add new value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -288,7 +282,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setRemoteMutedStatus(participantId, remoteMuted);
+            await service.setRemoteMutedStatus(participantId, remoteMuted);
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
             expect(videoControlCacheStorageServiceSpy.saveHearingStateForConference).toHaveBeenCalledOnceWith(
@@ -297,7 +291,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache', () => {
+        it('should update the value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -314,7 +308,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setRemoteMutedStatus(participantId, remoteMuted);
+            await service.setRemoteMutedStatus(participantId, remoteMuted);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -324,7 +318,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache and should retain existing property values', () => {
+        it('should update the value in the hearingControlStates and should update the cache and should retain existing property values', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -339,6 +333,9 @@ describe('VideoControlCacheService', () => {
                 isRemoteMuted: !isRemoteMuted
             };
 
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(initialHearingControlsState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+
             const expectedHearingControlsState: IHearingControlsState = { participantStates: {} };
             expectedHearingControlsState.participantStates[participantId] = {
                 isLocalAudioMuted: isLocalAudioMuted,
@@ -348,10 +345,8 @@ describe('VideoControlCacheService', () => {
 
             getSpiedPropertyGetter(conferenceServiceSpy, 'currentConferenceId').and.returnValue(conferenceId);
 
-            service['hearingControlStates'] = initialHearingControlsState;
-
             // Act
-            service.setRemoteMutedStatus(participantId, isRemoteMuted);
+            await service.setRemoteMutedStatus(participantId, isRemoteMuted);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -361,7 +356,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should do nothing if the hearing control state is not initialised', () => {
+        it('should do nothing if the hearing control state is not initialised', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -372,7 +367,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = null;
 
             // Act
-            service.setRemoteMutedStatus(participantId, remoteMuted);
+            await service.setRemoteMutedStatus(participantId, remoteMuted);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(null);
@@ -439,7 +434,12 @@ describe('VideoControlCacheService', () => {
     });
 
     describe('setLocalAudioMuted', () => {
-        it('should add new value in the hearingControlStates and should update the cache', () => {
+        beforeEach(() => {
+            const dummyState: IHearingControlsState = { participantStates: {} };
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(dummyState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+        });
+        it('should add new value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -455,7 +455,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setLocalAudioMuted(participantId, isLocalAudioMuted, true);
+            await service.setLocalAudioMuted(participantId, isLocalAudioMuted, true);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -465,7 +465,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache', () => {
+        it('should update the value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -482,7 +482,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setLocalAudioMuted(participantId, isLocalAudioMuted, true);
+            await service.setLocalAudioMuted(participantId, isLocalAudioMuted, true);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -492,7 +492,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache and should retain existing propertie values', () => {
+        it('should update the value in the hearingControlStates and should update the cache and should retain existing propertie values', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -507,6 +507,9 @@ describe('VideoControlCacheService', () => {
                 isSpotlighted: isSpotlighted
             };
 
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(initialHearingControlsState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+
             const expectedHearingControlsState: IHearingControlsState = { participantStates: {} };
             expectedHearingControlsState.participantStates[participantId] = {
                 isLocalAudioMuted: isLocalAudioMuted,
@@ -516,10 +519,8 @@ describe('VideoControlCacheService', () => {
 
             getSpiedPropertyGetter(conferenceServiceSpy, 'currentConferenceId').and.returnValue(conferenceId);
 
-            service['hearingControlStates'] = initialHearingControlsState;
-
             // Act
-            service.setLocalAudioMuted(participantId, isLocalAudioMuted, true);
+            await service.setLocalAudioMuted(participantId, isLocalAudioMuted, true);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -529,7 +530,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should do nothing if the hearing control state is not initialised', () => {
+        it('should do nothing if the hearing control state is not initialised', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -540,7 +541,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = null;
 
             // Act
-            service.setLocalAudioMuted(participantId, isLocalVideoMuted);
+            await service.setLocalAudioMuted(participantId, isLocalVideoMuted);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(null);
@@ -607,7 +608,13 @@ describe('VideoControlCacheService', () => {
     });
 
     describe('setLocalVideoMuted', () => {
-        it('should add new value in the hearingControlStates and should update the cache', () => {
+        beforeEach(() => {
+            const dummyState: IHearingControlsState = { participantStates: {} };
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(dummyState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+        });
+
+        it('should add new value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -623,7 +630,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setLocalVideoMuted(participantId, isLocalVideoMuted, true);
+            await service.setLocalVideoMuted(participantId, isLocalVideoMuted, true);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -633,7 +640,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache', () => {
+        it('should update the value in the hearingControlStates and should update the cache', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -650,7 +657,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = initialHearingControlsState;
 
             // Act
-            service.setLocalVideoMuted(participantId, isLocalVideoMuted, true);
+            await service.setLocalVideoMuted(participantId, isLocalVideoMuted, true);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -660,7 +667,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should update the value in the hearingControlStates and should update the cache and should retain existing propertie values', () => {
+        it('should update the value in the hearingControlStates and should update the cache and should retain existing propertie values', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -677,6 +684,9 @@ describe('VideoControlCacheService', () => {
                 isRemoteMuted: isRemoteMuted
             };
 
+            videoControlCacheStorageServiceSpy.loadHearingStateForConference.and.returnValue(of(initialHearingControlsState));
+            service = new VideoControlCacheService(conferenceServiceSpy, videoControlCacheStorageServiceSpy, loggerServiceSpy);
+
             const expectedHearingControlsState: IHearingControlsState = { participantStates: {} };
             expectedHearingControlsState.participantStates[participantId] = {
                 isLocalAudioMuted: isLocalAudioMuted,
@@ -687,10 +697,8 @@ describe('VideoControlCacheService', () => {
 
             getSpiedPropertyGetter(conferenceServiceSpy, 'currentConferenceId').and.returnValue(conferenceId);
 
-            service['hearingControlStates'] = initialHearingControlsState;
-
             // Act
-            service.setLocalVideoMuted(participantId, isLocalAudioMuted, true);
+            await service.setLocalVideoMuted(participantId, isLocalAudioMuted, true);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
@@ -700,7 +708,7 @@ describe('VideoControlCacheService', () => {
             );
         });
 
-        it('should do nothing if the hearing control state is not initialised', () => {
+        it('should do nothing if the hearing control state is not initialised', async () => {
             // Arrange
             const conferenceId = 'conference-id';
             const participantId = 'participant-id';
@@ -711,7 +719,7 @@ describe('VideoControlCacheService', () => {
             service['hearingControlStates'] = null;
 
             // Act
-            service.setLocalVideoMuted(participantId, isLocalVideoMuted);
+            await service.setLocalVideoMuted(participantId, isLocalVideoMuted);
 
             // Assert
             expect(service['hearingControlStates']).toEqual(null);
@@ -777,7 +785,36 @@ describe('VideoControlCacheService', () => {
             expect(result).toBeFalse();
         });
     });
+    describe('clearHandRaiseStatusForAll', () => {
+        it('should update hearingControlStates for all participants to false and should update the cache sync changes true', () => {
+            // Arrange
+            const conferenceId = 'conference-id';
+            const handRaiseStatus = true;
+            const noOfParticipants = 10;
+            const initialHearingControlsState: IHearingControlsState = { participantStates: {} };
+            const expectedHearingControlsState: IHearingControlsState = { participantStates: {} };
+            for (let i = 0; i < noOfParticipants; i++) {
+                initialHearingControlsState.participantStates[i] = { isHandRaised: handRaiseStatus };
+            }
+            for (let i = 0; i < noOfParticipants; i++) {
+                expectedHearingControlsState.participantStates[i] = { isHandRaised: !handRaiseStatus };
+            }
 
+            getSpiedPropertyGetter(conferenceServiceSpy, 'currentConferenceId').and.returnValue(conferenceId);
+
+            service['hearingControlStates'] = initialHearingControlsState;
+
+            // Act
+            service.clearHandRaiseStatusForAll(conferenceId);
+
+            // Assert
+            expect(service['hearingControlStates']).toEqual(expectedHearingControlsState);
+            expect(videoControlCacheStorageServiceSpy.saveHearingStateForConference).toHaveBeenCalledOnceWith(
+                conferenceId,
+                expectedHearingControlsState
+            );
+        });
+    });
     describe('setHandRaiseStatus', () => {
         beforeEach(() => {
             const dummyState: IHearingControlsState = { participantStates: {} };

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
@@ -13,7 +13,7 @@ export class VideoControlCacheService {
     private hearingControlStates: IHearingControlsState | null = { participantStates: {} };
     private conferenceId: string;
 
-    initHearingState(){
+    initHearingState() {
         this.conferenceService.currentConference$.subscribe(conference => {
             if (!conference) {
                 this.logger.warn(`${this.loggerPrefix} No conference loaded. Skipping loading of hearing state for conference`);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
@@ -61,7 +61,6 @@ export class VideoControlCacheService {
     }
 
     async setSpotlightStatus(participantId: string, spotlightValue: boolean, syncChanges: boolean = true) {
-
         this.logger.info(`${this.loggerPrefix} Setting spotlight status.`, {
             participantId: participantId,
             oldValue: this.hearingControlStates?.participantStates[participantId]?.isSpotlighted ?? null,
@@ -75,7 +74,7 @@ export class VideoControlCacheService {
         const self = this;
         const setSpotlightStatusInCache = () => {
             if (!self.hearingControlStates.participantStates[participantId]) {
-                self.hearingControlStates.participantStates[participantId] = {isSpotlighted: spotlightValue};
+                self.hearingControlStates.participantStates[participantId] = { isSpotlighted: spotlightValue };
             } else {
                 self.hearingControlStates.participantStates[participantId].isSpotlighted = spotlightValue;
             }
@@ -127,7 +126,6 @@ export class VideoControlCacheService {
         });
         return this.hearingControlStates?.participantStates[participantId]?.isRemoteMuted ?? false;
     }
-
 
     clearHandRaiseStatusForAll(conferenceId: string, syncChanges: boolean = true) {
         if (!this.hearingControlStates?.participantStates) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache.service.ts
@@ -13,11 +13,7 @@ export class VideoControlCacheService {
     private hearingControlStates: IHearingControlsState | null = { participantStates: {} };
     private conferenceId: string;
 
-    constructor(
-        private conferenceService: ConferenceService,
-        private storageService: DistributedVideoControlCacheService,
-        private logger: LoggerService
-    ) {
+    initHearingState(){
         this.conferenceService.currentConference$.subscribe(conference => {
             if (!conference) {
                 this.logger.warn(`${this.loggerPrefix} No conference loaded. Skipping loading of hearing state for conference`);
@@ -34,6 +30,14 @@ export class VideoControlCacheService {
                     });
                 });
         });
+    }
+
+    constructor(
+        private conferenceService: ConferenceService,
+        private storageService: DistributedVideoControlCacheService,
+        private logger: LoggerService
+    ) {
+        this.initHearingState();
     }
 
     private reinitialiseHearingStatesBeforeUpdate(callback: Function) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -117,7 +117,10 @@ describe('HearingControlsBaseComponent', () => {
             'setHandRaiseStatusById'
         ]);
 
-        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlService', ['clearHandRaiseStatusForAll', 'setHandRaiseStatus']);
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlService', [
+            'clearHandRaiseStatusForAll',
+            'setHandRaiseStatus'
+        ]);
 
         const loggedInParticipantSubject = new BehaviorSubject<ParticipantModel>(
             ParticipantModel.fromParticipantForUserResponse(participantOne)

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -45,6 +45,7 @@ import { ConferenceStatusChanged } from 'src/app/services/conference/models/conf
 import { ConfigService } from 'src/app/services/api/config.service';
 import { FeatureFlagService } from 'src/app/services/feature-flag.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
+import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
 
 describe('HearingControlsBaseComponent', () => {
     const participantOneId = Guid.create().toString();
@@ -95,6 +96,7 @@ describe('HearingControlsBaseComponent', () => {
     let clientSettingsResponse: ClientSettingsResponse;
     let featureFlagServiceSpy: jasmine.SpyObj<FeatureFlagService>;
     let videoControlServiceSpy: jasmine.SpyObj<VideoControlService>;
+    let videoControlCacheSpy: jasmine.SpyObj<VideoControlCacheService>;
 
     beforeEach(() => {
         clientSettingsResponse = new ClientSettingsResponse({
@@ -114,6 +116,8 @@ describe('HearingControlsBaseComponent', () => {
             'setRemoteMuteStatusById',
             'setHandRaiseStatusById'
         ]);
+
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlService', ['clearHandRaiseStatusForAll']);
 
         const loggedInParticipantSubject = new BehaviorSubject<ParticipantModel>(
             ParticipantModel.fromParticipantForUserResponse(participantOne)
@@ -145,7 +149,8 @@ describe('HearingControlsBaseComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         conference = new ConferenceTestData().getConferenceNow();
         component.participant = globalParticipant;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -117,7 +117,7 @@ describe('HearingControlsBaseComponent', () => {
             'setHandRaiseStatusById'
         ]);
 
-        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlService', ['clearHandRaiseStatusForAll']);
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlService', ['clearHandRaiseStatusForAll', 'setHandRaiseStatus']);
 
         const loggedInParticipantSubject = new BehaviorSubject<ParticipantModel>(
             ParticipantModel.fromParticipantForUserResponse(participantOne)

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -45,7 +45,7 @@ import { ConferenceStatusChanged } from 'src/app/services/conference/models/conf
 import { ConfigService } from 'src/app/services/api/config.service';
 import { FeatureFlagService } from 'src/app/services/feature-flag.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
-import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
+import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 
 describe('HearingControlsBaseComponent', () => {
     const participantOneId = Guid.create().toString();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -363,18 +363,18 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     toggleHandRaised() {
         const toggleCacheValue = (handRaisedUpdateValue: boolean) => {
             this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue)
-                .then(()=>{
-                    if(this.participant.interpreter_room){
+                .then(() => {
+                    if (this.participant.interpreter_room) {
                         this.videoControlCacheService.setHandRaiseStatus(this.participant.interpreter_room.id, handRaisedUpdateValue);
                     }
                 });
-        }
+        };
         if (this.handRaised) {
-            toggleCacheValue(false)
+            toggleCacheValue(false);
             this.videoCallService.lowerHand(this.conferenceId, this.participant.id);
             this.logger.info(`${this.loggerPrefix} Participant lowered own hand`, this.logPayload);
         } else {
-            toggleCacheValue(true)
+            toggleCacheValue(true);
             this.videoCallService.raiseHand(this.conferenceId, this.participant.id);
             this.logger.info(`${this.loggerPrefix} Participant raised own hand`, this.logPayload);
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -242,9 +242,7 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(() => (this.sharingDynamicEvidence = false));
 
-        this.videoCallService
-            .onParticipantCreated()
-            .subscribe(() => this.newParticipantEnteredHandshake())
+        this.videoCallService.onParticipantCreated().subscribe(() => this.newParticipantEnteredHandshake());
     }
 
     handleScreenShareConnected(connectedScreenShare: ConnectedScreenshare): void {
@@ -469,7 +467,7 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     private newParticipantEnteredHandshake() {
-        //resend buzz current position for late joiner just incase cache is out of sync
+        // resend buzz current position for late joiner just incase cache is out of sync
         this.videoControlService.setHandRaiseStatusById(this.participant?.id, this.handRaised);
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -362,11 +362,8 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
 
     toggleHandRaised() {
         const toggleCacheValue = (handRaisedUpdateValue: boolean) => {
-            this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue).then(() => {
-                if (this.participant.interpreter_room) {
-                    this.videoControlCacheService.setHandRaiseStatus(this.participant.interpreter_room.id, handRaisedUpdateValue);
-                }
-            });
+            this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue);
+
         };
         if (this.handRaised) {
             toggleCacheValue(false);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -362,12 +362,11 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
 
     toggleHandRaised() {
         const toggleCacheValue = (handRaisedUpdateValue: boolean) => {
-            this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue)
-                .then(() => {
-                    if (this.participant.interpreter_room) {
-                        this.videoControlCacheService.setHandRaiseStatus(this.participant.interpreter_room.id, handRaisedUpdateValue);
-                    }
-                });
+            this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue).then(() => {
+                if (this.participant.interpreter_room) {
+                    this.videoControlCacheService.setHandRaiseStatus(this.participant.interpreter_room.id, handRaisedUpdateValue);
+                }
+            });
         };
         if (this.handRaised) {
             toggleCacheValue(false);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -363,7 +363,6 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     toggleHandRaised() {
         const toggleCacheValue = (handRaisedUpdateValue: boolean) => {
             this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue);
-
         };
         if (this.handRaised) {
             toggleCacheValue(false);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -241,6 +241,10 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
             .onVideoEvidenceStopped()
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(() => (this.sharingDynamicEvidence = false));
+
+        this.videoCallService
+            .onParticipantCreated()
+            .subscribe(() => this.newParticipantEnteredHandshake())
     }
 
     handleScreenShareConnected(connectedScreenShare: ConnectedScreenshare): void {
@@ -462,5 +466,10 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
         }
 
         return false;
+    }
+
+    private newParticipantEnteredHandshake() {
+        //resend buzz current position for late joiner just incase cache is out of sync
+        this.videoControlService.setHandRaiseStatusById(this.participant?.id, this.handRaised);
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -18,7 +18,7 @@ import { HearingRole } from '../models/hearing-role-model';
 import { ConnectedScreenshare, ParticipantUpdated, StoppedScreenshare } from '../models/video-call-models';
 import { VideoCallService } from '../services/video-call.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
-import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
+import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 
 @Injectable()
 export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -18,6 +18,7 @@ import { HearingRole } from '../models/hearing-role-model';
 import { ConnectedScreenshare, ParticipantUpdated, StoppedScreenshare } from '../models/video-call-models';
 import { VideoCallService } from '../services/video-call.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
+import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
 
 @Injectable()
 export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy {
@@ -63,7 +64,8 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
         protected participantService: ParticipantService,
         protected translateService: TranslateService,
         protected videoControlService: VideoControlService,
-        protected userMediaService: UserMediaService
+        protected userMediaService: UserMediaService,
+        protected videoControlCacheService: VideoControlCacheService
     ) {
         this.handRaised = false;
         this.remoteMuted = false;
@@ -136,7 +138,6 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
 
     onLoggedInParticipantChanged(participant: ParticipantModel): void {
         this.isSpotlighted = participant.isSpotlighted;
-
         this.participantSpotlightUpdateSubscription?.unsubscribe();
         this.participantSpotlightUpdateSubscription = this.participantService.onParticipantSpotlightStatusChanged$
             .pipe(filter(updatedParticipant => updatedParticipant.id === participant.id))
@@ -374,6 +375,7 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
 
     pause() {
         this.logger.debug(`${this.loggerPrefix} Attempting to pause hearing`, this.logPayload);
+        this.videoControlCacheService.clearHandRaiseStatusForAll(this.conferenceId);
         this.videoCallService.pauseHearing(this.conferenceId);
     }
 
@@ -395,6 +397,7 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
                     this.leaveHearing.emit();
                 });
             } else {
+                this.videoControlCacheService.clearHandRaiseStatusForAll(this.conferenceId);
                 this.videoCallService.suspendHearing(this.conferenceId);
             }
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -361,10 +361,20 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     toggleHandRaised() {
+        const toggleCacheValue = (handRaisedUpdateValue: boolean) => {
+            this.videoControlCacheService.setHandRaiseStatus(this.participant.id, handRaisedUpdateValue)
+                .then(()=>{
+                    if(this.participant.interpreter_room){
+                        this.videoControlCacheService.setHandRaiseStatus(this.participant.interpreter_room.id, handRaisedUpdateValue);
+                    }
+                });
+        }
         if (this.handRaised) {
+            toggleCacheValue(false)
             this.videoCallService.lowerHand(this.conferenceId, this.participant.id);
             this.logger.info(`${this.loggerPrefix} Participant lowered own hand`, this.logPayload);
         } else {
+            toggleCacheValue(true)
             this.videoCallService.raiseHand(this.conferenceId, this.participant.id);
             this.logger.info(`${this.loggerPrefix} Participant raised own hand`, this.logPayload);
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -150,7 +150,8 @@ describe('ParticipantsPanelComponent', () => {
             'getHandRaiseStatus',
             'setRemoteMutedStatus',
             'getRemoteMutedStatus',
-            'clearHandRaiseStatusForAll'
+            'clearHandRaiseStatusForAll',
+            'initHearingState'
         ]);
         remoteMuteServiceSpy = createParticipantRemoteMuteStoreServiceSpy();
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -150,7 +150,7 @@ describe('ParticipantsPanelComponent', () => {
             'getHandRaiseStatus',
             'setRemoteMutedStatus',
             'getRemoteMutedStatus',
-            'initHearingControlState'
+            'clearHandRaiseStatusForAll'
         ]);
         remoteMuteServiceSpy = createParticipantRemoteMuteStoreServiceSpy();
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -70,7 +70,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.conferenceId = this.route.snapshot.paramMap.get('conferenceId');
-        this.videoControlCacheService.initHearingControlState();
         this.getParticipantsList().then(() => {
             this.participants
                 .map(p => p.id)
@@ -531,6 +530,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         this.logger.debug(`${this.loggerPrefix} Judge is attempting to lower all hands in conference`, {
             conference: this.conferenceId
         });
+        this.videoControlCacheService.clearHandRaiseStatusForAll(this.conferenceId);
         this.videoCallService.lowerAllHands(this.conferenceId);
         this.participants
             .filter(x => x instanceof LinkedParticipantPanelModel)
@@ -546,6 +546,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
             participant: p.id,
             pexipParticipant: p.pexipId
         });
+        this.videoControlCacheService.setHandRaiseStatus(p.id, false);
         this.videoCallService.lowerHandById(p.pexipId, this.conferenceId, p.id);
         if (p instanceof LinkedParticipantPanelModel) {
             this.lowerLinkedParticipantHand(p);
@@ -554,6 +555,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     lowerLinkedParticipantHand(linkedParticipant: LinkedParticipantPanelModel) {
         linkedParticipant.participants.forEach(async p => {
+            await this.videoControlCacheService.setHandRaiseStatus(p.id, false);
             await this.eventService.publishParticipantHandRaisedStatus(this.conferenceId, p.id, false);
         });
     }
@@ -617,6 +619,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         });
 
         if (participant.hasHandRaised()) {
+            this.videoControlCacheService.setHandRaiseStatus(participant.id, false);
             this.lowerParticipantHand(participant);
         }
         if (participant.hasSpotlight()) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -543,12 +543,11 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
             pexipParticipant: p.pexipId
         });
         this.videoCallService.lowerHandById(p.pexipId, this.conferenceId, p.id);
-        this.videoControlCacheService.setHandRaiseStatus(p.id, false)
-            .then(() => {
-                if (p instanceof LinkedParticipantPanelModel) {
-                    this.lowerLinkedParticipantHand(p);
-                }
-            });
+        this.videoControlCacheService.setHandRaiseStatus(p.id, false).then(() => {
+            if (p instanceof LinkedParticipantPanelModel) {
+                this.lowerLinkedParticipantHand(p);
+            }
+        });
     }
 
     lowerLinkedParticipantHand(linkedParticipant: LinkedParticipantPanelModel) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -543,17 +543,16 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
             pexipParticipant: p.pexipId
         });
         this.videoCallService.lowerHandById(p.pexipId, this.conferenceId, p.id);
-        this.videoControlCacheService.setHandRaiseStatus(p.id, false).then(() => {
-            if (p instanceof LinkedParticipantPanelModel) {
-                this.lowerLinkedParticipantHand(p);
-            }
-        });
+        this.videoControlCacheService.setHandRaiseStatus(p.id, false);
+        if (p instanceof LinkedParticipantPanelModel) {
+            this.lowerLinkedParticipantHand(p);
+        }
     }
 
     lowerLinkedParticipantHand(linkedParticipant: LinkedParticipantPanelModel) {
         linkedParticipant.participants.forEach(async p => {
-            await this.videoControlCacheService.setHandRaiseStatus(p.id, false);
             await this.eventService.publishParticipantHandRaisedStatus(this.conferenceId, p.id, false);
+            this.videoControlCacheService.setHandRaiseStatus(p.id, false);
         });
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
@@ -42,7 +42,7 @@ import { fakeAsync, flush } from '@angular/core/testing';
 import { ConfigService } from 'src/app/services/api/config.service';
 import { FeatureFlagService } from 'src/app/services/feature-flag.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
-import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
+import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 
 describe('PrivateConsultationRoomControlsComponent', () => {
     const participantOneId = Guid.create().toString();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
@@ -42,6 +42,7 @@ import { fakeAsync, flush } from '@angular/core/testing';
 import { ConfigService } from 'src/app/services/api/config.service';
 import { FeatureFlagService } from 'src/app/services/feature-flag.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
+import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
 
 describe('PrivateConsultationRoomControlsComponent', () => {
     const participantOneId = Guid.create().toString();
@@ -88,6 +89,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
     let clientSettingsResponse: ClientSettingsResponse;
     let featureFlagServiceSpy: jasmine.SpyObj<FeatureFlagService>;
     let videoControlServiceSpy: jasmine.SpyObj<VideoControlService>;
+    let videoControlCacheSpy: jasmine.SpyObj<VideoControlCacheService>;
 
     beforeAll(() => {
         featureFlagServiceSpy = jasmine.createSpyObj<FeatureFlagService>('FeatureFlagService', ['getFeatureFlagByName']);
@@ -112,7 +114,10 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             'setRemoteMuteStatusById',
             'setHandRaiseStatusById'
         ]);
-
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', [
+            'setSpotlightStatus',
+            'clearHandRaiseStatusForAll'
+        ]);
         userMediaServiceSpy = jasmine.createSpyObj<UserMediaService>([], ['isAudioOnly$']);
         isAudioOnlySubject = new Subject<boolean>();
         getSpiedPropertyGetter(userMediaServiceSpy, 'isAudioOnly$').and.returnValue(isAudioOnlySubject.asObservable());
@@ -137,7 +142,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         component.participant = globalParticipant;
         component.conferenceId = gloalConference.id;
@@ -246,7 +252,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         expect(_component.enableDynamicEvidenceSharing).toBe(false);
     });
@@ -270,7 +277,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         expect(_component.enableDynamicEvidenceSharing).toBe(true);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
@@ -116,7 +116,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         ]);
         videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', [
             'setSpotlightStatus',
-            'clearHandRaiseStatusForAll'
+            'clearHandRaiseStatusForAll',
+            'setHandRaiseStatus'
         ]);
         userMediaServiceSpy = jasmine.createSpyObj<UserMediaService>([], ['isAudioOnly$']);
         isAudioOnlySubject = new Subject<boolean>();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
@@ -14,7 +14,7 @@ import { UserMediaService } from 'src/app/services/user-media.service';
 import { HearingControlsBaseComponent } from '../hearing-controls/hearing-controls-base.component';
 import { VideoCallService } from '../services/video-call.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
-import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
+import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 
 @Component({
     selector: 'app-private-consultation-room-controls',

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
@@ -14,6 +14,7 @@ import { UserMediaService } from 'src/app/services/user-media.service';
 import { HearingControlsBaseComponent } from '../hearing-controls/hearing-controls-base.component';
 import { VideoCallService } from '../services/video-call.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
+import {VideoControlCacheService} from '../../services/conference/video-control-cache.service';
 
 @Component({
     selector: 'app-private-consultation-room-controls',
@@ -51,7 +52,8 @@ export class PrivateConsultationRoomControlsComponent extends HearingControlsBas
         protected userMediaService: UserMediaService,
         conferenceService: ConferenceService,
         configSerivce: ConfigService,
-        featureFlagService: FeatureFlagService
+        featureFlagService: FeatureFlagService,
+        protected videoControlCacheService: VideoControlCacheService
     ) {
         super(
             videoCallService,
@@ -61,7 +63,8 @@ export class PrivateConsultationRoomControlsComponent extends HearingControlsBas
             participantService,
             translateService,
             videoControlService,
-            userMediaService
+            userMediaService,
+            videoControlCacheService
         );
         this.canToggleParticipantsPanel = true;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
Updated all cache control service SET functions, to first reinitialise the hearing control state, then pass their update in as a callback, to ensure update to cache is in sync first. Also added new 'clearHandRaiseStatusForAll' function that clears the hand raise status in the cache for all participants. This is also called when pausing or suspending a hearing, as cache will become out of sync, when next pexip connection is made when restarting the hearing and control states are reset. Also added supporting tests.
Finally added a Handshake function, that subscribes to a new participant joining, this is to force an interaction with a second host and make sure they receive a ParticipantUpdate request from each participant when they join, to cover the off chance that the cache is still slightly out of sync.


### Change description ###
[VIH-8702](https://tools.hmcts.net/jira/browse/VIH-8702)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
