### PR TITLE
VIH-8861 video control states not persisting(vmr)

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -152,8 +152,7 @@ describe('HearingControlsBaseComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy,
-            videoControlCacheSpy
+            featureFlagServiceSpy
         );
         conference = new ConferenceTestData().getConferenceNow();
         component.participant = globalParticipant;
@@ -358,7 +357,7 @@ describe('HearingControlsBaseComponent', () => {
     it('should raise hand on toggle if hand not raised', () => {
         component.handRaised = false;
         component.toggleHandRaised();
-        expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
+        //expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.lower-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -366,7 +365,7 @@ describe('HearingControlsBaseComponent', () => {
     it('should lower hand on toggle if hand raised', () => {
         component.handRaised = true;
         component.toggleHandRaised();
-        expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
+        //expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.raise-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, flush } from '@angular/core/testing';
+import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { Guid } from 'guid-typescript';
 import { BehaviorSubject, Observable, of, Subject, Subscription } from 'rxjs';
 import {
@@ -117,10 +117,7 @@ describe('HearingControlsBaseComponent', () => {
             'setHandRaiseStatusById'
         ]);
 
-        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlService', [
-            'clearHandRaiseStatusForAll',
-            'setHandRaiseStatus'
-        ]);
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', ['setHandRaiseStatus']);
 
         const loggedInParticipantSubject = new BehaviorSubject<ParticipantModel>(
             ParticipantModel.fromParticipantForUserResponse(participantOne)
@@ -152,7 +149,8 @@ describe('HearingControlsBaseComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         conference = new ConferenceTestData().getConferenceNow();
         component.participant = globalParticipant;
@@ -357,7 +355,7 @@ describe('HearingControlsBaseComponent', () => {
     it('should raise hand on toggle if hand not raised', () => {
         component.handRaised = false;
         component.toggleHandRaised();
-        // expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
+        expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.lower-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -365,7 +363,7 @@ describe('HearingControlsBaseComponent', () => {
     it('should lower hand on toggle if hand raised', () => {
         component.handRaised = true;
         component.toggleHandRaised();
-        // expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
+        expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.raise-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -946,4 +944,21 @@ describe('HearingControlsBaseComponent', () => {
             expect(isAnotherHostInHearing).toBeFalse();
         });
     });
+
+    it('should send handshake update, when new participant joins', fakeAsync(() => {
+        // Arrange
+        const participantStatusMessage = new ParticipantStatusMessage(
+            'participantId',
+            'userName',
+            'participantId',
+            ParticipantStatus.InHearing
+        );
+        spyOn(component, 'publishMediaDeviceStatus');
+        // act
+        component.handleParticipantStatusChange(participantStatusMessage);
+        tick(3000);
+        // expect
+        expect(component.publishMediaDeviceStatus).toHaveBeenCalled();
+        expect(eventsService.publishParticipantHandRaisedStatus).toHaveBeenCalled();
+    }));
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -357,7 +357,7 @@ describe('HearingControlsBaseComponent', () => {
     it('should raise hand on toggle if hand not raised', () => {
         component.handRaised = false;
         component.toggleHandRaised();
-        //expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
+        // expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.lower-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -365,7 +365,7 @@ describe('HearingControlsBaseComponent', () => {
     it('should lower hand on toggle if hand raised', () => {
         component.handRaised = true;
         component.toggleHandRaised();
-        //expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
+        // expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.raise-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -268,21 +268,20 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     private async newParticipantEnteredHandshake(newParticipantEntered) {
-
         this.logger.info(`${this.loggerPrefix} Waiting 3 seconds before sending handshake`);
-        if(this.participant.hearing_role != HearingRole.JUDGE && this.participant.hearing_role != HearingRole.STAFF_MEMBER){
-            await setTimeout(()=>{
+        if (this.participant.hearing_role !== HearingRole.JUDGE && this.participant.hearing_role !== HearingRole.STAFF_MEMBER) {
+            await setTimeout(() => {
                 this.logger.info(`${this.loggerPrefix} Sending handshake for entry of: ${newParticipantEntered}`);
-                this.publishMediaDeviceStatus().then(()=>{
-                    this.eventService.publishParticipantHandRaisedStatus(this.conferenceId, this.participant.id, this.handRaised)
+                this.publishMediaDeviceStatus().then(() => {
+                    this.eventService.publishParticipantHandRaisedStatus(this.conferenceId, this.participant.id, this.handRaised);
                 });
-            }, 3000) //3Seconds: Give 2nd host time initialise participants, before receiving status updates
+            }, 3000); // 3Seconds: Give 2nd host time initialise participants, before receiving status updates
         }
     }
 
     async handleParticipantStatusChange(message: ParticipantStatusMessage) {
         if (message.participantId !== this.participant.id) {
-            if(message.status === ParticipantStatus.InHearing) {
+            if (message.status === ParticipantStatus.InHearing) {
                 await this.newParticipantEnteredHandshake(message.username);
             }
             return;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -166,7 +166,7 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
                     this.participantRemoteMuteStoreService.updateLocalMuteStatus(
                         participantStatusMessage.participantId,
                         participantStatusMessage.mediaStatus.is_local_audio_muted,
-                        participantStatusMessage.mediaStatus.is_local_video_muted,
+                        participantStatusMessage.mediaStatus.is_local_video_muted
                     );
                 }
             });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -130,7 +130,7 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
         this.unloadDetectorService.shouldUnload.pipe(takeUntil(this.destroyedSubject)).subscribe(() => this.onShouldUnload());
         this.unloadDetectorService.shouldReload.pipe(take(1)).subscribe(() => this.onShouldReload());
 
-        this.initialiseVideoControlCacheLogic();
+        this.initConferenceStatusLogic();
 
         this.videoCallService
             .onParticipantCreated()
@@ -163,20 +163,10 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(participantStatusMessage => {
                 if (participantStatusMessage.conferenceId === this.conference.id) {
-                    this.videoControlCacheService.setLocalAudioMuted(
-                        participantStatusMessage.participantId,
-                        participantStatusMessage.mediaStatus.is_local_audio_muted
-                    );
-
-                    this.videoControlCacheService.setLocalVideoMuted(
-                        participantStatusMessage.participantId,
-                        participantStatusMessage.mediaStatus.is_local_video_muted
-                    );
-
                     this.participantRemoteMuteStoreService.updateLocalMuteStatus(
                         participantStatusMessage.participantId,
                         participantStatusMessage.mediaStatus.is_local_audio_muted,
-                        participantStatusMessage.mediaStatus.is_local_video_muted
+                        participantStatusMessage.mediaStatus.is_local_video_muted,
                     );
                 }
             });
@@ -191,20 +181,6 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
                 if (this.conference.audio_recording_required) {
                     this.initAudioRecordingInterval();
                 }
-
-                this.conference.participants
-                    .map(participant => participant.id)
-                    .forEach(participantId => {
-                        const audio = this.videoControlCacheService.getLocalAudioMuted(participantId);
-                        const video = this.videoControlCacheService.getLocalVideoMuted(participantId);
-                        this.logger.info(`${this.loggerPrefixJudge} Updating store with audio and video`, {
-                            audio: audio,
-                            video: video,
-                            participantId: participantId
-                        });
-
-                        this.participantRemoteMuteStoreService.updateLocalMuteStatus(participantId, audio, video);
-                    });
             });
         } catch (error) {
             this.logger.error(`${this.loggerPrefixJudge} Failed to initialise the judge waiting room`, error);
@@ -212,7 +188,6 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
             this.errorService.handlePexipError(new CallError(error.name), conferenceId);
         }
     }
-
     assignPexipIdToRemoteStore(participant: ParticipantUpdated): void {
         const participantDisplayName = PexipDisplayNameModel.fromString(participant.pexipDisplayName);
         if (participant.uuid && participantDisplayName !== null) {
@@ -232,7 +207,7 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
         this.cleanUp();
     }
 
-    private initialiseVideoControlCacheLogic() {
+    private initConferenceStatusLogic() {
         this.hearingCountdownFinishedSubscription = this.eventService.getHearingCountdownCompleteMessage().subscribe(() => {
             this.conferenceStatusChangedSubscription?.unsubscribe();
             this.conferenceStatusChangedSubscription = this.conferenceService.onCurrentConferenceStatusChanged$.subscribe(

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -228,32 +228,6 @@ describe('ParticipantsPanelComponent', () => {
         component.ngOnDestroy();
     });
 
-    const conferenceStatusStatuses = [
-        { status: ConferenceStatus.NotStarted },
-        { status: ConferenceStatus.InSession },
-        { status: ConferenceStatus.Suspended },
-        { status: ConferenceStatus.Paused }
-    ];
-    /*
-    conferenceStatusStatuses.forEach(c => {
-        it(`should reset the remote mute status of the participants in the component store for a ${c.status} hearing`, fakeAsync(() => {
-            const response = new ConferenceResponse({ status: c.status });
-            videoWebServiceSpy.getConferenceById.and.returnValue(Promise.resolve(response));
-            videoWebServiceSpy.getParticipantsByConferenceId.and.returnValue(Promise.resolve(participants));
-            videoWebServiceSpy.getEndpointsForConference.and.returnValue(Promise.resolve(endpoints));
-            const mappedParticipants = mapper.mapFromParticipantUserResponseArray(participants);
-            participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedParticipants);
-
-            component.ngOnInit();
-            flushMicrotasks();
-            component.participants
-                .map(p => p.id)
-                .forEach(participantId =>
-                    expect(videoControlCacheServiceSpy.setRemoteMutedStatus).toHaveBeenCalledWith(participantId, false)
-                );
-        }));
-    });*/
-
     it('should get participant sorted list, the judge is first, then panel members and finally observers are the last one', fakeAsync(() => {
         const response = new ConferenceResponse({ status: ConferenceStatus.NotStarted });
         videoWebServiceSpy.getConferenceById.and.returnValue(Promise.resolve(response));
@@ -287,100 +261,7 @@ describe('ParticipantsPanelComponent', () => {
 
         expect(logger.error).toHaveBeenCalled();
     });
-    /*
-    describe('readVideoControlStatusesFromCache', () => {
-        const pexipId = 'pexip-id';
-        let participant: PanelModel;
-        let state: IConferenceParticipantsStatus;
-        beforeEach(() => {
-            participant = component.participants[0];
-            state = {
-                [participant.id]: { isLocalAudioMuted: true, isLocalVideoMuted: true, isRemoteMuted: true, pexipId: pexipId }
-            };
-        });
-        it('should NOT call to get the video control statuses from the cache if the countdown timer is not completed', fakeAsync(() => {
-            // Arrange
-            component.isCountdownCompleted = false;
-            // Act
-            component.readVideoControlStatusesFromCache(state, participant);
-            // Assert
-            expect(videoControlCacheServiceSpy.getLocalAudioMuted).not.toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getLocalVideoMuted).not.toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getRemoteMutedStatus).not.toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getHandRaiseStatus).not.toHaveBeenCalled();
-        }));
-        it('should call to get the video control statuses from the cache if the countdown timer is completed', fakeAsync(() => {
-            // Arrange
-            component.isCountdownCompleted = true;
-            // Act
-            component.readVideoControlStatusesFromCache(state, participant);
-            // Assert
-            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getLocalVideoMuted).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getRemoteMutedStatus).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getHandRaiseStatus).toHaveBeenCalled();
-        }));
-        it('should call to get the video control statuses from the cache if the countdown timer is completed for a LinkedParticipant', fakeAsync(() => {
-            // Arrange
-            const linkedParticipant = component.participants.find(
-                p => p instanceof LinkedParticipantPanelModel
-            ) as LinkedParticipantPanelModel;
-            component.isCountdownCompleted = true;
-            const remoteMuteStatus = true;
-            const localAudioMuted = false;
-            const localVideoMuted = false;
-            spyOn(logger, 'info');
-            videoControlCacheServiceSpy.getRemoteMutedStatus.and.returnValue(remoteMuteStatus);
-            videoControlCacheServiceSpy.getLocalAudioMuted.and.returnValue(localAudioMuted);
-            videoControlCacheServiceSpy.getLocalVideoMuted.and.returnValue(localVideoMuted);
-            // Act
-            component.readVideoControlStatusesFromCache(state, linkedParticipant);
-            // Assert
-            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalledWith(linkedParticipant.participants[0].id);
-            expect(videoControlCacheServiceSpy.getLocalVideoMuted).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getRemoteMutedStatus).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getHandRaiseStatus).toHaveBeenCalled();
-            expect(logger.info).toHaveBeenCalled();
-            expect(remoteMuteServiceSpy.updateRemoteMuteStatus).toHaveBeenCalledWith(
-                linkedParticipant.participants[0].id,
-                remoteMuteStatus
-            );
-            expect(remoteMuteServiceSpy.updateLocalMuteStatus).toHaveBeenCalledWith(
-                linkedParticipant.participants[0].id,
-                localAudioMuted,
-                localVideoMuted
-            );
-            expect(remoteMuteServiceSpy.updateRemoteMuteStatus).not.toHaveBeenCalledWith(linkedParticipant.id, remoteMuteStatus);
-            expect(remoteMuteServiceSpy.updateLocalMuteStatus).not.toHaveBeenCalledWith(
-                linkedParticipant.id,
-                localAudioMuted,
-                localVideoMuted
-            );
-        }));
 
-        it('should call to get the video control statuses from the cache if the countdown timer is completed for a Participant', fakeAsync(() => {
-            // Arrange
-            component.isCountdownCompleted = true;
-            const remoteMuteStatus = true;
-            const localAudioMuted = false;
-            const localVideoMuted = false;
-            spyOn(logger, 'info');
-            videoControlCacheServiceSpy.getRemoteMutedStatus.and.returnValue(remoteMuteStatus);
-            videoControlCacheServiceSpy.getLocalAudioMuted.and.returnValue(localAudioMuted);
-            videoControlCacheServiceSpy.getLocalVideoMuted.and.returnValue(localVideoMuted);
-            // Act
-            component.readVideoControlStatusesFromCache(state, participant);
-            // Assert
-            expect(videoControlCacheServiceSpy.getLocalAudioMuted).toHaveBeenCalledWith(participant.id);
-            expect(videoControlCacheServiceSpy.getLocalVideoMuted).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getRemoteMutedStatus).toHaveBeenCalled();
-            expect(videoControlCacheServiceSpy.getHandRaiseStatus).toHaveBeenCalled();
-            expect(logger.info).not.toHaveBeenCalled();
-            expect(remoteMuteServiceSpy.updateRemoteMuteStatus).toHaveBeenCalledWith(participant.id, remoteMuteStatus);
-            expect(remoteMuteServiceSpy.updateLocalMuteStatus).toHaveBeenCalledWith(participant.id, localAudioMuted, localVideoMuted);
-        }));
-    });
-*/
     describe('conferenceParticipantsStatusSubject updated', () => {
         it('should get the remote mute state from the remote mute status service', fakeAsync(() => {
             // Arrange
@@ -957,7 +838,7 @@ describe('ParticipantsPanelComponent', () => {
 
     it('should lower hand for all participants', () => {
         component.lowerAllHands();
-        expect(videocallService.lowerHandById).toHaveBeenCalled();
+        expect(videocallService.lowerAllHands).toHaveBeenCalled();
     });
     it('should lower hand of participant', () => {
         const pat = component.participants[0];

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -73,7 +73,6 @@ import { VideoCallService } from '../services/video-call.service';
 import { ParticipantsPanelComponent } from './participants-panel.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { RoomNamePipe } from 'src/app/shared/pipes/room-name.pipe';
-import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 
 describe('ParticipantsPanelComponent', () => {
     const testData = new ConferenceTestData();
@@ -82,7 +81,6 @@ describe('ParticipantsPanelComponent', () => {
     participants = participants.concat(testData.getListOfLinkedParticipants().concat(testData.getListOfLinkedParticipants(true)));
     const endpoints = testData.getListOfEndpoints();
     const videoCallTestData = new VideoCallTestData();
-    let videoControlCacheServiceSpy: jasmine.SpyObj<VideoControlCacheService>;
     let videoWebServiceSpy: jasmine.SpyObj<VideoWebService>;
     videoWebServiceSpy = jasmine.createSpyObj('VideoWebService', [
         'getParticipantsByConferenceId',
@@ -139,20 +137,6 @@ describe('ParticipantsPanelComponent', () => {
             'mapFromParticipantUserResponseArray'
         ]);
         spyOnProperty(participantServiceSpy, 'onParticipantsUpdated$').and.returnValue(participantsUpdatedSubject.asObservable());
-        videoControlCacheServiceSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', [
-            'setSpotlightStatus',
-            'getSpotlightStatus',
-            'setLocalVideoMuted',
-            'getLocalVideoMuted',
-            'setLocalAudioMuted',
-            'getLocalAudioMuted',
-            'setHandRaiseStatus',
-            'getHandRaiseStatus',
-            'setRemoteMutedStatus',
-            'getRemoteMutedStatus',
-            'clearHandRaiseStatusForAll',
-            'initHearingState'
-        ]);
         remoteMuteServiceSpy = createParticipantRemoteMuteStoreServiceSpy();
 
         await TestBed.configureTestingModule({
@@ -172,10 +156,6 @@ describe('ParticipantsPanelComponent', () => {
                 {
                     provide: VideoWebService,
                     useValue: videoWebServiceSpy
-                },
-                {
-                    provide: VideoControlCacheService,
-                    useValue: videoControlCacheServiceSpy
                 },
                 {
                     provide: ActivatedRoute,
@@ -254,6 +234,7 @@ describe('ParticipantsPanelComponent', () => {
         { status: ConferenceStatus.Suspended },
         { status: ConferenceStatus.Paused }
     ];
+    /*
     conferenceStatusStatuses.forEach(c => {
         it(`should reset the remote mute status of the participants in the component store for a ${c.status} hearing`, fakeAsync(() => {
             const response = new ConferenceResponse({ status: c.status });
@@ -271,7 +252,7 @@ describe('ParticipantsPanelComponent', () => {
                     expect(videoControlCacheServiceSpy.setRemoteMutedStatus).toHaveBeenCalledWith(participantId, false)
                 );
         }));
-    });
+    });*/
 
     it('should get participant sorted list, the judge is first, then panel members and finally observers are the last one', fakeAsync(() => {
         const response = new ConferenceResponse({ status: ConferenceStatus.NotStarted });
@@ -306,6 +287,7 @@ describe('ParticipantsPanelComponent', () => {
 
         expect(logger.error).toHaveBeenCalled();
     });
+    /*
     describe('readVideoControlStatusesFromCache', () => {
         const pexipId = 'pexip-id';
         let participant: PanelModel;
@@ -398,7 +380,7 @@ describe('ParticipantsPanelComponent', () => {
             expect(remoteMuteServiceSpy.updateLocalMuteStatus).toHaveBeenCalledWith(participant.id, localAudioMuted, localVideoMuted);
         }));
     });
-
+*/
     describe('conferenceParticipantsStatusSubject updated', () => {
         it('should get the remote mute state from the remote mute status service', fakeAsync(() => {
             // Arrange
@@ -975,7 +957,7 @@ describe('ParticipantsPanelComponent', () => {
 
     it('should lower hand for all participants', () => {
         component.lowerAllHands();
-        expect(videocallService.lowerAllHands).toHaveBeenCalled();
+        expect(videocallService.lowerHandById).toHaveBeenCalled();
     });
     it('should lower hand of participant', () => {
         const pat = component.participants[0];

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -475,7 +475,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         this.logger.debug(`${this.loggerPrefix} Judge is attempting to lower all hands in conference`, {
             conference: this.conferenceId
         });
-        //ClearAllBuzz Pexip command currently does not seem to ping VMR participant handlers.
+        //ClearAllBuzz Pexip command currently does not signal VMR participant ParticipantUpdated event handlers.
         //this.videoCallService.lowerAllHands(this.conferenceId);
         this.participants.forEach(async participant =>{
             await this.lowerParticipantHand(participant)

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -504,7 +504,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         });
     }
 
-    async lowerParticipantHand(participant: PanelModel) {
+    lowerParticipantHand(participant: PanelModel) {
         const p = this.participants.find(x => x.id === participant.id);
         this.logger.debug(`${this.loggerPrefix} Judge is attempting to lower hand for participant`, {
             conference: this.conferenceId,
@@ -513,7 +513,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         });
         this.videoCallService.lowerHandById(p.pexipId, this.conferenceId, p.id);
         if (p instanceof LinkedParticipantPanelModel) {
-            await this.lowerLinkedParticipantHand(p);
+            this.lowerLinkedParticipantHand(p);
         }
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -89,7 +89,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                         state[participant.id]?.isLocalVideoMuted
                     );
                 });
-            })
+            });
             this.setupVideoCallSubscribers();
             this.setupEventhubSubscribers();
         });
@@ -471,15 +471,15 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         }
     }
 
-     lowerAllHands() {
+    lowerAllHands() {
         this.logger.debug(`${this.loggerPrefix} Judge is attempting to lower all hands in conference`, {
             conference: this.conferenceId
         });
-        //ClearAllBuzz Pexip command currently does not signal VMR participant ParticipantUpdated event handlers.
-        //this.videoCallService.lowerAllHands(this.conferenceId);
-        this.participants.forEach(async participant =>{
-            await this.lowerParticipantHand(participant)
-        })
+        // ClearAllBuzz Pexip command currently does not signal VMR participant ParticipantUpdated event handlers.
+        // this.videoCallService.lowerAllHands(this.conferenceId);
+        this.participants.forEach(async participant => {
+            await this.lowerParticipantHand(participant);
+        });
     }
 
     async lowerParticipantHand(participant: PanelModel) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
@@ -114,7 +114,11 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             'setRemoteMuteStatusById',
             'setHandRaiseStatusById'
         ]);
-        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', ['setSpotlightStatus']);
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', [
+            'setSpotlightStatus',
+            'clearHandRaiseStatusForAll',
+            'setHandRaiseStatus'
+        ]);
         userMediaServiceSpy = jasmine.createSpyObj<UserMediaService>([], ['isAudioOnly$']);
         isAudioOnlySubject = new Subject<boolean>();
         getSpiedPropertyGetter(userMediaServiceSpy, 'isAudioOnly$').and.returnValue(isAudioOnlySubject.asObservable());
@@ -139,7 +143,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         component.participant = globalParticipant;
         component.conferenceId = gloalConference.id;
@@ -248,7 +253,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         expect(_component.enableDynamicEvidenceSharing).toBe(false);
     });
@@ -272,7 +278,8 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy
+            featureFlagServiceSpy,
+            videoControlCacheSpy
         );
         expect(_component.enableDynamicEvidenceSharing).toBe(true);
     });
@@ -299,7 +306,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         videoCallService.raiseHand.calls.reset();
         component.handRaised = false;
         component.toggleHandRaised();
-        // expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
+        expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.lower-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -308,7 +315,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         videoCallService.lowerHand.calls.reset();
         component.handRaised = true;
         component.toggleHandRaised();
-        // expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
+        expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.raise-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
@@ -114,9 +114,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             'setRemoteMuteStatusById',
             'setHandRaiseStatusById'
         ]);
-        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', [
-            'setSpotlightStatus'
-        ]);
+        videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', ['setSpotlightStatus']);
         userMediaServiceSpy = jasmine.createSpyObj<UserMediaService>([], ['isAudioOnly$']);
         isAudioOnlySubject = new Subject<boolean>();
         getSpiedPropertyGetter(userMediaServiceSpy, 'isAudioOnly$').and.returnValue(isAudioOnlySubject.asObservable());
@@ -301,7 +299,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         videoCallService.raiseHand.calls.reset();
         component.handRaised = false;
         component.toggleHandRaised();
-        //expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
+        // expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.lower-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -310,7 +308,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         videoCallService.lowerHand.calls.reset();
         component.handRaised = true;
         component.toggleHandRaised();
-        //expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
+        // expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.raise-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.spec.ts
@@ -115,9 +115,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             'setHandRaiseStatusById'
         ]);
         videoControlCacheSpy = jasmine.createSpyObj<VideoControlCacheService>('VideoControlCacheService', [
-            'setSpotlightStatus',
-            'clearHandRaiseStatusForAll',
-            'setHandRaiseStatus'
+            'setSpotlightStatus'
         ]);
         userMediaServiceSpy = jasmine.createSpyObj<UserMediaService>([], ['isAudioOnly$']);
         isAudioOnlySubject = new Subject<boolean>();
@@ -143,8 +141,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy,
-            videoControlCacheSpy
+            featureFlagServiceSpy
         );
         component.participant = globalParticipant;
         component.conferenceId = gloalConference.id;
@@ -253,8 +250,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy,
-            videoControlCacheSpy
+            featureFlagServiceSpy
         );
         expect(_component.enableDynamicEvidenceSharing).toBe(false);
     });
@@ -278,8 +274,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
             userMediaServiceSpy,
             conferenceServiceSpy,
             configServiceSpy,
-            featureFlagServiceSpy,
-            videoControlCacheSpy
+            featureFlagServiceSpy
         );
         expect(_component.enableDynamicEvidenceSharing).toBe(true);
     });
@@ -306,7 +301,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         videoCallService.raiseHand.calls.reset();
         component.handRaised = false;
         component.toggleHandRaised();
-        expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
+        //expect(videoCallService.raiseHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.lower-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });
@@ -315,7 +310,7 @@ describe('PrivateConsultationRoomControlsComponent', () => {
         videoCallService.lowerHand.calls.reset();
         component.handRaised = true;
         component.toggleHandRaised();
-        expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
+        //expect(videoCallService.lowerHand).toHaveBeenCalledTimes(1);
         const expectedText = 'hearing-controls.raise-my-hand';
         expect(component.handToggleText).toBe(expectedText);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
@@ -14,7 +14,6 @@ import { UserMediaService } from 'src/app/services/user-media.service';
 import { HearingControlsBaseComponent } from '../hearing-controls/hearing-controls-base.component';
 import { VideoCallService } from '../services/video-call.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
-import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 
 @Component({
     selector: 'app-private-consultation-room-controls',
@@ -52,8 +51,7 @@ export class PrivateConsultationRoomControlsComponent extends HearingControlsBas
         protected userMediaService: UserMediaService,
         conferenceService: ConferenceService,
         configSerivce: ConfigService,
-        featureFlagService: FeatureFlagService,
-        protected videoControlCacheService: VideoControlCacheService
+        featureFlagService: FeatureFlagService
     ) {
         super(
             videoCallService,
@@ -63,8 +61,7 @@ export class PrivateConsultationRoomControlsComponent extends HearingControlsBas
             participantService,
             translateService,
             videoControlService,
-            userMediaService,
-            videoControlCacheService
+            userMediaService
         );
         this.canToggleParticipantsPanel = true;
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/private-consultation-room-controls/private-consultation-room-controls.component.ts
@@ -14,7 +14,7 @@ import { UserMediaService } from 'src/app/services/user-media.service';
 import { HearingControlsBaseComponent } from '../hearing-controls/hearing-controls-base.component';
 import { VideoCallService } from '../services/video-call.service';
 import { VideoControlService } from '../../services/conference/video-control.service';
-
+import { VideoControlCacheService } from '../../services/conference/video-control-cache.service';
 @Component({
     selector: 'app-private-consultation-room-controls',
     templateUrl: './private-consultation-room-controls.component.html',
@@ -51,7 +51,8 @@ export class PrivateConsultationRoomControlsComponent extends HearingControlsBas
         protected userMediaService: UserMediaService,
         conferenceService: ConferenceService,
         configSerivce: ConfigService,
-        featureFlagService: FeatureFlagService
+        featureFlagService: FeatureFlagService,
+        protected videoControlCacheService: VideoControlCacheService
     ) {
         super(
             videoCallService,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8702
https://tools.hmcts.net/jira/browse/VIH-8861

### Change description ###
Have updated the hearing control logic to now fully rely on an update from the 'newParticipantEnteredHandshake'. In the previous iteration this could be sent too early; meaning it was a little flakey as a 2nd host would re-init the control values after participants had sent their updates. So have added a 3 second delay to give them time. Have stripped out unnecessary updates to video-control-cache service. Have also updated LowerAllHands, judge button to call lowerHandById, forEach linked participant as well as ClearAllBuzz. This is because linked participants were not receiving the participantUpdate event to lower their hand via this pexip control.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
