### PR TITLE
VIH-9401 vho dashboard shows hearings allocated to cso

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -36,7 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.41.21" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Faker.NETCore" Version="1.0.2" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
-      "BookingsApi.Client": {
-        "type": "Direct",
-        "requested": "[1.41.21, )",
-        "resolved": "1.41.21",
-        "contentHash": "sSB8jkB8Aw88S/qcEDdWphud2PuS83zMoVfHWMfUEZkkASlpF5aZ7+GPjwTwztVpkdG6G3t2WrVrrV+T/hrwsw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
-        }
-      },
       "DotNetSeleniumExtras.WaitHelpers": {
         "type": "Direct",
         "requested": "[3.11.0, )",
@@ -325,6 +316,14 @@
         "type": "Transitive",
         "resolved": "1.5.0",
         "contentHash": "CzIPzdIAFSd2zuLxI+0K9s48Qv3HQDbWiApn9h96j284rHs2bSPrn/PMca3mi4q3xLSEqOp+GUJ6+mXDD9prKg=="
+      },
+      "BookingsApi.Client": {
+        "type": "Transitive",
+        "resolved": "1.41.22",
+        "contentHash": "b63kaT2VkWhadi43Q9NTjvFPcgQB47GjjRdQDayHDbDck1oInNK6yOVCPxUmWRMhOc/BDtgRsdVT7KhOMxhYgA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
+        }
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -2496,6 +2495,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
+          "BookingsApi.Client": "[1.41.22, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",

--- a/VideoWeb/VideoWeb.Common/Configuration/HearingServicesConfiguration.cs
+++ b/VideoWeb/VideoWeb.Common/Configuration/HearingServicesConfiguration.cs
@@ -19,5 +19,6 @@ namespace VideoWeb.Common.Configuration
         public bool EnableIOSTabletSupport { get; set; }
         public bool EnableDynamicEvidenceSharing { get; set; }
         public int BlurRadius { get; set; }
+        public string LaunchDarklyClientId { get; set; }
     }
 }

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BookingsApi.Client" Version="1.41.22" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />

--- a/VideoWeb/VideoWeb.Contract/Responses/ClientSettingsResponse.cs
+++ b/VideoWeb/VideoWeb.Contract/Responses/ClientSettingsResponse.cs
@@ -74,5 +74,10 @@ namespace VideoWeb.Contract.Responses
         /// Blur radius in pixels
         /// </summary>
         public int BlurRadius { get; set; }
+
+        /// <summary>
+        /// Launch Darkly Client for feature toggling
+        /// </summary>
+        public string LaunchDarklyClientId { get; set; }
     }
 }

--- a/VideoWeb/VideoWeb.IntegrationTests/VideoWeb.IntegrationTests.csproj
+++ b/VideoWeb/VideoWeb.IntegrationTests/VideoWeb.IntegrationTests.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.41.21" />
     <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VideoWeb/VideoWeb.IntegrationTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.IntegrationTests/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
-      "BookingsApi.Client": {
-        "type": "Direct",
-        "requested": "[1.41.21, )",
-        "resolved": "1.41.21",
-        "contentHash": "sSB8jkB8Aw88S/qcEDdWphud2PuS83zMoVfHWMfUEZkkASlpF5aZ7+GPjwTwztVpkdG6G3t2WrVrrV+T/hrwsw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
-        }
-      },
       "coverlet.msbuild": {
         "type": "Direct",
         "requested": "[3.2.0, )",
@@ -80,6 +71,14 @@
           "System.Threading.Thread": "4.3.0",
           "System.Xml.XPath.XmlDocument": "4.3.0",
           "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
+      "BookingsApi.Client": {
+        "type": "Transitive",
+        "resolved": "1.41.22",
+        "contentHash": "b63kaT2VkWhadi43Q9NTjvFPcgQB47GjjRdQDayHDbDck1oInNK6yOVCPxUmWRMhOc/BDtgRsdVT7KhOMxhYgA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
       },
       "Castle.Core": {
@@ -2697,7 +2696,7 @@
       "videoweb": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.41.21, )",
+          "BookingsApi.Client": "[1.41.22, )",
           "Castle.Core": "[4.4.0, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",
@@ -2730,6 +2729,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
+          "BookingsApi.Client": "[1.41.22, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/UserDataControllerTest.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/UserDataControllerTest.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using BookingsApi.Client;
+using BookingsApi.Contract.Responses;
 using VideoWeb.Contract.Request;
 using VideoWeb.Contract.Responses;
 using VideoWeb.Controllers;
@@ -76,6 +78,23 @@ namespace VideoWeb.UnitTests.Controllers
             typedResult.Should().NotBeNull();
             typedResult.StatusCode.Should().Be(apiException.StatusCode);
         }
+
+        [Test]
+        public async Task GetVenuesByCso_should_return_list_of_venue_names()
+        {
+            var csos = new List<JusticeUserResponse>
+            {
+                Mock.Of<JusticeUserResponse>(),
+                Mock.Of<JusticeUserResponse>(),
+                Mock.Of<JusticeUserResponse>(),
+            };
+            _mocker.Mock<IBookingsApiClient>().Setup(x => x.GetJusticeUserListAsync()).ReturnsAsync(csos);
+            var result = await _sut.GetJusticeUsers();
+            var objectResult = result.Result as OkObjectResult;
+            objectResult.Should().NotBeNull();
+            objectResult?.StatusCode.Should().Be(200);
+            objectResult?.Value.Should().BeEquivalentTo(csos);
+        }     
     }
 }
 

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/VenueControllerTest.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/VenueControllerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
@@ -9,29 +10,25 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using VideoWeb.Controllers;
-using VideoApi.Client;
-using VideoApi.Contract.Responses;
 
 namespace VideoWeb.UnitTests.Controllers
 {
     public class VenueControllerTest
     {
         private VenuesController _controller;
-        private Mock<IVideoApiClient> _videoApiClientMock;
         private Mock<ILogger<VenuesController>> _mockLogger;
         private Mock<IBookingsApiClient> _bookingsApiClientMock;
 
         [SetUp]
         public void Setup()
         {
-            _videoApiClientMock = new Mock<IVideoApiClient>();
             _mockLogger = new Mock<ILogger<VenuesController>>();
             _bookingsApiClientMock = new Mock<IBookingsApiClient>();
-            _controller = new VenuesController(_videoApiClientMock.Object, _mockLogger.Object, _bookingsApiClientMock.Object);
+            _controller = new VenuesController( _mockLogger.Object, _bookingsApiClientMock.Object);
         }
 
         [Test]
-        public async Task Should_return_list_of_judges_with_hearings_with_status_ok()
+        public async Task GetVenues_Should_return_list_of_judges_with_hearings_with_status_ok()
         {
             var judges = new List<HearingVenueResponse>();
             _bookingsApiClientMock.Setup(x => x.GetHearingVenuesAsync()).ReturnsAsync(judges);
@@ -43,7 +40,7 @@ namespace VideoWeb.UnitTests.Controllers
         }
 
         [Test]
-        public async Task Should_return_error_when_unable_to_retrieve_venues()
+        public async Task GetVenues_Should_return_error_when_unable_to_retrieve_venues()
         {
             var apiException = new BookingsApiException("Venues not found", (int)HttpStatusCode.NotFound,
                 "Error", null, null);
@@ -55,6 +52,47 @@ namespace VideoWeb.UnitTests.Controllers
             var typedResult = (NotFoundResult)result.Result;
             typedResult.Should().NotBeNull();
             typedResult.StatusCode.Should().Be(apiException.StatusCode);
+        }
+        
+        [Test]
+        public async Task GetVenuesByCso_should_return_list_of_venue_names()
+        {
+            var venueNames = new List<string>
+            {
+                "Woolwich Crown Court",
+                "Birmingham Crown and Civil",
+                "Camelot, The court of King Arthur"
+            };
+            _bookingsApiClientMock.Setup(x => x.GetHearingVenuesByAllocatedCsoAsync(It.IsAny<Guid[]>())).ReturnsAsync(venueNames);
+            var result = await _controller.GetVenuesByCso(It.IsAny<Guid[]>());
+            var objectResult = result.Result as OkObjectResult;
+            objectResult.Should().NotBeNull();
+            objectResult?.StatusCode.Should().Be(200);
+            objectResult?.Value.Should().BeEquivalentTo(venueNames);
+        }        
+        
+        [Test]
+        public async Task GetVenuesByCso_should_catch_404_and_return_Ok_and_empty_list()
+        {
+            _bookingsApiClientMock.Setup(x => x.GetHearingVenuesByAllocatedCsoAsync(It.IsAny<Guid[]>()))
+                .ThrowsAsync(new BookingsApiException("Not Found", 404, "", It.IsAny<IReadOnlyDictionary<string, IEnumerable<string>>>(), It.IsAny<Exception>()));
+            var result = await _controller.GetVenuesByCso(It.IsAny<Guid[]>());
+            var objectResult = result.Result as OkObjectResult;
+            objectResult.Should().NotBeNull();
+            objectResult?.StatusCode.Should().Be(200);
+            objectResult?.Value.Should().NotBeNull();
+            objectResult?.Value.Should().BeEquivalentTo(new List<string>());
+        }       
+        
+        [Test]
+        public async Task GetVenuesByCso_should_catch_and_return_500()
+        {
+            _bookingsApiClientMock.Setup(x => x.GetHearingVenuesByAllocatedCsoAsync(It.IsAny<Guid[]>()))
+                .ThrowsAsync(new BookingsApiException("Internal Server Error", 500, "", It.IsAny<IReadOnlyDictionary<string, IEnumerable<string>>>(), It.IsAny<Exception>()));
+            var result = await _controller.GetVenuesByCso(It.IsAny<Guid[]>());
+            var objectResult = result.Result as ObjectResult;
+            objectResult.Should().NotBeNull();
+            objectResult?.StatusCode.Should().Be(500);
         }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.41.21",
-        "contentHash": "sSB8jkB8Aw88S/qcEDdWphud2PuS83zMoVfHWMfUEZkkASlpF5aZ7+GPjwTwztVpkdG6G3t2WrVrrV+T/hrwsw==",
+        "resolved": "1.41.22",
+        "contentHash": "b63kaT2VkWhadi43Q9NTjvFPcgQB47GjjRdQDayHDbDck1oInNK6yOVCPxUmWRMhOc/BDtgRsdVT7KhOMxhYgA==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2351,7 +2351,7 @@
       "videoweb": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.41.21, )",
+          "BookingsApi.Client": "[1.41.22, )",
           "Castle.Core": "[4.4.0, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",
@@ -2384,6 +2384,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
+          "BookingsApi.Client": "[1.41.22, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",

--- a/VideoWeb/VideoWeb/ClientApp/package-lock.json
+++ b/VideoWeb/VideoWeb/ClientApp/package-lock.json
@@ -8964,9 +8964,9 @@
             }
         },
         "nswag": {
-            "version": "13.18.2",
-            "resolved": "https://registry.npmjs.org/nswag/-/nswag-13.18.2.tgz",
-            "integrity": "sha512-7OpG9WkrZUO2+9I7hgQsaAHujsP/tCaIs7ML2B4wUuFLjSsG6lHucyrREyVO/h9l3MM/Cw4RlEGFBbluWhgeYg==",
+            "version": "13.13.2",
+            "resolved": "https://registry.npmjs.org/nswag/-/nswag-13.13.2.tgz",
+            "integrity": "sha512-L3Jraa8Ml7KKSBAcjvdo+suDT2HxgpQ0S3uaK29P3b40n3GPY/c0VrfjsQqDPfb0zjKri0F4xby6/6meUNwPMw==",
             "dev": true
         },
         "nth-check": {

--- a/VideoWeb/VideoWeb/ClientApp/package-lock.json
+++ b/VideoWeb/VideoWeb/ClientApp/package-lock.json
@@ -8964,10 +8964,9 @@
             }
         },
         "nswag": {
-            "version": "13.13.2",
-            "resolved": "https://registry.npmjs.org/nswag/-/nswag-13.13.2.tgz",
-            "integrity": "sha512-L3Jraa8Ml7KKSBAcjvdo+suDT2HxgpQ0S3uaK29P3b40n3GPY/c0VrfjsQqDPfb0zjKri0F4xby6/6meUNwPMw==",
-            "dev": true
+            "version": "13.18.2",
+            "resolved": "https://registry.npmjs.org/nswag/-/nswag-13.18.2.tgz",
+            "integrity": "sha512-7OpG9WkrZUO2+9I7hgQsaAHujsP/tCaIs7ML2B4wUuFLjSsG6lHucyrREyVO/h9l3MM/Cw4RlEGFBbluWhgeYg=="
         },
         "nth-check": {
             "version": "2.0.1",

--- a/VideoWeb/VideoWeb/ClientApp/package-lock.json
+++ b/VideoWeb/VideoWeb/ClientApp/package-lock.json
@@ -3440,8 +3440,7 @@
         "base64-js": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-            "dev": true
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "base64id": {
             "version": "2.0.0",
@@ -7737,6 +7736,44 @@
             "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
             "dev": true
         },
+        "launchdarkly-js-client-sdk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.1.0.tgz",
+            "integrity": "sha512-8aM3Wp5ZAS/TCIELOYkEs4CFzih/g7sO+YCHNQ5g0k80WDMTmTcGLMLhCKmrzaQnMK21HiBwbkBpAYnyzr5yUQ==",
+            "requires": {
+                "escape-string-regexp": "^4.0.0",
+                "launchdarkly-js-sdk-common": "5.0.1"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                }
+            }
+        },
+        "launchdarkly-js-sdk-common": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.1.tgz",
+            "integrity": "sha512-NPPU/9bT4hUCbglCCMAm9XGDWnRKs3aJ1OMhRF8g6xTUWAjOO2FieoGjwVbUVvOYKIiINVVtAWUiuVYbix1lqw==",
+            "requires": {
+                "base64-js": "^1.3.0",
+                "fast-deep-equal": "^2.0.1",
+                "uuid": "^8.0.0"
+            },
+            "dependencies": {
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
+            }
+        },
         "less": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/less/-/less-4.1.1.tgz",
@@ -8966,7 +9003,8 @@
         "nswag": {
             "version": "13.18.2",
             "resolved": "https://registry.npmjs.org/nswag/-/nswag-13.18.2.tgz",
-            "integrity": "sha512-7OpG9WkrZUO2+9I7hgQsaAHujsP/tCaIs7ML2B4wUuFLjSsG6lHucyrREyVO/h9l3MM/Cw4RlEGFBbluWhgeYg=="
+            "integrity": "sha512-7OpG9WkrZUO2+9I7hgQsaAHujsP/tCaIs7ML2B4wUuFLjSsG6lHucyrREyVO/h9l3MM/Cw4RlEGFBbluWhgeYg==",
+            "dev": true
         },
         "nth-check": {
             "version": "2.0.1",

--- a/VideoWeb/VideoWeb/ClientApp/package.json
+++ b/VideoWeb/VideoWeb/ClientApp/package.json
@@ -63,6 +63,7 @@
         "core-js": "^3.8.2",
         "govuk-frontend": "^3.14.0",
         "guid-typescript": "^1.0.9",
+        "launchdarkly-js-client-sdk": "^3.1.0",
         "moment": "^2.29.1",
         "ng2-charts": "^2.4.2",
         "ngx-clipboard": "^14.0.1",

--- a/VideoWeb/VideoWeb/ClientApp/package.json
+++ b/VideoWeb/VideoWeb/ClientApp/package.json
@@ -11,6 +11,7 @@
         "test-once": "ng test --watch=false --code-coverage",
         "test-once-ci": "ng test --browsers=ChromeHeadlessNoPrompt --watch=false --code-coverage",
         "lint": "ng lint && npm run prettify && npm run translations-lint",
+        "lint-fix": "ng lint --fix && npm run prettify-fix",
         "translations-lint": "npx jsonlint-cli src/assets/i18n/*.json",
         "prettify": "run-script-os",
         "prettify:nix": "npx prettier -c 'src/app/**/*.*'",

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/api/video-web.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/api/video-web.service.ts
@@ -23,7 +23,8 @@ import {
     LoggedParticipantResponse,
     AllowedEndpointResponse,
     HearingVenueResponse,
-    StaffMemberJoinConferenceRequest
+    StaffMemberJoinConferenceRequest,
+    JusticeUserResponse
 } from '../clients/api-client';
 import { ConferenceLite } from '../models/conference-lite';
 import { SessionStorage } from '../session-storage';
@@ -97,6 +98,14 @@ export class VideoWebService implements IVideoWebApiService {
 
     getVenues(): Observable<HearingVenueResponse[]> {
         return this.apiClient.getVenues();
+    }
+
+    getCSOs(): Observable<JusticeUserResponse[]> {
+        return this.apiClient.getCSOs();
+    }
+
+    getVenuesForAllocatedCSOs(csoIds): Observable<string[]> {
+        return this.apiClient.getVenuesByAllocatedCso(csoIds);
     }
 
     staffMemberJoinConference(conferenceId: string, request: StaffMemberJoinConferenceRequest): Promise<ConferenceForHostResponse> {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/clients/api-client.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/clients/api-client.ts
@@ -6358,6 +6358,101 @@ export class ApiClient extends ApiClientBase {
     }
 
     /**
+     * Get CSOS
+     * @return Success
+     */
+    getCSOs(): Observable<JusticeUserResponse[]> {
+        let url_ = this.baseUrl + '/api/accounts/csos';
+        url_ = url_.replace(/[?&]$/, '');
+
+        let options_: any = {
+            observe: 'response',
+            responseType: 'blob',
+            headers: new HttpHeaders({
+                Accept: 'application/json'
+            })
+        };
+
+        return _observableFrom(this.transformOptions(options_))
+            .pipe(
+                _observableMergeMap(transformedOptions_ => {
+                    return this.http.request('get', url_, transformedOptions_);
+                })
+            )
+            .pipe(
+                _observableMergeMap((response_: any) => {
+                    return this.processGetCSOs(response_);
+                })
+            )
+            .pipe(
+                _observableCatch((response_: any) => {
+                    if (response_ instanceof HttpResponseBase) {
+                        try {
+                            return this.processGetCSOs(response_ as any);
+                        } catch (e) {
+                            return _observableThrow(e) as any as Observable<JusticeUserResponse[]>;
+                        }
+                    } else return _observableThrow(response_) as any as Observable<JusticeUserResponse[]>;
+                })
+            );
+    }
+
+    protected processGetCSOs(response: HttpResponseBase): Observable<JusticeUserResponse[]> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse
+                ? response.body
+                : (response as any).error instanceof Blob
+                ? (response as any).error
+                : undefined;
+
+        let _headers: any = {};
+        if (response.headers) {
+            for (let key of response.headers.keys()) {
+                _headers[key] = response.headers.get(key);
+            }
+        }
+        if (status === 500) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    let result500: any = null;
+                    let resultData500 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    result500 = resultData500 !== undefined ? resultData500 : <any>null;
+
+                    return throwException('Server Error', status, _responseText, _headers, result500);
+                })
+            );
+        } else if (status === 200) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    let result200: any = null;
+                    let resultData200 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    if (Array.isArray(resultData200)) {
+                        result200 = [] as any;
+                        for (let item of resultData200) result200!.push(JusticeUserResponse.fromJS(item));
+                    } else {
+                        result200 = <any>null;
+                    }
+                    return _observableOf(result200);
+                })
+            );
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    return throwException('Unauthorized', status, _responseText, _headers);
+                })
+            );
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    return throwException('An unexpected server error occurred.', status, _responseText, _headers);
+                })
+            );
+        }
+        return _observableOf<JusticeUserResponse[]>(null as any);
+    }
+
+    /**
      * Get available courts
      * @return Success
      */
@@ -6459,6 +6554,117 @@ export class ApiClient extends ApiClientBase {
             );
         }
         return _observableOf<HearingVenueResponse[]>(null as any);
+    }
+
+    /**
+     * Get Hearing Venue Names By Cso
+     * @param csos (optional)
+     * @return Success
+     */
+    getVenuesByAllocatedCso(csos: string[] | undefined): Observable<string[]> {
+        let url_ = this.baseUrl + '/hearing-venues/allocated-cso?';
+        if (csos === null) throw new Error("The parameter 'csos' cannot be null.");
+        else if (csos !== undefined)
+            csos &&
+                csos.forEach(item => {
+                    url_ += 'csos=' + encodeURIComponent('' + item) + '&';
+                });
+        url_ = url_.replace(/[?&]$/, '');
+
+        let options_: any = {
+            observe: 'response',
+            responseType: 'blob',
+            headers: new HttpHeaders({
+                Accept: 'application/json'
+            })
+        };
+
+        return _observableFrom(this.transformOptions(options_))
+            .pipe(
+                _observableMergeMap(transformedOptions_ => {
+                    return this.http.request('get', url_, transformedOptions_);
+                })
+            )
+            .pipe(
+                _observableMergeMap((response_: any) => {
+                    return this.processGetVenuesByAllocatedCso(response_);
+                })
+            )
+            .pipe(
+                _observableCatch((response_: any) => {
+                    if (response_ instanceof HttpResponseBase) {
+                        try {
+                            return this.processGetVenuesByAllocatedCso(response_ as any);
+                        } catch (e) {
+                            return _observableThrow(e) as any as Observable<string[]>;
+                        }
+                    } else return _observableThrow(response_) as any as Observable<string[]>;
+                })
+            );
+    }
+
+    protected processGetVenuesByAllocatedCso(response: HttpResponseBase): Observable<string[]> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse
+                ? response.body
+                : (response as any).error instanceof Blob
+                ? (response as any).error
+                : undefined;
+
+        let _headers: any = {};
+        if (response.headers) {
+            for (let key of response.headers.keys()) {
+                _headers[key] = response.headers.get(key);
+            }
+        }
+        if (status === 500) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    let result500: any = null;
+                    let resultData500 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    result500 = resultData500 !== undefined ? resultData500 : <any>null;
+
+                    return throwException('Server Error', status, _responseText, _headers, result500);
+                })
+            );
+        } else if (status === 200) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    let result200: any = null;
+                    let resultData200 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    if (Array.isArray(resultData200)) {
+                        result200 = [] as any;
+                        for (let item of resultData200) result200!.push(item);
+                    } else {
+                        result200 = <any>null;
+                    }
+                    return _observableOf(result200);
+                })
+            );
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    let result404: any = null;
+                    let resultData404 = _responseText === '' ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                    result404 = ProblemDetails.fromJS(resultData404);
+                    return throwException('Not Found', status, _responseText, _headers, result404);
+                })
+            );
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    return throwException('Unauthorized', status, _responseText, _headers);
+                })
+            );
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(
+                _observableMergeMap(_responseText => {
+                    return throwException('An unexpected server error occurred.', status, _responseText, _headers);
+                })
+            );
+        }
+        return _observableOf<string[]>(null as any);
     }
 
     /**
@@ -6709,6 +6915,81 @@ export class HearingVenueResponse implements IHearingVenueResponse {
 export interface IHearingVenueResponse {
     id?: number;
     name?: string | undefined;
+}
+
+export class JusticeUserResponse implements IJusticeUserResponse {
+    id?: string;
+    first_name?: string | undefined;
+    lastname?: string | undefined;
+    contact_email?: string | undefined;
+    username?: string | undefined;
+    telephone?: string | undefined;
+    user_role_id?: number;
+    user_role_name?: string | undefined;
+    is_vh_team_leader?: boolean;
+    created_by?: string | undefined;
+    full_name?: string | undefined;
+
+    constructor(data?: IJusticeUserResponse) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property)) (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data['id'];
+            this.first_name = _data['first_name'];
+            this.lastname = _data['lastname'];
+            this.contact_email = _data['contact_email'];
+            this.username = _data['username'];
+            this.telephone = _data['telephone'];
+            this.user_role_id = _data['user_role_id'];
+            this.user_role_name = _data['user_role_name'];
+            this.is_vh_team_leader = _data['is_vh_team_leader'];
+            this.created_by = _data['created_by'];
+            this.full_name = _data['full_name'];
+        }
+    }
+
+    static fromJS(data: any): JusticeUserResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new JusticeUserResponse();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data['id'] = this.id;
+        data['first_name'] = this.first_name;
+        data['lastname'] = this.lastname;
+        data['contact_email'] = this.contact_email;
+        data['username'] = this.username;
+        data['telephone'] = this.telephone;
+        data['user_role_id'] = this.user_role_id;
+        data['user_role_name'] = this.user_role_name;
+        data['is_vh_team_leader'] = this.is_vh_team_leader;
+        data['created_by'] = this.created_by;
+        data['full_name'] = this.full_name;
+        return data;
+    }
+}
+
+export interface IJusticeUserResponse {
+    id?: string;
+    first_name?: string | undefined;
+    lastname?: string | undefined;
+    contact_email?: string | undefined;
+    username?: string | undefined;
+    telephone?: string | undefined;
+    user_role_id?: number;
+    user_role_name?: string | undefined;
+    is_vh_team_leader?: boolean;
+    created_by?: string | undefined;
+    full_name?: string | undefined;
 }
 
 export class ProblemDetails implements IProblemDetails {
@@ -8478,6 +8759,8 @@ export class ClientSettingsResponse implements IClientSettingsResponse {
     enable_dynamic_evidence_sharing?: boolean;
     /** Blur radius in pixels */
     blur_radius?: number;
+    /** Launch Darkly Client for feature toggling */
+    launch_darkly_client_id?: string | undefined;
 
     constructor(data?: IClientSettingsResponse) {
         if (data) {
@@ -8505,6 +8788,7 @@ export class ClientSettingsResponse implements IClientSettingsResponse {
             this.enable_ios_tablet_support = _data['enable_ios_tablet_support'];
             this.enable_dynamic_evidence_sharing = _data['enable_dynamic_evidence_sharing'];
             this.blur_radius = _data['blur_radius'];
+            this.launch_darkly_client_id = _data['launch_darkly_client_id'];
         }
     }
 
@@ -8531,6 +8815,7 @@ export class ClientSettingsResponse implements IClientSettingsResponse {
         data['enable_ios_tablet_support'] = this.enable_ios_tablet_support;
         data['enable_dynamic_evidence_sharing'] = this.enable_dynamic_evidence_sharing;
         data['blur_radius'] = this.blur_radius;
+        data['launch_darkly_client_id'] = this.launch_darkly_client_id;
         return data;
     }
 }
@@ -8563,6 +8848,8 @@ export interface IClientSettingsResponse {
     enable_dynamic_evidence_sharing?: boolean;
     /** Blur radius in pixels */
     blur_radius?: number;
+    /** Launch Darkly Client for feature toggling */
+    launch_darkly_client_id?: string | undefined;
 }
 
 export class ConferenceForHostResponse implements IConferenceForHostResponse {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { ConfigService } from './api/config.service';
-
+import { Logger } from 'src/app/services/logging/logger-base';
 import { LaunchDarklyService } from './launch-darkly.service';
 
 describe('LaunchDarklyService', () => {
@@ -10,7 +10,7 @@ describe('LaunchDarklyService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            providers: [{ provide: ConfigService, useValue: configServiceSpy }]
+            providers: [{ provide: ConfigService, useValue: configServiceSpy }, Logger]
         });
         service = TestBed.inject(LaunchDarklyService);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from './api/config.service';
+
+import { LaunchDarklyService } from './launch-darkly.service';
+
+describe('LaunchDarklyService', () => {
+    let service: LaunchDarklyService;
+    const configServiceSpy = jasmine.createSpyObj('ConfigService', ['getConfig']);
+    configServiceSpy.getConfig.and.returnValue({ launch_darkly_client_id: 'client_id' });
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [{ provide: ConfigService, useValue: configServiceSpy }]
+        });
+        service = TestBed.inject(LaunchDarklyService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    it('LD client should be intialised', () => {
+        service.initialize();
+        expect(service.ldClient).toBeDefined();
+    });
+
+    it('should trigger onReady event', () => {
+        spyOn(service.ldClient, 'on').and.callThrough();
+        service.onReady();
+        expect(service.ldClient.on).toHaveBeenCalledTimes(1);
+        expect(service.ldClient.on).toHaveBeenCalledWith('ready', jasmine.any(Function));
+    });
+
+    it('should trigger onChange event', () => {
+        spyOn(service.ldClient, 'on').and.callThrough();
+        service.onChange();
+        expect(service.ldClient.on).toHaveBeenCalledTimes(1);
+        expect(service.ldClient.on).toHaveBeenCalledWith('change', jasmine.any(Function));
+    });
+});

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import * as LDClient from 'launchdarkly-js-client-sdk';
 import { ReplaySubject } from 'rxjs';
 import { ConfigService } from './api/config.service';
+import { Logger } from 'src/app/services/logging/logger-base';
 
 export const FEATURE_FLAGS = {
     vhoWorkAllocation: 'vho-work-allocation'
@@ -15,7 +16,7 @@ export class LaunchDarklyService {
     ldClient: LDClient.LDClient;
     flagChange = new ReplaySubject();
 
-    constructor(private configService: ConfigService) {
+    constructor(private configService: ConfigService, private logger: Logger) {
         this.initialize();
 
         this.onReady();
@@ -42,13 +43,13 @@ export class LaunchDarklyService {
                 this.flags[flag] = flags[flag].current;
             }
             this.flagChange.next(this.flags);
-            console.log('Flags updated', this.flags);
+            this.logger.info('Flags updated', this.flags);
         });
     }
 
     private setAllFlags(): void {
         this.flags = this.ldClient.allFlags();
         this.flagChange.next(this.flags);
-        console.log('Flags initialized');
+        this.logger.info('Flags initialized');
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import * as LDClient from 'launchdarkly-js-client-sdk';
+import { ReplaySubject } from 'rxjs';
+import { ConfigService } from './api/config.service';
+
+export const FEATURE_FLAGS = {
+    vhoWorkAllocation: 'vho-work-allocation'
+};
+
+@Injectable({
+    providedIn: 'root'
+})
+export class LaunchDarklyService {
+    private flags: any;
+    ldClient: LDClient.LDClient;
+    flagChange = new ReplaySubject();
+
+    constructor(private configService: ConfigService) {
+        this.initialize();
+
+        this.onReady();
+
+        this.onChange();
+    }
+
+    initialize(): void {
+        this.flags = {};
+        const ldClientId = this.configService.getConfig().launch_darkly_client_id;
+        const user: LDClient.LDUser = { key: 'VideoWeb', anonymous: true };
+        this.ldClient = LDClient.initialize(ldClientId, user);
+    }
+
+    onReady(): void {
+        this.ldClient.on('ready', flags => {
+            this.setAllFlags();
+        });
+    }
+
+    onChange(): void {
+        this.ldClient.on('change', flags => {
+            for (const flag of Object.keys(flags)) {
+                this.flags[flag] = flags[flag].current;
+            }
+            this.flagChange.next(this.flags);
+            console.log('Flags updated', this.flags);
+        });
+    }
+
+    private setAllFlags(): void {
+        this.flags = this.ldClient.allFlags();
+        this.flagChange.next(this.flags);
+        console.log('Flags initialized');
+    }
+}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/staff-member-venue-list/staff-member-venue-list.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/staff-member-venue-list/staff-member-venue-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { Router } from '@angular/router';
-import { of } from 'rxjs';
+import { of, ReplaySubject } from 'rxjs';
 import { VideoWebService } from 'src/app/services/api/video-web.service';
 import { CourtRoomsAccountResponse, HearingVenueResponse } from 'src/app/services/clients/api-client';
 import { Logger } from 'src/app/services/logging/logger-base';
@@ -10,6 +10,10 @@ import { CourtRoomsAccounts } from '../../../vh-officer/services/models/court-ro
 import { VhoStorageKeys } from '../../../vh-officer/services/models/session-keys';
 import { pageUrls } from '../../page-url.constants';
 import { StaffMemberVenueListComponent } from './staff-member-venue-list.component';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { LaunchDarklyService } from '../../../services/launch-darkly.service';
+import { TranslatePipeMock } from '../../../testing/mocks/mock-translation-pipe';
 
 describe('StaffMemerVenueListComponent', () => {
     let component: StaffMemberVenueListComponent;
@@ -17,6 +21,7 @@ describe('StaffMemerVenueListComponent', () => {
     let router: jasmine.SpyObj<Router>;
     let vhoQueryService: jasmine.SpyObj<VhoQueryService>;
     const logger: Logger = new MockLogger();
+    let launchDarklyServiceSpy: jasmine.SpyObj<LaunchDarklyService>;
 
     const venueSessionStorage = new SessionStorage<string[]>(VhoStorageKeys.VENUE_ALLOCATIONS_KEY);
 
@@ -49,17 +54,37 @@ describe('StaffMemerVenueListComponent', () => {
         videoWebServiceSpy = jasmine.createSpyObj<VideoWebService>('VideoWebService', ['getVenues']);
         router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
         vhoQueryService = jasmine.createSpyObj<VhoQueryService>('VhoQueryService', ['getCourtRoomsAccounts']);
+        launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['flagChange']);
     });
 
     beforeEach(() => {
-        component = new StaffMemberVenueListComponent(videoWebServiceSpy, router, vhoQueryService, logger);
+        component = new StaffMemberVenueListComponent(videoWebServiceSpy, router, vhoQueryService, logger, launchDarklyServiceSpy);
         videoWebServiceSpy.getVenues.and.returnValue(of(venueNames));
         vhoQueryService.getCourtRoomsAccounts.and.returnValue(Promise.resolve(courtAccounts));
+        launchDarklyServiceSpy.flagChange = new ReplaySubject();
+        launchDarklyServiceSpy.flagChange.next({ 'vho-work-allocation': true });
         venueSessionStorage.clear();
     });
 
     it('should navigate to staff member hearing list', () => {
         component.goToHearingList();
         expect(router.navigateByUrl).toHaveBeenCalledWith(pageUrls.StaffMemberHearingList);
+    });
+
+    describe('component rendering', () => {
+        it('Should not show cso list, when implemented by staff-member-venue-list and feature flag on', () => {
+            TestBed.configureTestingModule({
+                declarations: [StaffMemberVenueListComponent, TranslatePipeMock],
+                providers: [
+                    { provide: VideoWebService, useValue: videoWebServiceSpy },
+                    { provide: Router, useValue: router },
+                    { provide: VhoQueryService, useValue: vhoQueryService },
+                    { provide: Logger, useValue: logger },
+                    { provide: LaunchDarklyService, useValue: launchDarklyServiceSpy }
+                ]
+            });
+            const fixture = TestBed.createComponent(StaffMemberVenueListComponent);
+            expect(fixture.debugElement.query(By.css('#cso-list'))).toBeFalsy();
+        });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/staff-member-venue-list/staff-member-venue-list.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/staff-member-venue-list/staff-member-venue-list.component.ts
@@ -5,6 +5,7 @@ import { Logger } from 'src/app/services/logging/logger-base';
 import { VhoQueryService } from 'src/app/vh-officer/services/vho-query-service.service';
 import { pageUrls } from '../../page-url.constants';
 import { VenueListComponentDirective } from '../venue-list.component';
+import { LaunchDarklyService } from '../../../services/launch-darkly.service';
 
 @Component({
     selector: 'app-staff-member-venue-list',
@@ -16,9 +17,14 @@ export class StaffMemberVenueListComponent extends VenueListComponentDirective {
         protected videoWebService: VideoWebService,
         protected router: Router,
         protected vhoQueryService: VhoQueryService,
-        protected logger: Logger
+        protected logger: Logger,
+        protected ldService: LaunchDarklyService
     ) {
-        super(videoWebService, router, vhoQueryService, logger);
+        super(videoWebService, router, vhoQueryService, logger, ldService);
+    }
+
+    get showVhoSpecificContent(): boolean {
+        return false;
     }
 
     goToHearingList() {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/venue-list.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/venue-list.component.html
@@ -2,21 +2,37 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-m">{{'venue-list.title' | translate}}</h1>
   </div>
-
-  <div class="govuk-grid-column-three-quarters">
-    <ng-select id="venue-allocation-list" class="custom"
-      [attr.aria-label]="'venue-list.allocation-list-label' | translate" [items]="venues" [multiple]="true"
-      bindLabel="name" bindValue="name" [placeholder]="'venue-list.selection-default-text' | translate" [(ngModel)]="selectedVenues" [closeOnSelect]="false"
-      (change)="updateSelection()" [clearSearchOnAdd]="true" [selectOnTab]="true">
-      <ng-template ng-option-tmp let-item="item" let-item$="item$" let-index="index">
-        <input id="venue-{{ index }}" type="checkbox" [ngModel]="item$.selected"
-          [attr.aria-label]="'venue-list.label' | translate: { name: item.name}" />
-        {{ item.name }}
-      </ng-template>
-    </ng-select>
-  </div>
+    <div class="govuk-grid-column-three-quarters">
+        <ng-select id="venue-allocation-list" class="selection-list"
+                   [attr.aria-label]="'venue-list.allocation-list-label' | translate" [items]="venues" [multiple]="true"
+                   bindLabel="name" bindValue="name" [placeholder]="'venue-list.selection-default-text' | translate" [(ngModel)]="selectedVenues" [closeOnSelect]="false"
+                   (change)="updateVenueSelection()" [clearSearchOnAdd]="true" [selectOnTab]="true">
+            <ng-template ng-option-tmp let-item="item" let-item$="item$" let-index="index">
+                <input id="venue-{{ index }}" type="checkbox" [ngModel]="item$.selected" [attr.aria-label]="'venue-list.label' | translate: { name: item.name}" />
+                {{ item.name }}
+            </ng-template>
+        </ng-select>
+    </div>
+    <div id="cso-list" *ngIf="vhoWorkAllocationFeatureFlag && showVhoSpecificContent">
+        <div class="govuk-grid-column-full">
+            <p>OR</p>
+        </div>
+        <div class="govuk-grid-column-three-quarters">
+            <ng-select id="cso-allocation-list" class="selection-list" [attr.aria-label]="'Cso list'" [items]="csos" [multiple]="true"
+                       bindLabel="first_name" bindValue="id" [placeholder]="'Select CSOs'" [(ngModel)]="selectedCsos" [closeOnSelect]="false"
+                       (change)="clearVenue()" [clearSearchOnAdd]="true" [selectOnTab]="true">
+                <ng-template ng-option-tmp let-item="item" let-item$="item$" let-index="index">
+                    <input id="cso-{{ index }}" type="checkbox" [ngModel]="item$.selected" [checked]="item$.selected" [attr.aria-label]="'CSO '+ item.first_name" />
+                    {{ item.full_name }}
+                </ng-template>
+            </ng-select>
+        </div>
+    </div>
   <div class="govuk-grid-column-one-quarter">
-    <input type="button" [disabled]="!venuesSelected" [value]="'venue-list.selection-button-text' | translate" (click)="goToHearingList()"
+    <input type="button" [disabled]="!venuesSelected && !csosSelected" [value]="'venue-list.selection-button-text' | translate" (click)="goToHearingList()"
       id="select-venue-allocation-btn" class="govuk-button" />
   </div>
+    <div class="govuk-grid-column-full" *ngIf="errorMessage">
+        <p class="govuk-error-message">{{ errorMessage }}</p>
+    </div>
 </div>

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/venue-list.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/venue-list.component.scss
@@ -2,7 +2,7 @@
 @import '~govuk-frontend/govuk/core/all';
 @import '~govuk-frontend/govuk/components/all';
 
-#venue-allocation-list {
+.selection-list {
   @extend .govuk-body;
 }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/vh-officer-venue-list/vh-officer-venue-list.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/venue-list/vh-officer-venue-list/vh-officer-venue-list.component.spec.ts
@@ -1,8 +1,8 @@
-import { fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { of } from 'rxjs';
+import { of, ReplaySubject } from 'rxjs';
 import { VideoWebService } from 'src/app/services/api/video-web.service';
-import { CourtRoomsAccountResponse, HearingVenueResponse } from 'src/app/services/clients/api-client';
+import { CourtRoomsAccountResponse, HearingVenueResponse, JusticeUserResponse } from 'src/app/services/clients/api-client';
 import { Logger } from 'src/app/services/logging/logger-base';
 import { SessionStorage } from 'src/app/services/session-storage';
 import { pageUrls } from 'src/app/shared/page-url.constants';
@@ -11,6 +11,9 @@ import { VhoQueryService } from 'src/app/vh-officer/services/vho-query-service.s
 import { CourtRoomsAccounts } from '../../../vh-officer/services/models/court-rooms-accounts';
 import { VhoStorageKeys } from '../../../vh-officer/services/models/session-keys';
 import { VhOfficerVenueListComponent } from './vh-officer-venue-list.component';
+import { By } from '@angular/platform-browser';
+import { LaunchDarklyService } from '../../../services/launch-darkly.service';
+import { TranslatePipeMock } from '../../../testing/mocks/mock-translation-pipe';
 
 describe('VHOfficerVenueListComponent', () => {
     let component: VhOfficerVenueListComponent;
@@ -18,6 +21,7 @@ describe('VHOfficerVenueListComponent', () => {
     let router: jasmine.SpyObj<Router>;
     let vhoQueryService: jasmine.SpyObj<VhoQueryService>;
     const logger: Logger = new MockLogger();
+    let launchDarklyServiceSpy: jasmine.SpyObj<LaunchDarklyService>;
 
     const venueSessionStorage = new SessionStorage<string[]>(VhoStorageKeys.VENUE_ALLOCATIONS_KEY);
     const roomSessionStorage = new SessionStorage<CourtRoomsAccounts[]>(VhoStorageKeys.COURT_ROOMS_ACCOUNTS_ALLOCATION_KEY);
@@ -47,32 +51,79 @@ describe('VHOfficerVenueListComponent', () => {
     venueAccounts.push(venueAccounts1);
     venueAccounts.push(venueAccounts2);
 
+    const cso1 = new JusticeUserResponse({ username: 'test-user1@hearings.reform.hmcts.net' });
+    const cso2 = new JusticeUserResponse({ username: 'test-user2@hearings.reform.hmcts.net' });
+    const csos: JusticeUserResponse[] = [];
+    csos.push(cso1);
+    csos.push(cso2);
+
+    const selectedCsos = ['test-user-id1', 'test-user-id2'];
+
     beforeAll(() => {
-        videoWebServiceSpy = jasmine.createSpyObj<VideoWebService>('VideoWebService', ['getVenues']);
+        videoWebServiceSpy = jasmine.createSpyObj<VideoWebService>('VideoWebService', [
+            'getVenues',
+            'getVenuesForAllocatedCSOs',
+            'getCSOs'
+        ]);
         router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
         vhoQueryService = jasmine.createSpyObj<VhoQueryService>('VhoQueryService', ['getCourtRoomsAccounts']);
+        launchDarklyServiceSpy = jasmine.createSpyObj('LaunchDarklyService', ['flagChange']);
     });
 
     beforeEach(() => {
-        component = new VhOfficerVenueListComponent(videoWebServiceSpy, router, vhoQueryService, logger);
+        component = new VhOfficerVenueListComponent(videoWebServiceSpy, router, vhoQueryService, logger, launchDarklyServiceSpy);
         videoWebServiceSpy.getVenues.and.returnValue(of(venueNames));
+        videoWebServiceSpy.getVenuesForAllocatedCSOs.and.returnValue(of(venueNames.map(e => e.name)));
+        videoWebServiceSpy.getCSOs.and.returnValue(of(csos));
         vhoQueryService.getCourtRoomsAccounts.and.returnValue(Promise.resolve(courtAccounts));
+        launchDarklyServiceSpy.flagChange = new ReplaySubject();
+        launchDarklyServiceSpy.flagChange.next({ 'vho-work-allocation': true });
         venueSessionStorage.clear();
+    });
+
+    it('ngOnit should get csos and populate csos property for multi-select list', () => {
+        component.csos = [];
+        component.ngOnInit();
+        expect(videoWebServiceSpy.getCSOs).toHaveBeenCalled();
+        expect(component.csos).toEqual(csos);
     });
 
     it('should update storage with selection', () => {
         const selection = [venueNames[0].name];
         component.selectedVenues = selection;
-        component.updateSelection();
+        component.updateVenueSelection();
         const result = venueSessionStorage.get();
         expect(result.length).toBe(selection.length);
         expect(result[0]).toBe(venueNames[0].name);
     });
 
-    it('should navigate to admin hearing list', fakeAsync(() => {
+    it('should navigate to admin hearing list, with venues selected', fakeAsync(() => {
+        component.selectedVenues = selectedJudgeNames;
+        component.selectedCsos = [];
         component.goToHearingList();
         tick();
         expect(router.navigateByUrl).toHaveBeenCalledWith(pageUrls.AdminHearingList);
+    }));
+
+    it('should navigate to admin hearing list, with allocated csos selected', fakeAsync(() => {
+        component.selectedVenues = [];
+        component.selectedCsos = selectedCsos;
+        component.goToHearingList();
+        tick();
+        expect(videoWebServiceSpy.getVenuesForAllocatedCSOs).toHaveBeenCalledWith(selectedCsos);
+        expect(router.navigateByUrl).toHaveBeenCalledWith(pageUrls.AdminHearingList);
+    }));
+
+    it('should attempt to navigate to admin hearing list but log and display error when no venues returned', fakeAsync(() => {
+        component.selectedVenues = [];
+        component.selectedCsos = selectedCsos;
+        const loggerSpy = spyOn(logger, 'warn');
+        videoWebServiceSpy.getVenuesForAllocatedCSOs.and.returnValue(of([]));
+        component.goToHearingList();
+        tick();
+        expect(videoWebServiceSpy.getVenuesForAllocatedCSOs).toHaveBeenCalledWith(selectedCsos);
+        expect(loggerSpy).toHaveBeenCalled();
+        expect(component.errorMessage).toBe('Failed to find venues');
     }));
 
     it('should  create filter records with all options are selected and store in storage', fakeAsync(() => {
@@ -118,6 +169,7 @@ describe('VHOfficerVenueListComponent', () => {
         expect(result[1].courtsRooms[1].selected).toBeTrue();
         roomSessionStorage.set(currentStorage);
     }));
+
     it('should not get court rooms accounts if no venues selected', fakeAsync(() => {
         component.selectedVenues = null;
         spyOn(logger, 'warn');
@@ -125,4 +177,34 @@ describe('VHOfficerVenueListComponent', () => {
         tick();
         expect(logger.warn).toHaveBeenCalled();
     }));
+
+    describe('component rendering', () => {
+        let fixture: ComponentFixture<VhOfficerVenueListComponent>;
+        let fixtureComponent: VhOfficerVenueListComponent;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [VhOfficerVenueListComponent, TranslatePipeMock],
+                providers: [
+                    { provide: VideoWebService, useValue: videoWebServiceSpy },
+                    { provide: Router, useValue: router },
+                    { provide: VhoQueryService, useValue: vhoQueryService },
+                    { provide: Logger, useValue: logger },
+                    { provide: LaunchDarklyService, useValue: launchDarklyServiceSpy }
+                ]
+            });
+            fixture = TestBed.createComponent(VhOfficerVenueListComponent);
+            fixtureComponent = fixture.componentInstance;
+        });
+
+        it('Should show cso list, when implemented by vh-officer-venue-list', () => {
+            fixture.detectChanges();
+            expect(fixture.debugElement.query(By.css('#cso-list'))).toBeTruthy();
+        });
+
+        it('Should not show cso list, when implemented by vh-officer-venue-list and feature flag off', () => {
+            launchDarklyServiceSpy.flagChange.next({ 'vho-work-allocation': false });
+            fixture.detectChanges();
+            expect(fixture.debugElement.query(By.css('#cso-list'))).toBeFalsy();
+        });
+    });
 });

--- a/VideoWeb/VideoWeb/Controllers/UserDataController.cs
+++ b/VideoWeb/VideoWeb/Controllers/UserDataController.cs
@@ -1,16 +1,16 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using BookingsApi.Client;
+using BookingsApi.Contract.Responses;
 using Microsoft.AspNetCore.Authorization;
 using VideoWeb.Common.Models;
 using VideoWeb.Contract.Request;
 using VideoWeb.Contract.Responses;
 using VideoWeb.Mappings;
 using UserApi.Client;
-using UserApi.Contract.Responses;
 using VideoApi.Client;
 using VideoApi.Contract.Responses;
 
@@ -25,17 +25,17 @@ namespace VideoWeb.Controllers
         private readonly ILogger<UserDataController> _logger;
         private readonly IMapperFactory _mapperFactory;
         private readonly IVideoApiClient _videoApiClient;
-
+        private readonly IBookingsApiClient _bookingApiClient;
 
         public UserDataController(
-            IUserApiClient userApiClient,
             ILogger<UserDataController> logger,
             IMapperFactory mapperFactory,
-            IVideoApiClient videoApiClient)
+            IVideoApiClient videoApiClient, IBookingsApiClient bookingApiClient)
         {
             _logger = logger;
             _mapperFactory = mapperFactory;
             _videoApiClient = videoApiClient;
+            _bookingApiClient = bookingApiClient;
         }
 
         /// <summary>
@@ -44,12 +44,15 @@ namespace VideoWeb.Controllers
         [HttpGet("courtrooms", Name = "GetCourtRoomAccounts")]
         [ProducesResponseType(typeof(IList<CourtRoomsAccountResponse>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public async Task<ActionResult<IList<CourtRoomsAccountResponse>>> GetCourtRoomsAccounts([FromQuery]VhoConferenceFilterQuery query)
+        public async Task<ActionResult<IList<CourtRoomsAccountResponse>>> GetCourtRoomsAccounts(
+            [FromQuery] VhoConferenceFilterQuery query)
         {
             try
             {
-                var conferences = await _videoApiClient.GetConferencesTodayForAdminByHearingVenueNameAsync(query.HearingVenueNames);
-                var courtRoomsAccountResponsesMapper = _mapperFactory.Get<IEnumerable<ConferenceForAdminResponse>, List<CourtRoomsAccountResponse>>();
+                var conferences =
+                    await _videoApiClient.GetConferencesTodayForAdminByHearingVenueNameAsync(query.HearingVenueNames);
+                var courtRoomsAccountResponsesMapper = _mapperFactory
+                    .Get<IEnumerable<ConferenceForAdminResponse>, List<CourtRoomsAccountResponse>>();
                 var accountList = courtRoomsAccountResponsesMapper.Map(conferences);
 
                 return Ok(accountList);
@@ -60,5 +63,12 @@ namespace VideoWeb.Controllers
                 return StatusCode(e.StatusCode, e.Response);
             }
         }
+
+        /// <summary>
+        ///Get CSOS
+        /// </summary>
+        [HttpGet("csos", Name = "GetCSOs")]
+        [ProducesResponseType(typeof(IList<JusticeUserResponse>), (int)HttpStatusCode.OK)]
+        public async Task<ActionResult<IList<JusticeUserResponse>>> GetJusticeUsers() =>Ok(await _bookingApiClient.GetJusticeUserListAsync());
     }
 }

--- a/VideoWeb/VideoWeb/Controllers/VenuesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/VenuesController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
@@ -8,9 +9,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using VideoWeb.Common.Models;
-using VideoApi.Client;
-using VideoApi.Contract.Responses;
-
 namespace VideoWeb.Controllers
 {
     [Produces("application/json")]
@@ -23,7 +21,7 @@ namespace VideoWeb.Controllers
         private readonly IBookingsApiClient _bookingsApiClient;
 
 
-        public VenuesController(IVideoApiClient videoApiClient, ILogger<VenuesController> logger, IBookingsApiClient bookingsApiClient)
+        public VenuesController(ILogger<VenuesController> logger, IBookingsApiClient bookingsApiClient)
         {
             _logger = logger;
             _bookingsApiClient = bookingsApiClient;
@@ -49,6 +47,30 @@ namespace VideoWeb.Controllers
             {
                 _logger.LogError(e, "Unable to retrieve venues");
                 return NotFound();
+            }
+        }
+        
+        /// <summary>
+        /// Get Hearing Venue Names By Cso
+        /// </summary>
+        /// <returns>Hearing Venue Names</returns>
+        [Authorize(AppRoles.VhOfficerRole)]
+        [HttpGet("allocated-cso", Name = "GetVenuesByAllocatedCso")]
+        [ProducesResponseType(typeof(IList<string>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        public async Task<ActionResult<IList<string>>> GetVenuesByCso([FromQuery] Guid[] csos)
+        {
+            try
+            {
+                return Ok(await _bookingsApiClient.GetHearingVenuesByAllocatedCsoAsync(csos));
+            }
+            catch (BookingsApiException e)
+            {
+                _logger.LogError(e, "Unable to get venues with allocated csos");
+                if (e.StatusCode is (int)HttpStatusCode.NotFound)
+                    return Ok(new List<string>());
+                
+                return StatusCode(e.StatusCode, e.Message);
             }
         }
     }

--- a/VideoWeb/VideoWeb/Mappings/ClientSettingsResponseMapper.cs
+++ b/VideoWeb/VideoWeb/Mappings/ClientSettingsResponseMapper.cs
@@ -34,7 +34,8 @@ namespace VideoWeb.Mappings
                 EnableIOSMobileSupport = servicesConfiguration.EnableIOSMobileSupport,
                 EnableIOSTabletSupport = servicesConfiguration.EnableIOSTabletSupport,
                 EnableDynamicEvidenceSharing = servicesConfiguration.EnableDynamicEvidenceSharing,
-                BlurRadius = servicesConfiguration.BlurRadius
+                BlurRadius = servicesConfiguration.BlurRadius,
+                LaunchDarklyClientId = servicesConfiguration.LaunchDarklyClientId
             };
         }
 

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.41.21" />
+    <PackageReference Include="BookingsApi.Client" Version="1.41.22" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.41.21, )",
-        "resolved": "1.41.21",
-        "contentHash": "sSB8jkB8Aw88S/qcEDdWphud2PuS83zMoVfHWMfUEZkkASlpF5aZ7+GPjwTwztVpkdG6G3t2WrVrrV+T/hrwsw==",
+        "requested": "[1.41.22, )",
+        "resolved": "1.41.22",
+        "contentHash": "b63kaT2VkWhadi43Q9NTjvFPcgQB47GjjRdQDayHDbDck1oInNK6yOVCPxUmWRMhOc/BDtgRsdVT7KhOMxhYgA==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2269,6 +2269,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
+          "BookingsApi.Client": "[1.41.22, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,7 +242,12 @@ parameters:
             value: $(EnableVideoFilters)
           - name: VhServices:EnableDynamicEvidenceSharing
             value: $(EnableDynamicEvidenceSharing)
-
+            
+            #Launch Darkly Config
+          - name: VhServices:LaunchDarklyClientId
+            value: vh-launchdarkly-client-id
+            secret: true
+            
           # Quick Links Configuration
           - name: QuickLinks:Issuer
             value: $(video_api_url)

--- a/charts/vh-video-web/Chart.yaml
+++ b/charts/vh-video-web/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: vh-video-web
 home: https://github.com/hmcts/vh-video-web
-version: 0.0.7
+version: 0.0.8
 description: Helm Chart for Video Hearing video-web
 maintainers:
   - name: VH Devops

--- a/charts/vh-video-web/values.yaml
+++ b/charts/vh-video-web/values.yaml
@@ -45,6 +45,7 @@ java:
         - vhservices--emailreformdomain
         - vhservices--internaleventsecret
         - ejudad--clientid
+        - ejudad--tenantid
         - name: launchdarkly-client-id
           alias: VHSERVICES--LAUNCHDARKLYCLIENTID
         - name: azuread--identifieruri

--- a/charts/vh-video-web/values.yaml
+++ b/charts/vh-video-web/values.yaml
@@ -45,7 +45,8 @@ java:
         - vhservices--emailreformdomain
         - vhservices--internaleventsecret
         - ejudad--clientid
-        - ejudad--tenantid
+        - name: launchdarkly-client-id
+          alias: VHSERVICES--LAUNCHDARKLYCLIENTID
         - name: azuread--identifieruri
           alias: azuread--resourceid
     vh-bookings-api:

--- a/charts/vh-video-web/values.yaml
+++ b/charts/vh-video-web/values.yaml
@@ -21,6 +21,8 @@ java:
         - azuread--vhvideowebclientid
         - connectionstrings--signalr
         - connectionstrings--rediscache
+        - name: launchdarkly-client-id
+          alias: VHSERVICES--LAUNCHDARKLYCLIENTID
     vh-video-web:
       excludeEnvironmentSuffix: false
       resourceGroup: vh-infra-core-{{ .Values.global.environment }}
@@ -46,8 +48,6 @@ java:
         - vhservices--internaleventsecret
         - ejudad--clientid
         - ejudad--tenantid
-        - name: launchdarkly-client-id
-          alias: VHSERVICES--LAUNCHDARKLYCLIENTID
         - name: azuread--identifieruri
           alias: azuread--resourceid
     vh-bookings-api:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9401

### Change description ###
Added to the existing venue selection components for the vho command centre - a CSO option menu. Works by reusing the existing logic to fetch the the venues for the command centre, by overiding the list of venue names, with a new list fetched from the BookingApi, based on the CSO guids provided. Have also added the Launch Darkly Client Service along with supporting IaC changes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
