### PR TITLE
VIH-8890 Fix for participant scrollbar not showing in Firefox

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
@@ -182,14 +182,6 @@
   }
 }
 
-.chat-wrapper {
-  width: 333px;
-  padding: 12px;
-  float: right;
-  max-height: 675px;
-  overflow: overlay;
-}
-
 .room-title {
   color: lightgray;
   margin-left: 40px;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-global-styles.scss
@@ -171,12 +171,12 @@
   top: 4.094375rem;
   right: 0;
   z-index: 998;
-  overflow: overlay;
+  overflow: auto;
   background-color: #333;
   box-shadow: 0px 5px 10px 0px rgb(0 0 0 / 70%);
   box-shadow: 0px 20px 30px 0px rgb(0 0 0 / 30%);
   @include responds-to(small) {
-    width: rem(333px);
+    width: rem(340px);
     top: 0px;
     position: relative;
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8890


### Change description ###
Fixes an issue where the participant scrollbar in the hearing does not display in Firefox.
The `overflow:overlay` css property is not supported in Firefox. This is replaced with `overflow:auto`.
Since the scrollbar takes extra space in the div, we increase the width of the container to prevent the controls from wrapping.
Also remove the other `overflow:overlay` reference, which is not used.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
