### PR TITLE
VIH-8937 Fix for issues with panel member hearing controls after participant added

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1177,7 +1177,7 @@ describe('ParticipantsPanelComponent', () => {
         a new participant has been added and the participants list refreshed
         */
 
-        const participants: ParticipantForUserResponse[] = [];
+        const participantsForHearing: ParticipantForUserResponse[] = [];
 
         const participant1 = new ParticipantForUserResponse({
             id: '1111-1111-1111-1111',
@@ -1216,11 +1216,11 @@ describe('ParticipantsPanelComponent', () => {
             linked_participants: []
         });
 
-        participants.push(participant1);
-        participants.push(participant2);
-        participants.push(participant3);
+        participantsForHearing.push(participant1);
+        participantsForHearing.push(participant2);
+        participantsForHearing.push(participant3);
 
-        const panelModelParticipants = new ParticipantPanelModelMapper().mapFromParticipantUserResponseArray(participants);
+        const panelModelParticipants = new ParticipantPanelModelMapper().mapFromParticipantUserResponseArray(participantsForHearing);
 
         component.participants = panelModelParticipants;
         component.nonEndpointParticipants = panelModelParticipants;
@@ -1268,14 +1268,14 @@ describe('ParticipantsPanelComponent', () => {
             linked_participants: []
         });
 
-        participants.push(newParticipant);
+        participantsForHearing.push(newParticipant);
 
-        let mappedParticipants = mapper.mapFromParticipantUserResponseArray(participants);
+        const mappedParticipants = mapper.mapFromParticipantUserResponseArray(participantsForHearing);
         participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedParticipants);
 
         component.setupEventhubSubscribers();
 
-        let message = new ParticipantsUpdatedMessage(conferenceId, participants);
+        const message = new ParticipantsUpdatedMessage(conferenceId, participantsForHearing);
         getParticipantsUpdatedSubjectMock.next(message);
 
         const updatedParticipant2 = component.participants.find(p => p.id === participant2.interpreter_room.id);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1233,6 +1233,9 @@ describe('ParticipantsPanelComponent', () => {
                 isLocalCameraOff: false
             };
 
+            const pexipId = Guid.create().toString();
+            p.assignPexipId(pexipId);
+
             p.updateParticipant(
                 initialStates.isRemoteMuted,
                 initialStates.handRaised,
@@ -1293,8 +1296,12 @@ describe('ParticipantsPanelComponent', () => {
 
         component.setupEventhubSubscribers();
 
+        const participantsBeforeUpdate = [...component.nonEndpointParticipants];
+
         const message = new ParticipantsUpdatedMessage(conferenceId, participantsForHearing);
         getParticipantsUpdatedSubjectMock.next(message);
+
+        const panelModelLinkedParticipant = participantsBeforeUpdate.find(p => p.id === participant2.interpreter_room.id);
 
         const updatedParticipant2 = component.participants.find(p => p.id === participant2.interpreter_room.id);
 
@@ -1303,6 +1310,7 @@ describe('ParticipantsPanelComponent', () => {
         expect(updatedParticipant2.hasSpotlight()).toBe(true);
         expect(updatedParticipant2.isLocalMicMuted()).toBe(true);
         expect(updatedParticipant2.isLocalCameraOff()).toBe(true);
+        expect(updatedParticipant2.pexipId).toEqual(panelModelLinkedParticipant.pexipId);
 
         const updatedParticipant3 = component.participants.find(p => p.id === participant3.id);
 
@@ -1380,6 +1388,9 @@ describe('ParticipantsPanelComponent', () => {
                 isLocalCameraOff: false
             };
 
+            const pexipId = Guid.create().toString();
+            p.assignPexipId(pexipId);
+
             p.updateParticipant(
                 initialStates.isRemoteMuted,
                 initialStates.handRaised,
@@ -1432,6 +1443,8 @@ describe('ParticipantsPanelComponent', () => {
 
         component.setupEventhubSubscribers();
 
+        const participantsBeforeUpdate = [...component.nonEndpointParticipants];
+
         const message = new ParticipantsUpdatedMessage(conferenceId, participantsForHearing);
         getParticipantsUpdatedSubjectMock.next(message);
 
@@ -1439,9 +1452,12 @@ describe('ParticipantsPanelComponent', () => {
             p => p.id === linkedParticipantInterpreterRoom.id
         ) as LinkedParticipantPanelModel;
 
+        const panelModelLinkedParticipant = participantsBeforeUpdate.find(p => p.id === linkedParticipantInterpreterRoom.id);
+
         expect(linkedParticipant.isMicRemoteMuted()).toBe(false);
         expect(linkedParticipant.hasHandRaised()).toBe(false);
         expect(linkedParticipant.hasSpotlight()).toBe(false);
+        expect(linkedParticipant.pexipId).toEqual(panelModelLinkedParticipant.pexipId);
 
         const updatedPanelMember1 = linkedParticipant.participants.find(p => p.id === panelMember1.id);
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1172,6 +1172,11 @@ describe('ParticipantsPanelComponent', () => {
     });
 
     it('should persist states for participant after new participant is added', () => {
+        /*
+        If the states have changed for an existing participant (muted, raised, spotlighted) these should persist after
+        a new participant has been added and the participants list refreshed
+        */
+
         const participants: ParticipantForUserResponse[] = [];
 
         const participant1 = new ParticipantForUserResponse({

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -237,15 +237,9 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     const mappedListLinkedParticipantPanelIndex = mappedList.findIndex(x => x.role === Role.JudicialOfficeHolder);
 
                     if (nonEndpointParticipantsLinkedParticipantPanelIndex > -1 && mappedListLinkedParticipantPanelIndex > -1) {
-                        let joh = this.nonEndpointParticipants[
+                        const linkedParticipant = this.nonEndpointParticipants[
                             nonEndpointParticipantsLinkedParticipantPanelIndex
                         ] as LinkedParticipantPanelModel;
-
-                        const isRemoteMuted = joh.isMicRemoteMuted();
-                        const handRaised = joh.hasHandRaised();
-                        const spotlighted = joh.hasSpotlight();
-                        const isLocalMicMuted = joh.isLocalMicMuted();
-                        const isLocalCameraOff = joh.isLocalCameraOff();
 
                         this.nonEndpointParticipants.splice(
                             nonEndpointParticipantsLinkedParticipantPanelIndex,
@@ -254,13 +248,25 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                         );
 
                         // Re-apply the state properties
-                        joh = this.nonEndpointParticipants[
+                        const linkedParticipantToUpdate = this.nonEndpointParticipants[
                             nonEndpointParticipantsLinkedParticipantPanelIndex
                         ] as LinkedParticipantPanelModel;
 
-                        joh.participants.forEach(p =>
-                            joh.updateParticipant(isRemoteMuted, handRaised, spotlighted, p.id, isLocalMicMuted, isLocalCameraOff)
-                        );
+                        linkedParticipantToUpdate.participants.forEach(p => {
+                            const linkedParticipantParticipant = linkedParticipant.participants.find(lp => lp.id === p.id);
+                            if (!linkedParticipantParticipant) {
+                                return;
+                            }
+
+                            linkedParticipantToUpdate.updateParticipant(
+                                linkedParticipant.isMicRemoteMuted(),
+                                linkedParticipant.hasHandRaised(),
+                                linkedParticipant.hasSpotlight(),
+                                linkedParticipantParticipant.id,
+                                linkedParticipantParticipant.isLocalMicMuted(),
+                                linkedParticipantParticipant.isLocalCameraOff()
+                            );
+                        });
                     }
 
                     this.updateParticipants();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -101,9 +101,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                         }
                     }
 
-                    this.logger.debug(`${this.loggerPrefix} refreshing participants, current participant`, participant);
-                    this.logger.debug(`${this.loggerPrefix} refreshing participants, state participant`, participant);
-
                     participant.updateParticipant(
                         state[participant.id]?.isRemoteMuted,
                         false,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -237,38 +237,9 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     const mappedListLinkedParticipantPanelIndex = mappedList.findIndex(x => x.role === Role.JudicialOfficeHolder);
 
                     if (nonEndpointParticipantsLinkedParticipantPanelIndex > -1 && mappedListLinkedParticipantPanelIndex > -1) {
-                        const linkedParticipant = this.nonEndpointParticipants[
-                            nonEndpointParticipantsLinkedParticipantPanelIndex
-                        ] as LinkedParticipantPanelModel;
-
-                        this.nonEndpointParticipants.splice(
-                            nonEndpointParticipantsLinkedParticipantPanelIndex,
-                            1,
-                            mappedList[mappedListLinkedParticipantPanelIndex]
-                        );
-
-                        // Re-apply the state properties
-                        const linkedParticipantToUpdate = this.nonEndpointParticipants[
-                            nonEndpointParticipantsLinkedParticipantPanelIndex
-                        ] as LinkedParticipantPanelModel;
-
-                        linkedParticipantToUpdate.participants.forEach(p => {
-                            const linkedParticipantParticipant = linkedParticipant.participants.find(lp => lp.id === p.id);
-                            if (!linkedParticipantParticipant) {
-                                return;
-                            }
-
-                            linkedParticipantToUpdate.updateParticipant(
-                                linkedParticipant.isMicRemoteMuted(),
-                                linkedParticipant.hasHandRaised(),
-                                linkedParticipant.hasSpotlight(),
-                                linkedParticipantParticipant.id,
-                                linkedParticipantParticipant.isLocalMicMuted(),
-                                linkedParticipantParticipant.isLocalCameraOff()
-                            );
-                        });
-
-                        linkedParticipantToUpdate.assignPexipId(linkedParticipant.pexipId);
+                        const index = nonEndpointParticipantsLinkedParticipantPanelIndex;
+                        const newParticipant = mappedList[mappedListLinkedParticipantPanelIndex];
+                        this.replaceNonEndpointLinkedParticipant(index, newParticipant);
                     }
 
                     this.updateParticipants();
@@ -771,5 +742,30 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         });
 
         this.getOrderedParticipants(combined);
+    }
+
+    private replaceNonEndpointLinkedParticipant(nonEndpointParticipantsIndex: number, newParticipant: PanelModel) {
+        const linkedParticipant = this.nonEndpointParticipants[nonEndpointParticipantsIndex] as LinkedParticipantPanelModel;
+
+        this.nonEndpointParticipants.splice(nonEndpointParticipantsIndex, 1, newParticipant);
+
+        // Re-apply the state properties
+        const linkedParticipantToUpdate = this.nonEndpointParticipants[nonEndpointParticipantsIndex] as LinkedParticipantPanelModel;
+        linkedParticipantToUpdate.participants.forEach(p => {
+            const linkedParticipantParticipant = linkedParticipant.participants.find(lp => lp.id === p.id);
+            if (!linkedParticipantParticipant) {
+                return;
+            }
+
+            linkedParticipantToUpdate.updateParticipant(
+                linkedParticipant.isMicRemoteMuted(),
+                linkedParticipant.hasHandRaised(),
+                linkedParticipant.hasSpotlight(),
+                linkedParticipantParticipant.id,
+                linkedParticipantParticipant.isLocalMicMuted(),
+                linkedParticipantParticipant.isLocalCameraOff()
+            );
+        });
+        linkedParticipantToUpdate.assignPexipId(linkedParticipant.pexipId);
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -267,6 +267,8 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                                 linkedParticipantParticipant.isLocalCameraOff()
                             );
                         });
+
+                        linkedParticipantToUpdate.assignPexipId(linkedParticipant.pexipId);
                     }
 
                     this.updateParticipants();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -100,6 +100,10 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                             participant.assignPexipId(state[participant.id].pexipId);
                         }
                     }
+
+                    this.logger.debug(`${this.loggerPrefix} refreshing participants, current participant`, participant);
+                    this.logger.debug(`${this.loggerPrefix} refreshing participants, state participant`, participant);
+
                     participant.updateParticipant(
                         state[participant.id]?.isRemoteMuted,
                         false,
@@ -706,6 +710,20 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     private updateParticipants() {
         const combined = [...this.nonEndpointParticipants, ...this.endpointParticipants];
+
+        combined.forEach(c => {
+            const participant = this.participants.find(p => p.id === c.id);
+
+            c.updateParticipant(
+                participant.isMicRemoteMuted(),
+                participant.hasHandRaised(),
+                participant.hasSpotlight(),
+                participant.id,
+                participant.isLocalMicMuted(),
+                participant.isLocalCameraOff()
+            );
+        });
+
         this.getOrderedParticipants(combined);
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -241,10 +241,29 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     const mappedListLinkedParticipantPanelIndex = mappedList.findIndex(x => x.role === Role.JudicialOfficeHolder);
 
                     if (nonEndpointParticipantsLinkedParticipantPanelIndex > -1 && mappedListLinkedParticipantPanelIndex > -1) {
+                        let joh = this.nonEndpointParticipants[
+                            nonEndpointParticipantsLinkedParticipantPanelIndex
+                        ] as LinkedParticipantPanelModel;
+
+                        const isRemoteMuted = joh.isMicRemoteMuted();
+                        const handRaised = joh.hasHandRaised();
+                        const spotlighted = joh.hasSpotlight();
+                        const isLocalMicMuted = joh.isLocalMicMuted();
+                        const isLocalCameraOff = joh.isLocalCameraOff();
+
                         this.nonEndpointParticipants.splice(
                             nonEndpointParticipantsLinkedParticipantPanelIndex,
                             1,
                             mappedList[mappedListLinkedParticipantPanelIndex]
+                        );
+
+                        // Re-apply the state properties
+                        joh = this.nonEndpointParticipants[
+                            nonEndpointParticipantsLinkedParticipantPanelIndex
+                        ] as LinkedParticipantPanelModel;
+
+                        joh.participants.forEach(p =>
+                            joh.updateParticipant(isRemoteMuted, handRaised, spotlighted, p.id, isLocalMicMuted, isLocalCameraOff)
                         );
                     }
 
@@ -710,20 +729,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
 
     private updateParticipants() {
         const combined = [...this.nonEndpointParticipants, ...this.endpointParticipants];
-
-        combined.forEach(c => {
-            const participant = this.participants.find(p => p.id === c.id);
-
-            c.updateParticipant(
-                participant.isMicRemoteMuted(),
-                participant.hasHandRaised(),
-                participant.hasSpotlight(),
-                participant.id,
-                participant.isLocalMicMuted(),
-                participant.isLocalCameraOff()
-            );
-        });
-
         this.getOrderedParticipants(combined);
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -100,7 +100,6 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                             participant.assignPexipId(state[participant.id].pexipId);
                         }
                     }
-
                     participant.updateParticipant(
                         state[participant.id]?.isRemoteMuted,
                         false,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8937


### Change description ###
Fixes some issues with the panel member hearing controls which happen after a new participant is added to the hearing.

- States are reset (raised hand is lowered, muted is changed to unmuted, spotlight is removed)
- Controls don't work (clicking on them doesn't toggle)

There is a splice operation in place to replace a panel member with one from another array. However this panel member has been mapped to a different object type and doesn't have the state (muted, hand raised etc) properties, so we need to re-apply them for the states to be persisted.

We also need to re-assign a pexip id for the controls to work.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
