### PR TITLE
VIH-8774 Fix for production validation errors

### DIFF
--- a/VideoWeb/VideoWeb/Extensions/ConfigureAuthSchemeExtensions.cs
+++ b/VideoWeb/VideoWeb/Extensions/ConfigureAuthSchemeExtensions.cs
@@ -148,24 +148,18 @@ namespace VideoWeb.Extensions
             foreach (var scheme in schemes.SelectMany(s => s.GetProviderSchemes()))
             {
                 options.AddPolicy(scheme, new AuthorizationPolicyBuilder()
+               .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
                .RequireAuthenticatedUser()
-               .RequireRole(allRoles)
-               .AddAuthenticationSchemes(scheme)
+               .RequireRole(allRoles)               
                .Build());
             }
 
             foreach (var policy in rolePolicies)
             {
                 var policyBuilder = new AuthorizationPolicyBuilder()
+                .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
                 .RequireAuthenticatedUser()
                 .RequireRole(policy.Value);
-
-                // TODO: These didnt use to include the EventHubSchemes but should they have?
-                foreach (var schemeName in schemes.Select(s => s.SchemeName))
-                {
-                    policyBuilder = policyBuilder.AddAuthenticationSchemes(schemeName);
-                }
-
                 options.AddPolicy(policy.Key, policyBuilder.Build());
             }
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8774


### Change description ###
Fix for production validation errors.
This was happening because we are trying to authenticate the request against every registered scheme applied to a policy. The issue arose because we use more than one JWT and only one can be used on any given request.
This fix means every time the authorization policy is hit, it will execute one of the schemes based on the content of the token.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
