### PR TITLE
VIH-8805 Add missing translations for war pensions appeals

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
@@ -1125,7 +1125,9 @@
     "secretaryofstate": "Ysgrifennydd Gwladol",
     "trafficcommissioner": "Y Comisiynydd Traffig",
     "elaas": "Cynllun Cynghori ar Apeliadau Cyfraith Cyflogaeth",
-    "presentingofficer":"Swyddog Cyflwyno"
+    "presentingofficer":"Swyddog Cyflwyno",
+    "inabsence": "Mewn absenoldeb",
+    "vetsuk": "Vets UK"
   },
   "venue-list": {
     "title": "Dewis eich gwrandawiadau",

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
@@ -742,7 +742,9 @@
     "secretaryofstate": "Secretary of State",
     "trafficcommissioner": "Traffic Commissioner",
     "elaas": "ELAAS",
-    "presentingofficer":"Presenting Officer"
+    "presentingofficer":"Presenting Officer",
+    "inabsence": "In absence",
+    "vetsuk": "Vets UK"
   },
   "case-type": {
     "adoption": "Adoption",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8805


### Change description ###
Adds missing translations for the new case role groups.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
