### PR TITLE
VIH-8974 anyone can invite into a consultation bug

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/participant-waiting-room.component.ts
@@ -271,6 +271,7 @@ export class ParticipantWaitingRoomComponent extends WaitingRoomBaseDirective im
                 p.id !== this.participant.id &&
                 p.role !== Role.JudicialOfficeHolder &&
                 p.role !== Role.Judge &&
+                p.role !== Role.StaffMember &&
                 p.case_type_group !== CaseTypeGroup.OBSERVER &&
                 p.hearing_role !== HearingRole.OBSERVER &&
                 p.hearing_role !== HearingRole.WITNESS

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
@@ -13,14 +13,14 @@
                             [canInvite]="canInvite"
                             [status]="getParticipantStatus(judge)"
                             >
-                        </app-participant-item>                              
+                        </app-participant-item>
                 </div>
             </ng-container>
             <ng-container *ngFor="let group of johGroupResult">
                 <ng-container *ngIf="group.length > 0">
                     <ng-container *ngTemplateOutlet="johIcon"></ng-container>
                     <div class="member-group">
-                        <ng-container *ngFor="let participant of group; trackBy: trackParticipant">        
+                        <ng-container *ngFor="let participant of group; trackBy: trackParticipant">
                             <app-participant-item
                                 [participant]="participant"
                                 [interpreter]="participant?.interpreter"
@@ -30,12 +30,12 @@
                                 [canInvite]="canInvite"
                                 [status]="getParticipantStatus(participant)"
                                 >
-                            </app-participant-item>                              
+                            </app-participant-item>
                         </ng-container>
                     </div>
                 </ng-container>
             </ng-container>
-        </ng-container> 
+        </ng-container>
         <ng-container *ngFor="let staffMember of staffMembers">
             <div class="member-group">
                 <app-participant-item
@@ -43,10 +43,10 @@
                     [conferenceId]="conference.id"
                     [roomLabel]="roomLabel"
                     [participantCallStatuses]="participantCallStatuses"
-                    [canInvite]="canInvite"
+                    [canInvite]="canInvite && !participantHasInviteRestrictions(staffMember)"
                     [status]="getParticipantStatus(staffMember)"
                     >
-                </app-participant-item>           
+                </app-participant-item>
             </div>
         </ng-container>
         <ng-container  *ngFor="let participant of getPrivateConsultationParticipants(); trackBy: trackParticipant">
@@ -54,10 +54,10 @@
                 <app-participant-item
                                 [participant]="participant"
                                 [interpreter]="participant?.interpreter"
-                                [conferenceId]="conference.id" 
+                                [conferenceId]="conference.id"
                                 [roomLabel]="roomLabel"
-                                [participantCallStatuses]="participantCallStatuses" 
-                                [canInvite]="canInvite"
+                                [participantCallStatuses]="participantCallStatuses"
+                                [canInvite]="canInvite && !participantHasInviteRestrictions(participant)"
                                 [status]="getParticipantStatus(participant)"
                                 >
                 </app-participant-item>
@@ -68,17 +68,17 @@
         <ng-container *ngFor="let endpoint of endpoints">
             <div class="endpoint-row">
                 <div class="header-left" [class]="getRowClasses(endpoint)">
-                    <app-invite-participant *ngIf="canCallEndpoint(endpoint)" 
+                    <app-invite-participant *ngIf="canCallEndpoint(endpoint)"
                         [endpointId]="endpoint.id"
-                        [conferenceId]="conference.id" 
+                        [conferenceId]="conference.id"
                         [roomLabel]="roomLabel">
                     </app-invite-participant>
-                    <fa-icon *ngIf="isParticipantInCurrentRoom(endpoint)" 
-                        icon="check" 
+                    <fa-icon *ngIf="isParticipantInCurrentRoom(endpoint)"
+                        icon="check"
                         aria-hidden="true"></fa-icon>
                 </div>
 
-                <app-private-consultation-participant-display-name 
+                <app-private-consultation-participant-display-name
                     [displayName]="endpoint?.display_name"
                     [isInCurrentRoom]="isParticipantInCurrentRoom(endpoint)"
                     [isAvailable]="isParticipantAvailable(endpoint)">
@@ -91,12 +91,12 @@
         <ng-container *ngIf="isJohConsultation()">
             <ng-container *ngFor="let participant of getObservers(); trackBy: trackParticipant">
                 <div class="member-group">
-                    <app-participant-item 
-                                    [participant]="participant" 
+                    <app-participant-item
+                                    [participant]="participant"
                                     [interpreter]="participant?.interpreter"
-                                    [conferenceId]="conference.id" 
+                                    [conferenceId]="conference.id"
                                     [roomLabel]="roomLabel"
-                                    [participantCallStatuses]="participantCallStatuses" 
+                                    [participantCallStatuses]="participantCallStatuses"
                                     [canInvite]="canInvite"
                                     [status]="getParticipantStatus(participant)"
                                     >
@@ -115,7 +115,7 @@
         [sctsAltText]=""
         [hmctsImageSource]="'/assets/images/UkGovCrestWhite.png'"
         [hmctsAltText]=""
-        alt="" 
-        />                    
+        alt=""
+        />
     </div>
 </ng-template>

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -723,14 +723,44 @@ describe('PrivateConsultationParticipantsComponent', () => {
     });
 
     describe('participantHasInviteRestrictions', () => {
-        beforeEach(() => {
-            conference.participants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
-            component.initParticipants();
+        it('should return true if user is not judical, and participant is in not allowed to be invited', () => {
+            // arrange
+            component.loggedInUser = {
+                role: Role.Individual
+            } as LoggedParticipantResponse;
+            const participant = {
+                hearing_role: HearingRole.WITNESS
+            } as ParticipantListItem;
+            // act
+            const result = component.participantHasInviteRestrictions(participant);
+            // assert
+            expect(result).toBeTrue();
         });
 
-        it('should return true if user is not a joh, and participant is in not allowed to be invited', () => {
-            const privateConsultationParticipants = component.getPrivateConsultationParticipants();
+        it('should return false if user is not judical, and participant is allowed to be invited', () => {
+            // arrange
+            component.loggedInUser = {
+                role: Role.Individual
+            } as LoggedParticipantResponse;
+            const participant = {
+                hearing_role: HearingRole.APPELLANT
+            } as ParticipantListItem;
+            // act
+            const result = component.participantHasInviteRestrictions(participant);
+            // assert
+            expect(result).toBeFalse();
+        });
 
+        it('should return false if user is judical', () => {
+            // arrange
+            // default for this test suit is judge
+            const participant = {
+                hearing_role: HearingRole.STAFF_MEMBER
+            } as ParticipantListItem;
+            // act
+            const result = component.participantHasInviteRestrictions(participant);
+            // assert
+            expect(result).toBeFalse();
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -721,4 +721,16 @@ describe('PrivateConsultationParticipantsComponent', () => {
             expect(quickLinkParticipant2Index).toEqual(5);
         });
     });
+
+    describe('participantHasInviteRestrictions', () => {
+        beforeEach(() => {
+            conference.participants = new ConferenceTestData().getFullListOfNonJudgeParticipants();
+            component.initParticipants();
+        });
+
+        it('should return true if user is not a joh, and participant is in not allowed to be invited', () => {
+            const privateConsultationParticipants = component.getPrivateConsultationParticipants();
+
+        });
+    });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -1,22 +1,16 @@
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
-import {TranslateService} from '@ngx-translate/core';
-import {ConsultationService} from 'src/app/services/api/consultation.service';
-import {VideoWebService} from 'src/app/services/api/video-web.service';
-import {
-    LinkType,
-    ParticipantResponse,
-    ParticipantStatus,
-    Role,
-    VideoEndpointResponse
-} from 'src/app/services/clients/api-client';
-import {EventsService} from 'src/app/services/events.service';
-import {Logger} from 'src/app/services/logging/logger-base';
-import {ParticipantStatusMessage} from 'src/app/services/models/participant-status-message';
-import {RoomTransfer} from 'src/app/shared/models/room-transfer';
-import {HearingRole} from '../../models/hearing-role-model';
-import {WRParticipantStatusListDirective} from '../../waiting-room-shared/wr-participant-list-shared.component';
-import {ParticipantListItem} from '../participant-list-item';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { ConsultationService } from 'src/app/services/api/consultation.service';
+import { VideoWebService } from 'src/app/services/api/video-web.service';
+import { LinkType, ParticipantResponse, ParticipantStatus, Role, VideoEndpointResponse } from 'src/app/services/clients/api-client';
+import { EventsService } from 'src/app/services/events.service';
+import { Logger } from 'src/app/services/logging/logger-base';
+import { ParticipantStatusMessage } from 'src/app/services/models/participant-status-message';
+import { RoomTransfer } from 'src/app/shared/models/room-transfer';
+import { HearingRole } from '../../models/hearing-role-model';
+import { WRParticipantStatusListDirective } from '../../waiting-room-shared/wr-participant-list-shared.component';
+import { ParticipantListItem } from '../participant-list-item';
 
 @Component({
     selector: 'app-private-consultation-participants',
@@ -197,8 +191,11 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
     }
 
     participantHasInviteRestrictions(participant: ParticipantListItem): boolean {
-        const userIsJudicial = (this.loggedInUser.role == Role.Judge || this.loggedInUser.role == Role.StaffMember ||  this.loggedInUser.role == Role.JudicialOfficeHolder);
-        if(!userIsJudicial)
+        const userIsJudicial =
+            this.loggedInUser.role === Role.Judge ||
+            this.loggedInUser.role === Role.StaffMember ||
+            this.loggedInUser.role === Role.JudicialOfficeHolder;
+        if (!userIsJudicial) {
             switch (participant.hearing_role) {
                 case HearingRole.INTERPRETER:
                 case HearingRole.WINGER:
@@ -207,9 +204,11 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
                 case HearingRole.JUDGE:
                 case HearingRole.STAFF_MEMBER:
                 case HearingRole.PANEL_MEMBER:
-                    return true
-                default: return false
+                    return true;
+                default:
+                    return false;
             }
+        }
         return false;
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -197,7 +197,6 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
             this.loggedInUser.role === Role.JudicialOfficeHolder;
         if (!userIsJudicial) {
             switch (participant.hearing_role) {
-                case HearingRole.INTERPRETER:
                 case HearingRole.WINGER:
                 case HearingRole.WITNESS:
                 case HearingRole.OBSERVER:

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -1,16 +1,22 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
-import { ConsultationService } from 'src/app/services/api/consultation.service';
-import { VideoWebService } from 'src/app/services/api/video-web.service';
-import { LinkType, ParticipantResponse, ParticipantStatus, VideoEndpointResponse } from 'src/app/services/clients/api-client';
-import { EventsService } from 'src/app/services/events.service';
-import { Logger } from 'src/app/services/logging/logger-base';
-import { ParticipantStatusMessage } from 'src/app/services/models/participant-status-message';
-import { RoomTransfer } from 'src/app/shared/models/room-transfer';
-import { HearingRole } from '../../models/hearing-role-model';
-import { WRParticipantStatusListDirective } from '../../waiting-room-shared/wr-participant-list-shared.component';
-import { ParticipantListItem } from '../participant-list-item';
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {TranslateService} from '@ngx-translate/core';
+import {ConsultationService} from 'src/app/services/api/consultation.service';
+import {VideoWebService} from 'src/app/services/api/video-web.service';
+import {
+    LinkType,
+    ParticipantResponse,
+    ParticipantStatus,
+    Role,
+    VideoEndpointResponse
+} from 'src/app/services/clients/api-client';
+import {EventsService} from 'src/app/services/events.service';
+import {Logger} from 'src/app/services/logging/logger-base';
+import {ParticipantStatusMessage} from 'src/app/services/models/participant-status-message';
+import {RoomTransfer} from 'src/app/shared/models/room-transfer';
+import {HearingRole} from '../../models/hearing-role-model';
+import {WRParticipantStatusListDirective} from '../../waiting-room-shared/wr-participant-list-shared.component';
+import {ParticipantListItem} from '../participant-list-item';
 
 @Component({
     selector: 'app-private-consultation-participants',
@@ -188,5 +194,22 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
         return participantResponses.map(c => {
             return this.mapResponseToListItem(c);
         });
+    }
+
+    participantHasInviteRestrictions(participant: ParticipantListItem): boolean {
+        const userIsJudicial = (this.loggedInUser.role == Role.Judge || this.loggedInUser.role == Role.StaffMember ||  this.loggedInUser.role == Role.JudicialOfficeHolder);
+        if(!userIsJudicial)
+            switch (participant.hearing_role) {
+                case HearingRole.INTERPRETER:
+                case HearingRole.WINGER:
+                case HearingRole.WITNESS:
+                case HearingRole.OBSERVER:
+                case HearingRole.JUDGE:
+                case HearingRole.STAFF_MEMBER:
+                case HearingRole.PANEL_MEMBER:
+                    return true
+                default: return false
+            }
+        return false;
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.spec.ts
@@ -502,14 +502,16 @@ describe('ParticipantWaitingRoomComponent when conference exists', () => {
         component.openJoinConsultationModal();
         expect(component.displayJoinPrivateConsultationModal).toBeTruthy();
     });
-    it('should return non judge and joh participants from getPrivateConsultationParticipants', () => {
+    it('should return non judge, staff member and joh participants from getPrivateConsultationParticipants', () => {
         const joh = new ParticipantResponse();
         joh.role = Role.JudicialOfficeHolder;
         const judge = new ParticipantResponse();
         judge.role = Role.Judge;
+        const staff = new ParticipantResponse();
+        staff.role = Role.StaffMember;
         const representative = new ParticipantResponse();
         representative.hearing_role = HearingRole.REPRESENTATIVE;
-        component.conference.participants = [judge, judge, representative, representative, representative, joh, joh, joh];
+        component.conference.participants = [judge, judge, representative, representative, representative, joh, joh, joh, staff];
         expect(component.getPrivateConsultationParticipants().length).toBe(3);
     });
     it('should return non observer and witness participants from getPrivateConsultationParticipants', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8974

### Change description ###
The current implementation had no restrictions on what type of user 'Individuals' could invite into the private consultation. Have added an additional rule along side the 'CanInvite' check. Aswell as the list of participants a private consultation can be started with.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
