### PR TITLE
VIH-9039 exempt participants from private consultation panel

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
@@ -49,7 +49,7 @@
                 </app-participant-item>
             </div>
         </ng-container>
-        <ng-container  *ngFor="let participant of getPrivateConsultationParticipants(); trackBy: trackParticipant">
+        <ng-container  *ngFor="let participant of getConsultationParticipants(); trackBy: trackParticipant">
             <div class="member-group">
                 <app-participant-item
                                 [participant]="participant"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.html
@@ -37,7 +37,7 @@
             </ng-container>
         </ng-container>
         <ng-container *ngFor="let staffMember of staffMembers">
-            <div class="member-group">
+            <div class="member-group" *ngIf="!isPrivateConsultation()">
                 <app-participant-item
                     [participant]="staffMember"
                     [conferenceId]="conference.id"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -376,23 +376,24 @@ describe('PrivateConsultationParticipantsComponent', () => {
         interpreter.hearing_role = HearingRole.INTERPRETER;
         const representative = participants[1];
         component.nonJudgeParticipants = [interpreter, representative];
-        expect(component.getPrivateConsultationParticipants().length).toBe(1);
+        expect(component.getConsultationParticipants().length).toBe(1);
     });
 
     it('should not get witness', () => {
+        component.roomLabel = 'participantconsultationroom134';
         const participants = new ConferenceTestData().getListOfParticipants();
         const witness = participants[0];
         witness.hearing_role = HearingRole.WITNESS;
         const representative = participants[1];
         component.nonJudgeParticipants = [witness, representative];
-        expect(component.getPrivateConsultationParticipants().length).toBe(1);
+        expect(component.getConsultationParticipants().length).toBe(1);
     });
 
     it('should sort quick link participants', () => {
         const testData = new ConferenceTestData();
         component.conference.participants = [testData.quickLinkParticipant2, testData.quickLinkParticipant1];
         component.initParticipants();
-        const participants = component.getPrivateConsultationParticipants();
+        const participants = component.getConsultationParticipants();
 
         expect(participants.length).toBe(2);
         expect(participants.find(x => x.display_name === testData.quickLinkParticipant1.display_name)).toBeTruthy();
@@ -707,7 +708,9 @@ describe('PrivateConsultationParticipantsComponent', () => {
         });
 
         it('should return list in correct order', () => {
-            const privateConsultationParticipants = component.getPrivateConsultationParticipants();
+
+            component.roomLabel = 'participantconsultationroom124';
+            const privateConsultationParticipants = component.getConsultationParticipants();
 
             const applicant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr B Smith');
             const applicant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr A Smith'); // interpreter

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -710,11 +710,11 @@ describe('PrivateConsultationParticipantsComponent', () => {
             const privateConsultationParticipants = component.getPrivateConsultationParticipants();
 
             const applicant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr B Smith');
-            const applicant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr A Smith'); //interpreter
-            const applicant3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr G Smith'); //witness
-            const respondent1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr E Smith'); //witness
+            const applicant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr A Smith'); // interpreter
+            const applicant3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr G Smith'); // witness
+            const respondent1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr E Smith'); // witness
             const respondent2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr F Smith');
-            const respondent3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr H Smith'); //interpreter
+            const respondent3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr H Smith'); // interpreter
             const quickLinkParticipant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr C Smith');
             const quickLinkParticipant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr D Smith');
 
@@ -724,7 +724,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
             expect(applicant3Index).toEqual(-1);
             expect(respondent1Index).toEqual(-1);
 
-            //correct ordering
+            // correct ordering
             expect(applicant1Index).toEqual(0);
             expect(respondent2Index).toEqual(1);
             expect(quickLinkParticipant1Index).toEqual(2);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -389,15 +389,6 @@ describe('PrivateConsultationParticipantsComponent', () => {
         expect(component.getConsultationParticipants().length).toBe(1);
     });
 
-    it('should not get witness', () => {
-        const participants = new ConferenceTestData().getListOfParticipants();
-        const witness = participants[0];
-        witness.hearing_role = HearingRole.WITNESS;
-        const representative = participants[1];
-        component.nonJudgeParticipants = [witness, representative];
-        expect(component.getConsultationParticipants().length).toBe(1);
-    });
-
     it('should sort quick link participants', () => {
         const testData = new ConferenceTestData();
         component.conference.participants = [testData.quickLinkParticipant2, testData.quickLinkParticipant1];

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -395,7 +395,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
         witness.hearing_role = HearingRole.WITNESS;
         const representative = participants[1];
         component.nonJudgeParticipants = [witness, representative];
-        expect(component.getPrivateConsultationParticipants().length).toBe(1);
+        expect(component.getConsultationParticipants().length).toBe(1);
     });
 
     it('should sort quick link participants', () => {
@@ -717,7 +717,6 @@ describe('PrivateConsultationParticipantsComponent', () => {
         });
 
         it('should return list in correct order', () => {
-
             component.roomLabel = 'participantconsultationroom124';
             const privateConsultationParticipants = component.getConsultationParticipants();
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -124,8 +124,8 @@ describe('PrivateConsultationParticipantsComponent', () => {
     });
 
     it('should get private consultation', () => {
-        component.roomLabel = 'test-room';
-        expect(component.isJohConsultation()).toEqual(false);
+        component.roomLabel = 'participantconsultationroom134';
+        expect(component.isPrivateConsultation()).toEqual(true);
     });
 
     it('should get yellow row classes', () => {
@@ -376,6 +376,15 @@ describe('PrivateConsultationParticipantsComponent', () => {
         interpreter.hearing_role = HearingRole.INTERPRETER;
         const representative = participants[1];
         component.nonJudgeParticipants = [interpreter, representative];
+        expect(component.getPrivateConsultationParticipants().length).toBe(1);
+    });
+
+    it('should not get witness', () => {
+        const participants = new ConferenceTestData().getListOfParticipants();
+        const witness = participants[0];
+        witness.hearing_role = HearingRole.WITNESS;
+        const representative = participants[1];
+        component.nonJudgeParticipants = [witness, representative];
         expect(component.getPrivateConsultationParticipants().length).toBe(1);
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -710,24 +710,25 @@ describe('PrivateConsultationParticipantsComponent', () => {
             const privateConsultationParticipants = component.getPrivateConsultationParticipants();
 
             const applicant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr B Smith');
-            const applicant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr A Smith');
-            const applicant3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr G Smith');
-            const respondent1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr E Smith');
+            const applicant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr A Smith'); //interpreter
+            const applicant3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr G Smith'); //witness
+            const respondent1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr E Smith'); //witness
             const respondent2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr F Smith');
-            const respondent3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr H Smith');
+            const respondent3Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr H Smith'); //interpreter
             const quickLinkParticipant1Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr C Smith');
             const quickLinkParticipant2Index = privateConsultationParticipants.findIndex(x => x.name === 'Mr D Smith');
 
-            // Interpreters are filtered out
+            // Interpreters and Witnesses are filtered out
             expect(applicant2Index).toEqual(-1);
             expect(respondent3Index).toEqual(-1);
+            expect(applicant3Index).toEqual(-1);
+            expect(respondent1Index).toEqual(-1);
 
+            //correct ordering
             expect(applicant1Index).toEqual(0);
-            expect(applicant3Index).toEqual(1);
-            expect(respondent1Index).toEqual(2);
-            expect(respondent2Index).toEqual(3);
-            expect(quickLinkParticipant1Index).toEqual(4);
-            expect(quickLinkParticipant2Index).toEqual(5);
+            expect(respondent2Index).toEqual(1);
+            expect(quickLinkParticipant1Index).toEqual(2);
+            expect(quickLinkParticipant2Index).toEqual(3);
         });
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -110,8 +110,14 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
         return this.roomLabel?.toLowerCase().includes('judgejohconsultationroom');
     }
 
+    isPrivateConsultation(): boolean {
+        return this.roomLabel?.toLowerCase().includes('participantconsultationroom');
+    }
+
     getPrivateConsultationParticipants(): ParticipantListItem[] {
-        const participants = this.nonJudgeParticipants.filter(x => x.hearing_role !== HearingRole.INTERPRETER);
+        const participants = this.nonJudgeParticipants.filter(
+            x => x.hearing_role !== HearingRole.INTERPRETER && x.hearing_role !== HearingRole.WITNESS
+        );
         return participants.map(c => {
             return this.mapResponseToListItem(c);
         });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -114,10 +114,12 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
         return this.roomLabel?.toLowerCase().includes('participantconsultationroom');
     }
 
-    getPrivateConsultationParticipants(): ParticipantListItem[] {
-        const participants = this.nonJudgeParticipants.filter(
-            x => x.hearing_role !== HearingRole.INTERPRETER && x.hearing_role !== HearingRole.WITNESS
-        );
+    getConsultationParticipants(): ParticipantListItem[] {
+        let participants = this.nonJudgeParticipants.filter(x => x.hearing_role !== HearingRole.INTERPRETER);
+        if (this.isPrivateConsultation()) {
+            participants = participants.filter(x => x.hearing_role !== HearingRole.WITNESS);
+        }
+
         return participants.map(c => {
             return this.mapResponseToListItem(c);
         });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -194,12 +194,14 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         this.logger.debug(`${this.loggerPrefix} Setting up EventHub subscribers`);
         this.eventhubSubscription$.add(
             this.eventService.getParticipantStatusMessage().subscribe(message => {
+                this.logger.warn(`${this.loggerPrefix} getParticipantStatusMessage: ${message.status}`);
                 this.handleParticipantStatusChange(message);
             })
         );
 
         this.eventhubSubscription$.add(
             this.eventService.getEndpointStatusMessage().subscribe(message => {
+                this.logger.warn(`${this.loggerPrefix} getEndpointStatusMessage: ${message.status}`);
                 this.handleEndpointStatusChange(message);
             })
         );

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -194,14 +194,12 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
         this.logger.debug(`${this.loggerPrefix} Setting up EventHub subscribers`);
         this.eventhubSubscription$.add(
             this.eventService.getParticipantStatusMessage().subscribe(message => {
-                this.logger.warn(`${this.loggerPrefix} getParticipantStatusMessage: ${message.status}`);
                 this.handleParticipantStatusChange(message);
             })
         );
 
         this.eventhubSubscription$.add(
             this.eventService.getEndpointStatusMessage().subscribe(message => {
-                this.logger.warn(`${this.loggerPrefix} getEndpointStatusMessage: ${message.status}`);
                 this.handleEndpointStatusChange(message);
             })
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9039

### Change description ###
updated getPrivateConsultationParticipants method, and renamed, as it's used by more than just private consultations, also JOHConsultation ect.. added in conditional filter and updated tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
