### PR TITLE
VIH-8753 Fix judge context menu error

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.spec.ts
@@ -25,6 +25,7 @@ import { By } from '@angular/platform-browser';
 import { finalize } from 'rxjs/operators';
 import { PanelModel } from '../models/panel-model-base';
 import { HearingRoleHelper } from 'src/app/shared/helpers/hearing-role-helper';
+
 export class MockElementRef extends ElementRef {
     constructor() {
         super(null);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.spec.ts
@@ -136,14 +136,14 @@ describe('JudgeContextMenuComponent', () => {
     });
 
     describe('showHearingRole', () => {
-        const dontShowForHearingRole = HearingRoleHelper.panelMemberRoles;
-        const hearingRoles = Object.keys(CaseTypeGroup);
+        const dontShowForHearingRole = [HearingRole.JUDGE, ...HearingRoleHelper.panelMemberRoles];
+        const hearingRoles = Object.keys(HearingRole);
 
         hearingRoles.forEach(hearingRoleString => {
-            const testHearingRole = CaseTypeGroup[hearingRoleString];
+            const testHearingRole = HearingRole[hearingRoleString];
             const showFor = !dontShowForHearingRole.includes(testHearingRole);
             it(`should return ${showFor} when hearing role is ${hearingRoleString}`, () => {
-                component.participant.caseTypeGroup = testHearingRole;
+                component.participant.hearingRole = testHearingRole;
                 expect(component.showHearingRole()).toBe(showFor);
             });
         });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.spec.ts
@@ -24,6 +24,7 @@ import { LowerCasePipe } from '@angular/common';
 import { By } from '@angular/platform-browser';
 import { finalize } from 'rxjs/operators';
 import { PanelModel } from '../models/panel-model-base';
+import { HearingRoleHelper } from 'src/app/shared/helpers/hearing-role-helper';
 export class MockElementRef extends ElementRef {
     constructor() {
         super(null);
@@ -130,6 +131,27 @@ describe('JudgeContextMenuComponent', () => {
             component.participant.caseTypeGroup = caseTypeGroup;
             expect(caseTypeGroups).not.toContain(caseTypeGroup);
             expect(component.showCaseTypeGroup()).toBe(true);
+        });
+    });
+
+    describe('showHearingRole', () => {
+        const dontShowForHearingRole = HearingRoleHelper.panelMemberRoles;
+        const hearingRoles = Object.keys(CaseTypeGroup);
+
+        hearingRoles.forEach(hearingRoleString => {
+            const testHearingRole = CaseTypeGroup[hearingRoleString];
+            const showFor = !dontShowForHearingRole.includes(testHearingRole);
+            it(`should return ${showFor} when hearing role is ${hearingRoleString}`, () => {
+                component.participant.caseTypeGroup = testHearingRole;
+                expect(component.showHearingRole()).toBe(showFor);
+            });
+        });
+
+        it(`should return true when hearing role is any other value`, () => {
+            const hearingRole = 'AnyOtherValue';
+            component.participant.hearingRole = hearingRole;
+            expect(hearingRoles).not.toContain(hearingRole);
+            expect(component.showHearingRole()).toBe(true);
         });
     });
 
@@ -465,16 +487,19 @@ describe('JudgeContextMenuComponent', () => {
                             hearingRoleFullElementId = fakeGetElementId('hearing-role-full');
                         });
                         it('should not show for judge', () => {
-                            component.participant.caseTypeGroup = CaseTypeGroup.JUDGE;
+                            component.participant.hearingRole = HearingRole.JUDGE;
                             fixture.detectChanges();
                             hearingRoleFullElement = fixture.debugElement.query(By.css(`#${hearingRoleFullElementId}`));
                             expect(hearingRoleFullElement).toBeFalsy();
                         });
-                        it('should not show for panel member', () => {
-                            component.participant.caseTypeGroup = CaseTypeGroup.PANEL_MEMBER;
-                            fixture.detectChanges();
-                            hearingRoleFullElement = fixture.debugElement.query(By.css(`#${hearingRoleFullElementId}`));
-                            expect(hearingRoleFullElement).toBeFalsy();
+                        const panelMemberHearingRoles = HearingRoleHelper.panelMemberRoles;
+                        panelMemberHearingRoles.forEach(hearingRole => {
+                            it(`should not show for panel member - ${hearingRole}`, () => {
+                                component.participant.hearingRole = hearingRole;
+                                fixture.detectChanges();
+                                hearingRoleFullElement = fixture.debugElement.query(By.css(`#${hearingRoleFullElementId}`));
+                                expect(hearingRoleFullElement).toBeFalsy();
+                            });
                         });
 
                         describe('when not judge or panel member', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-context-menu/judge-context-menu.component.ts
@@ -11,6 +11,7 @@ import {
 import { HearingRole } from '../models/hearing-role-model';
 import { CaseTypeGroup } from '../models/case-type-group';
 import { TranslateService } from '@ngx-translate/core';
+import { HearingRoleHelper } from 'src/app/shared/helpers/hearing-role-helper';
 
 @Component({
     selector: 'app-judge-context-menu',
@@ -98,6 +99,10 @@ export class JudgeContextMenuComponent implements OnInit {
         return this.participant.hearingRole === HearingRole.WITNESS;
     }
 
+    get isPanelMember(): boolean {
+        return HearingRoleHelper.isPanelMember(this.participant.hearingRole);
+    }
+
     showCaseTypeGroup(): boolean {
         return !this.participant.caseTypeGroup ||
             this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.NONE.toLowerCase() ||
@@ -109,10 +114,7 @@ export class JudgeContextMenuComponent implements OnInit {
     }
 
     showHearingRole(): boolean {
-        return !(
-            this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.JUDGE.toLowerCase() ||
-            this.participant.caseTypeGroup.toLowerCase() === CaseTypeGroup.PANEL_MEMBER.toLowerCase()
-        );
+        return !(this.isJudge || this.isPanelMember);
     }
 
     getMutedStatusText(): string {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8821


### Change description ###
Fixes an error when members without a case type group are in a hearing.

The showHearingRole() function (introduced recently) is using a flaky method of determining whether the participant is a judge or panel member. Updated it to use the hearing role instead of the case group type.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
