### PR TITLE
VIH-8945 fix for duplicating interpreter

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -200,8 +200,8 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
                 const interpreterToMove = sortedNonJudgeParticipants[interpreterIndex];
 
                 sortedNonJudgeParticipants.splice(interpreterIndex, 1);
-                const interpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id); // get interpretee index again as it would have shifted
-                sortedNonJudgeParticipants.splice(interpreteeIndex + 1, 0, interpreterToMove);
+                const newInterpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id); // get interpretee index again as it would have shifted
+                sortedNonJudgeParticipants.splice(newInterpreteeIndex + 1, 0, interpreterToMove);
             }
         });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -200,7 +200,7 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
                 const interpreterToMove = sortedNonJudgeParticipants[interpreterIndex];
 
                 sortedNonJudgeParticipants.splice(interpreterIndex, 1);
-                const interpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id); //get interpretee index again as it would have shifted
+                const interpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id); // get interpretee index again as it would have shifted
                 sortedNonJudgeParticipants.splice(interpreteeIndex + 1, 0, interpreterToMove);
             }
         });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -199,8 +199,9 @@ export abstract class WRParticipantStatusListDirective implements DoCheck {
             if (interpreterIndex !== interpreteeIndex + 1) {
                 const interpreterToMove = sortedNonJudgeParticipants[interpreterIndex];
 
-                sortedNonJudgeParticipants.splice(interpreteeIndex + 1, 0, interpreterToMove);
                 sortedNonJudgeParticipants.splice(interpreterIndex, 1);
+                const interpreteeIndex = sortedNonJudgeParticipants.findIndex(x => x.id === interpretee.id); //get interpretee index again as it would have shifted
+                sortedNonJudgeParticipants.splice(interpreteeIndex + 1, 0, interpreterToMove);
             }
         });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8934


### Change description ###
When repositioning the interpreter underneath the interpretee, all the indices shifted up one, so upon removing the old interpreter position, the wrong participant would be removed, instead leaving two instances of the interpreter.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
