### PR TITLE
VIH-8753 Video web fixes for Criminal Injuries Compensation case type

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/participant-status/participant-status.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/participant-status/participant-status.component.spec.ts
@@ -60,9 +60,9 @@ describe('ParticipantStatusComponent', () => {
 
     describe('sort participants', () => {
         it('should sort participants in correct order', async () => {
-            const participants: ParticipantContactDetails[] = [];
+            const participantsToSort: ParticipantContactDetails[] = [];
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: CaseTypeGroup.JUDGE,
@@ -74,7 +74,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: CaseTypeGroup.STAFF_MEMBER,
@@ -86,7 +86,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: 'Appellant',
@@ -98,7 +98,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: 'Appellant',
@@ -110,7 +110,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: CaseTypeGroup.PANEL_MEMBER,
@@ -122,7 +122,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: CaseTypeGroup.PANEL_MEMBER,
@@ -142,7 +142,7 @@ describe('ParticipantStatusComponent', () => {
                 })
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: 'Appellant',
@@ -163,7 +163,7 @@ describe('ParticipantStatusComponent', () => {
                 })
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: 'Appellant',
@@ -176,7 +176,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            participants.push(
+            participantsToSort.push(
                 new ParticipantContactDetails(
                     new ParticipantContactDetailsResponseVho({
                         case_type_group: CaseTypeGroup.OBSERVER,
@@ -188,7 +188,7 @@ describe('ParticipantStatusComponent', () => {
                 )
             );
 
-            component.participants = participants;
+            component.participants = participantsToSort;
 
             const participantList = component.sortParticipants();
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/participant-status/participant-status.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/participant-status/participant-status.component.spec.ts
@@ -1,7 +1,10 @@
 import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
-import { ParticipantContactDetailsResponseVho, Role } from 'src/app/services/clients/api-client';
+import { LinkedParticipantResponse, LinkType, ParticipantContactDetailsResponseVho, Role } from 'src/app/services/clients/api-client';
+import { ParticipantContactDetails } from 'src/app/shared/models/participant-contact-details';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { eventsServiceSpy } from 'src/app/testing/mocks/mock-events-service';
+import { CaseTypeGroup } from 'src/app/waiting-space/models/case-type-group';
+import { HearingRole } from 'src/app/waiting-space/models/hearing-role-model';
 import { VideoWebService } from '../../services/api/video-web.service';
 import { ErrorService } from '../../services/error.service';
 import { ParticipantStatusReader } from '../../shared/models/participant-status-reader';
@@ -54,4 +57,172 @@ describe('ParticipantStatusComponent', () => {
         expect(component.participants.length).toBe(4);
         expect(component.loadingData).toBeFalsy();
     }));
+
+    describe('sort participants', () => {
+        it('should sort participants in correct order', async () => {
+            const participants: ParticipantContactDetails[] = [];
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: CaseTypeGroup.JUDGE,
+                        display_name: 'Manual Judge 26',
+                        hearing_role: HearingRole.JUDGE,
+                        linked_participants: [],
+                        role: Role.Judge
+                    })
+                )
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: CaseTypeGroup.STAFF_MEMBER,
+                        display_name: 'A Staff Member',
+                        hearing_role: HearingRole.STAFF_MEMBER,
+                        linked_participants: [],
+                        role: Role.StaffMember
+                    })
+                )
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: 'Appellant',
+                        display_name: 'M Individual 10',
+                        hearing_role: 'Family Member',
+                        linked_participants: [],
+                        role: Role.Individual
+                    })
+                )
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: 'Appellant',
+                        display_name: 'Witness 01',
+                        hearing_role: HearingRole.WITNESS,
+                        linked_participants: [],
+                        role: Role.Individual
+                    })
+                )
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: CaseTypeGroup.PANEL_MEMBER,
+                        display_name: 'M PanelMember 04',
+                        hearing_role: HearingRole.MEDICAL_MEMBER,
+                        linked_participants: [],
+                        role: Role.JudicialOfficeHolder
+                    })
+                )
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: CaseTypeGroup.PANEL_MEMBER,
+                        display_name: 'P Member_01',
+                        hearing_role: HearingRole.LAY_MEMBER,
+                        linked_participants: [],
+                        role: Role.JudicialOfficeHolder
+                    })
+                )
+            );
+
+            const linkedParticipants1: LinkedParticipantResponse[] = [];
+            linkedParticipants1.push(
+                new LinkedParticipantResponse({
+                    link_type: LinkType.Interpreter,
+                    linked_id: 'f195ea9d-0118-4790-bda9-dbc49796584f'
+                })
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: 'Appellant',
+                        display_name: 'M Interpreter 06',
+                        hearing_role: HearingRole.INTERPRETER,
+                        id: '77bb94c6-040b-47f3-87ce-378a4fb2ab57',
+                        linked_participants: linkedParticipants1,
+                        role: Role.Individual
+                    })
+                )
+            );
+
+            const linkedParticipants2: LinkedParticipantResponse[] = [];
+            linkedParticipants2.push(
+                new LinkedParticipantResponse({
+                    link_type: LinkType.Interpreter,
+                    linked_id: '77bb94c6-040b-47f3-87ce-378a4fb2ab57'
+                })
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: 'Appellant',
+                        display_name: 'M Individual 12',
+                        hearing_role: 'Family Member',
+                        id: 'f195ea9d-0118-4790-bda9-dbc49796584f',
+                        linked_participants: linkedParticipants2,
+                        role: Role.Individual
+                    })
+                )
+            );
+
+            participants.push(
+                new ParticipantContactDetails(
+                    new ParticipantContactDetailsResponseVho({
+                        case_type_group: CaseTypeGroup.OBSERVER,
+                        display_name: 'M Observer 03',
+                        hearing_role: HearingRole.OBSERVER,
+                        linked_participants: [],
+                        role: Role.Individual
+                    })
+                )
+            );
+
+            component.participants = participants;
+
+            const participantList = component.sortParticipants();
+
+            // Judge
+            const judgeIndex = participantList.findIndex(x => x.displayName === 'Manual Judge 26');
+            expect(judgeIndex).toEqual(0);
+
+            // Panel members and wingers
+            const panelMember1Index = participantList.findIndex(x => x.displayName === 'M PanelMember 04');
+            const panelMember2Index = participantList.findIndex(x => x.displayName === 'P Member_01');
+            expect(panelMember1Index).toEqual(1);
+            expect(panelMember2Index).toEqual(2);
+
+            // Others
+            const other1Index = participantList.findIndex(x => x.displayName === 'A Staff Member');
+            const other2Index = participantList.findIndex(x => x.displayName === 'M Individual 10');
+            const other3Index = participantList.findIndex(x => x.displayName === 'Witness 01');
+            expect(other1Index).toEqual(3);
+            expect(other2Index).toEqual(4);
+            expect(other3Index).toEqual(5);
+
+            // Interpreters and interpretees
+            const interp1Index = participantList.findIndex(x => x.displayName === 'M Interpreter 06');
+            const interp2Index = participantList.findIndex(x => x.displayName === 'M Individual 12');
+            expect(interp1Index).toEqual(6);
+            expect(interp2Index).toEqual(7);
+
+            // Interpreter 06
+            // Individual 12
+
+            // Observers
+            const observer1Index = participantList.findIndex(x => x.displayName === 'M Observer 03');
+            expect(observer1Index).toEqual(8);
+            // Observer 03
+        });
+    });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/vho-shared/participant-status-base/participant-status-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/vho-shared/participant-status-base/participant-status-base.component.ts
@@ -9,6 +9,7 @@ import { EventsService } from 'src/app/services/events.service';
 import { Logger } from 'src/app/services/logging/logger-base';
 import { ParticipantStatusReader } from 'src/app/shared/models/participant-status-reader';
 import { ParticipantStatusMessage } from 'src/app/services/models/participant-status-message';
+import { HearingRoleHelper } from 'src/app/shared/helpers/hearing-role-helper';
 
 @Directive()
 export abstract class ParticipantStatusDirective {
@@ -137,10 +138,11 @@ export abstract class ParticipantStatusDirective {
         }
     }
 
-    private sortParticipants() {
+    sortParticipants() {
         const judges = this.participants.filter(participant => participant.hearingRole === HearingRole.JUDGE);
+
         const panelMembersAndWingers = this.participants.filter(participant =>
-            [HearingRole.PANEL_MEMBER.toString(), HearingRole.WINGER.toString()].includes(participant.hearingRole)
+            [...HearingRoleHelper.panelMemberRoles, HearingRole.WINGER.toString()].includes(participant.hearingRole)
         );
         const observers = this.participants.filter(participant => participant.hearingRole === HearingRole.OBSERVER);
         const interpretersAndInterpretees = this.participants.filter(participant => participant.isInterpreterOrInterpretee);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.html
@@ -4,7 +4,7 @@
     <span [id]="idPrefix + '-display-name'">
       <strong>{{ participant.displayName }}</strong>
     </span>
-    <span *ngIf="!isJudge" [id]="idPrefix + '-hearing-role-full'">
+    <span *ngIf="showHearingRole()" [id]="idPrefix + '-hearing-role-full'">
         <span [id]="idPrefix + '-hearing-role'">
           {{ 'hearing-role.' + (participant.hearingRole | hyphenate) | translate}}
         </span>

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.ts
@@ -99,16 +99,13 @@ export class JudgeContextMenuComponent implements OnInit {
     }
 
     showCaseTypeGroup(): boolean {
-        const result =
-            !this.participant.caseTypeGroup ||
+        return !this.participant.caseTypeGroup ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.NONE.toLowerCase() ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.OBSERVER.toLowerCase() ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.ENDPOINT.toLowerCase()
-                ? false
-                : true;
-
-        return result;
+            ? false
+            : true;
     }
 
     showHearingRole(): boolean {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.ts
@@ -99,14 +99,23 @@ export class JudgeContextMenuComponent implements OnInit {
     }
 
     showCaseTypeGroup(): boolean {
-        return !this.participant.caseTypeGroup ||
+        const result =
+            !this.participant.caseTypeGroup ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.NONE.toLowerCase() ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.OBSERVER.toLowerCase() ||
-            this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.PANEL_MEMBER.toLowerCase() ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.ENDPOINT.toLowerCase()
-            ? false
-            : true;
+                ? false
+                : true;
+
+        return result;
+    }
+
+    showHearingRole(): boolean {
+        return !(
+            this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
+            this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.PANEL_MEMBER.toLowerCase()
+        );
     }
 
     getMutedStatusText(): string {

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/cy.json
@@ -1127,7 +1127,8 @@
     "elaas": "Cynllun Cynghori ar Apeliadau Cyfraith Cyflogaeth",
     "presentingofficer":"Swyddog Cyflwyno",
     "inabsence": "Mewn absenoldeb",
-    "vetsuk": "Vets UK"
+    "vetsuk": "Vets UK",
+    "panelmember": "Aelod o'r Panel"
   },
   "venue-list": {
     "title": "Dewis eich gwrandawiadau",

--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
@@ -744,7 +744,8 @@
     "elaas": "ELAAS",
     "presentingofficer":"Presenting Officer",
     "inabsence": "In absence",
-    "vetsuk": "Vets UK"
+    "vetsuk": "Vets UK",
+    "panelmember": "Panel Member"
   },
   "case-type": {
     "adoption": "Adoption",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8753


### Change description ###
Applies some additional changes necessary after adding the Criminal Injuries Compensation case type.

- Fixes an issue with the hearing role being displayed instead of the case type group for panel members in the hearing room context menu tooltip. Until now panel members have had a hearing role of "Panel Member" so this hasn't been a problem - the same text has been displayed. This is resolved by not showing the case role text for panel members in addition to judges.

- Fixes an issue with lay members and medical members showing in the wrong position in the command centre participant list. This was due to them not being recognised as panel members.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
