### PR TITLE
VIH-8937 Fix for panel member hearing control resets after adding participant

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1177,7 +1177,7 @@ describe('ParticipantsPanelComponent', () => {
         a new participant has been added and the participants list refreshed
         */
 
-        const participants: ParticipantForUserResponse[] = [];
+        const participantsForHearing: ParticipantForUserResponse[] = [];
 
         const participant1 = new ParticipantForUserResponse({
             id: '1111-1111-1111-1111',
@@ -1216,11 +1216,11 @@ describe('ParticipantsPanelComponent', () => {
             linked_participants: []
         });
 
-        participants.push(participant1);
-        participants.push(participant2);
-        participants.push(participant3);
+        participantsForHearing.push(participant1);
+        participantsForHearing.push(participant2);
+        participantsForHearing.push(participant3);
 
-        const panelModelParticipants = new ParticipantPanelModelMapper().mapFromParticipantUserResponseArray(participants);
+        const panelModelParticipants = new ParticipantPanelModelMapper().mapFromParticipantUserResponseArray(participantsForHearing);
 
         component.participants = panelModelParticipants;
         component.nonEndpointParticipants = panelModelParticipants;
@@ -1268,14 +1268,14 @@ describe('ParticipantsPanelComponent', () => {
             linked_participants: []
         });
 
-        participants.push(newParticipant);
+        participantsForHearing.push(newParticipant);
 
-        let mappedParticipants = mapper.mapFromParticipantUserResponseArray(participants);
+        const mappedParticipants = mapper.mapFromParticipantUserResponseArray(participantsForHearing);
         participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedParticipants);
 
         component.setupEventhubSubscribers();
 
-        let message = new ParticipantsUpdatedMessage(conferenceId, participants);
+        const message = new ParticipantsUpdatedMessage(conferenceId, participantsForHearing);
         getParticipantsUpdatedSubjectMock.next(message);
 
         const updatedParticipant2 = component.participants.find(p => p.id === participant2.interpreter_room.id);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1172,6 +1172,11 @@ describe('ParticipantsPanelComponent', () => {
     });
 
     it('should persist states for participant after new participant is added', () => {
+        /*
+        If the states have changed for an existing participant (muted, raised, spotlighted) these should persist after
+        a new participant has been added and the participants list refreshed
+        */
+
         const participants: ParticipantForUserResponse[] = [];
 
         const participant1 = new ParticipantForUserResponse({

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -237,15 +237,9 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     const mappedListLinkedParticipantPanelIndex = mappedList.findIndex(x => x.role === Role.JudicialOfficeHolder);
 
                     if (nonEndpointParticipantsLinkedParticipantPanelIndex > -1 && mappedListLinkedParticipantPanelIndex > -1) {
-                        let joh = this.nonEndpointParticipants[
+                        const linkedParticipant = this.nonEndpointParticipants[
                             nonEndpointParticipantsLinkedParticipantPanelIndex
                         ] as LinkedParticipantPanelModel;
-
-                        const isRemoteMuted = joh.isMicRemoteMuted();
-                        const handRaised = joh.hasHandRaised();
-                        const spotlighted = joh.hasSpotlight();
-                        const isLocalMicMuted = joh.isLocalMicMuted();
-                        const isLocalCameraOff = joh.isLocalCameraOff();
 
                         this.nonEndpointParticipants.splice(
                             nonEndpointParticipantsLinkedParticipantPanelIndex,
@@ -254,13 +248,25 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                         );
 
                         // Re-apply the state properties
-                        joh = this.nonEndpointParticipants[
+                        const linkedParticipantToUpdate = this.nonEndpointParticipants[
                             nonEndpointParticipantsLinkedParticipantPanelIndex
                         ] as LinkedParticipantPanelModel;
 
-                        joh.participants.forEach(p =>
-                            joh.updateParticipant(isRemoteMuted, handRaised, spotlighted, p.id, isLocalMicMuted, isLocalCameraOff)
-                        );
+                        linkedParticipantToUpdate.participants.forEach(p => {
+                            const linkedParticipantParticipant = linkedParticipant.participants.find(lp => lp.id === p.id);
+                            if (!linkedParticipantParticipant) {
+                                return;
+                            }
+
+                            linkedParticipantToUpdate.updateParticipant(
+                                linkedParticipant.isMicRemoteMuted(),
+                                linkedParticipant.hasHandRaised(),
+                                linkedParticipant.hasSpotlight(),
+                                linkedParticipantParticipant.id,
+                                linkedParticipantParticipant.isLocalMicMuted(),
+                                linkedParticipantParticipant.isLocalCameraOff()
+                            );
+                        });
                     }
 
                     this.updateParticipants();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -101,9 +101,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                         }
                     }
 
-                    this.logger.debug(`${this.loggerPrefix} refreshing participants, current participant`, participant);
-                    this.logger.debug(`${this.loggerPrefix} refreshing participants, state participant`, participant);
-
                     participant.updateParticipant(
                         state[participant.id]?.isRemoteMuted,
                         false,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -100,6 +100,10 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                             participant.assignPexipId(state[participant.id].pexipId);
                         }
                     }
+
+                    this.logger.debug(`${this.loggerPrefix} refreshing participants, current participant`, participant);
+                    this.logger.debug(`${this.loggerPrefix} refreshing participants, state participant`, participant);
+
                     participant.updateParticipant(
                         state[participant.id]?.isRemoteMuted,
                         false,
@@ -706,6 +710,20 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     private updateParticipants() {
         const combined = [...this.nonEndpointParticipants, ...this.endpointParticipants];
+
+        combined.forEach(c => {
+            const participant = this.participants.find(p => p.id === c.id);
+
+            c.updateParticipant(
+                participant.isMicRemoteMuted(),
+                participant.hasHandRaised(),
+                participant.hasSpotlight(),
+                participant.id,
+                participant.isLocalMicMuted(),
+                participant.isLocalCameraOff()
+            );
+        });
+
         this.getOrderedParticipants(combined);
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -241,10 +241,29 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     const mappedListLinkedParticipantPanelIndex = mappedList.findIndex(x => x.role === Role.JudicialOfficeHolder);
 
                     if (nonEndpointParticipantsLinkedParticipantPanelIndex > -1 && mappedListLinkedParticipantPanelIndex > -1) {
+                        let joh = this.nonEndpointParticipants[
+                            nonEndpointParticipantsLinkedParticipantPanelIndex
+                        ] as LinkedParticipantPanelModel;
+
+                        const isRemoteMuted = joh.isMicRemoteMuted();
+                        const handRaised = joh.hasHandRaised();
+                        const spotlighted = joh.hasSpotlight();
+                        const isLocalMicMuted = joh.isLocalMicMuted();
+                        const isLocalCameraOff = joh.isLocalCameraOff();
+
                         this.nonEndpointParticipants.splice(
                             nonEndpointParticipantsLinkedParticipantPanelIndex,
                             1,
                             mappedList[mappedListLinkedParticipantPanelIndex]
+                        );
+
+                        // Re-apply the state properties
+                        joh = this.nonEndpointParticipants[
+                            nonEndpointParticipantsLinkedParticipantPanelIndex
+                        ] as LinkedParticipantPanelModel;
+
+                        joh.participants.forEach(p =>
+                            joh.updateParticipant(isRemoteMuted, handRaised, spotlighted, p.id, isLocalMicMuted, isLocalCameraOff)
                         );
                     }
 
@@ -710,20 +729,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     private updateParticipants() {
         const combined = [...this.nonEndpointParticipants, ...this.endpointParticipants];
-
-        combined.forEach(c => {
-            const participant = this.participants.find(p => p.id === c.id);
-
-            c.updateParticipant(
-                participant.isMicRemoteMuted(),
-                participant.hasHandRaised(),
-                participant.hasSpotlight(),
-                participant.id,
-                participant.isLocalMicMuted(),
-                participant.isLocalCameraOff()
-            );
-        });
-
         this.getOrderedParticipants(combined);
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -100,7 +100,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                             participant.assignPexipId(state[participant.id].pexipId);
                         }
                     }
-
                     participant.updateParticipant(
                         state[participant.id]?.isRemoteMuted,
                         false,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8937


### Change description ###
Fixes an issue where the hearing control states (hand raised, muted, spotlighted) for panel members are not persisted after a new participant is added.

There is a splice operation in place to replace the panel member in the array with the panel member in another array. However this replacement panel member has been previously mapped to a different object type which doesn't have the hearing control state properties (isMuted, hasHandRaised etc). The fix is to re-apply these properties after the splice.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
