### PR TITLE
VIH-8854 Audio lost when invited to a consultation

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -542,6 +542,7 @@ export abstract class WaitingRoomBaseDirective {
         roomLabel: string
     ) {
         if (answer === ConsultationAnswer.Accepted && requestedFor === responseInitiatorId) {
+            this.hasTriedToLeaveConsultation = false;
             await this.onConsultationAccepted(roomLabel);
         } else if (answer === ConsultationAnswer.Transferring) {
             this.onTransferingToConsultation(roomLabel);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8854

### Change description ###
Set the hasTriedToLeaveConsultation bool to false within the 'accepted' consultation invite, event handler. This would normally be done when clicking to join a consultation button, however this is step is missed when being invited to one instead. This would result in the video not being unmuted, when they rejoin.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
