### PR TITLE
VIH-9441 Fix for quick links error

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/app.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/app.component.spec.ts
@@ -262,13 +262,6 @@ describe('AppComponent', () => {
         expect(errorServiceSpy.goToUnauthorised).toHaveBeenCalled();
     });
 
-    it('should not check auth or get profile on logout', async () => {
-        component.securityService = securityServiceSpy;
-        await component.checkAuth();
-        expect(routerSpy.navigate).toHaveBeenCalledTimes(0);
-        expect(profileServiceSpy.getUserProfile).toHaveBeenCalledTimes(0);
-    });
-
     describe('NavigationEndEvent', () => {
         const navEvent = new NavigationEnd(1, 'url', 'urlAfterRedirects');
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
@@ -3,8 +3,8 @@ import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { AuthStateResult, EventTypes, OidcClientNotification, PublicEventsService } from 'angular-auth-oidc-client';
-import { BehaviorSubject, NEVER, Observable, Subject, Subscription, combineLatest } from 'rxjs';
-import { catchError, delay, filter, map, takeUntil } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
+import { delay, filter, first, takeUntil } from 'rxjs/operators';
 import { ProfileService } from './services/api/profile.service';
 import { Role } from './services/clients/api-client';
 import { ConnectionStatusService } from './services/connection-status.service';
@@ -20,6 +20,7 @@ import { BackLinkDetails } from './shared/models/back-link-details';
 import { Location } from '@angular/common';
 import { NoSleepService } from './services/no-sleep.service';
 import { HideComponentsService } from './waiting-space/services/hide-components.service';
+import { ConfigService } from './services/api/config.service';
 
 @Component({
     selector: 'app-root',
@@ -58,6 +59,7 @@ export class AppComponent implements OnInit, OnDestroy {
         pageTracker: PageTrackerService,
         testLanguageService: TestLanguageService,
         translate: TranslateService,
+        private configService: ConfigService,
         private eventService: PublicEventsService,
         private securityServiceProviderService: SecurityServiceProvider,
         private location: Location,
@@ -85,30 +87,26 @@ export class AppComponent implements OnInit, OnDestroy {
         this.checkBrowser();
         this.setupSecurityServiceProviderSubscription();
         this.noSleepService.enable();
-        combineLatest([
-            this.securityServiceProviderService.currentSecurityService$,
-            this.securityServiceProviderService.currentIdp$
-        ]).subscribe(([securityService, idp]) => {
-            this.currentIdp = idp;
-            this.securityService = securityService;
-
-            if (this.currentIdp === 'quickLink') {
-                return;
-            }
-            this.securityService.checkAuth(undefined, this.currentIdp).subscribe(async ({ isAuthenticated }) => {
-                if (isAuthenticated) {
-                    await this.postAuthSetup(isAuthenticated, false);
-
-                    this.eventService
-                        .registerForEvents()
-                        .pipe(filter(notification => notification.type === EventTypes.NewAuthenticationResult))
-                        .subscribe(async (value: OidcClientNotification<AuthStateResult>) => {
-                            this.logger.info('[AppComponent] - OidcClientNotification event received with value ', value);
-                            await this.postAuthSetup(true, value.value.isRenewProcess);
-                        });
+        this.configService
+            .getClientSettings()
+            .pipe(first())
+            .subscribe({
+                next: () => {
+                    this.currentIdp = this.securityServiceProviderService.currentIdp;
+                    this.securityService.checkAuth(undefined, this.currentIdp).subscribe(async ({ isAuthenticated }) => {
+                        await this.postAuthSetup(isAuthenticated, false);
+                        if (this.currentIdp !== 'quickLink') {
+                            this.eventService
+                                .registerForEvents()
+                                .pipe(filter(notification => notification.type === EventTypes.NewAuthenticationResult))
+                                .subscribe(async (value: OidcClientNotification<AuthStateResult>) => {
+                                    this.logger.info('[AppComponent] - OidcClientNotification event received with value ', value);
+                                    await this.postAuthSetup(true, value.value.isRenewProcess);
+                                });
+                        }
+                    });
                 }
             });
-        });
     }
 
     setupNavigationSubscriptions() {
@@ -149,19 +147,6 @@ export class AppComponent implements OnInit, OnDestroy {
         if (!this.deviceTypeService.isSupportedBrowser()) {
             this.router.navigateByUrl(pageUrls.UnsupportedBrowser);
         }
-    }
-
-    checkAuth(): Observable<boolean> {
-        return this.securityService.checkAuth(this.currentIdp).pipe(
-            map(loginResponse => loginResponse.isAuthenticated),
-            catchError(err => {
-                this.logger.error('[AppComponent] - Check Auth Error', err);
-                if (!this.isSignInUrl) {
-                    this.router.navigate(['/']);
-                }
-                return NEVER;
-            })
-        );
     }
 
     async retrieveProfileRole(): Promise<void> {
@@ -222,24 +207,16 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     private setupSecurityServiceProviderSubscription() {
-        combineLatest([this.securityServiceProviderService.currentSecurityService$, this.securityServiceProviderService.currentIdp$])
-            .pipe(takeUntil(this.destroyed$))
-            .subscribe(([service, idp]) => {
-                this.securityService = service;
-                this.currentIdp = idp;
+        this.securityServiceProviderService.currentSecurityService$.pipe(takeUntil(this.destroyed$)).subscribe(service => {
+            this.securityService = service;
+            this.serviceChanged$.next();
 
-                this.serviceChanged$.next();
-
-                if (this.currentIdp === 'quickLink') {
-                    return;
-                }
-
-                service
-                    .isAuthenticated(this.securityServiceProviderService.currentIdp)
-                    .pipe(takeUntil(this.serviceChanged$), takeUntil(this.destroyed$), delay(0)) // delay(0) pipe is to prevent angular ExpressionChangedAfterItHasBeenCheckedError
-                    .subscribe(authenticated => {
-                        this.loggedIn = authenticated;
-                    });
-            });
+            service
+                .isAuthenticated(this.securityServiceProviderService.currentIdp)
+                .pipe(takeUntil(this.serviceChanged$), takeUntil(this.destroyed$), delay(0)) // delay(0) pipe is to prevent angular ExpressionChangedAfterItHasBeenCheckedError
+                .subscribe(authenticated => {
+                    this.loggedIn = authenticated;
+                });
+        });
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
@@ -91,19 +91,21 @@ export class AppComponent implements OnInit, OnDestroy {
         ]).subscribe(([securityService, idp]) => {
             this.currentIdp = idp;
             this.securityService = securityService;
+
+            if (this.currentIdp === 'quickLink') {
+                return;
+            }
             this.securityService.checkAuth(undefined, this.currentIdp).subscribe(async ({ isAuthenticated }) => {
                 if (isAuthenticated) {
                     await this.postAuthSetup(isAuthenticated, false);
 
-                    if (this.currentIdp !== 'quickLink') {
-                        this.eventService
-                            .registerForEvents()
-                            .pipe(filter(notification => notification.type === EventTypes.NewAuthenticationResult))
-                            .subscribe(async (value: OidcClientNotification<AuthStateResult>) => {
-                                this.logger.info('[AppComponent] - OidcClientNotification event received with value ', value);
-                                await this.postAuthSetup(true, value.value.isRenewProcess);
-                            });
-                    }
+                    this.eventService
+                        .registerForEvents()
+                        .pipe(filter(notification => notification.type === EventTypes.NewAuthenticationResult))
+                        .subscribe(async (value: OidcClientNotification<AuthStateResult>) => {
+                            this.logger.info('[AppComponent] - OidcClientNotification event received with value ', value);
+                            await this.postAuthSetup(true, value.value.isRenewProcess);
+                        });
                 }
             });
         });
@@ -227,6 +229,10 @@ export class AppComponent implements OnInit, OnDestroy {
                 this.currentIdp = idp;
 
                 this.serviceChanged$.next();
+
+                if (this.currentIdp === 'quickLink') {
+                    return;
+                }
 
                 service
                     .isAuthenticated(this.securityServiceProviderService.currentIdp)

--- a/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/app.component.ts
@@ -95,6 +95,7 @@ export class AppComponent implements OnInit, OnDestroy {
                     this.currentIdp = this.securityServiceProviderService.currentIdp;
                     this.securityService.checkAuth(undefined, this.currentIdp).subscribe(async ({ isAuthenticated }) => {
                         await this.postAuthSetup(isAuthenticated, false);
+
                         if (this.currentIdp !== 'quickLink') {
                             this.eventService
                                 .registerForEvents()

--- a/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/quick-links/quick-links.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/quick-links/quick-links.component.ts
@@ -3,8 +3,6 @@ import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } 
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { catchError, first, map, takeUntil } from 'rxjs/operators';
-import { IdpProviders } from 'src/app/security/idp-providers';
-import { SecurityConfigSetupService } from 'src/app/security/security-config-setup.service';
 import { QuickLinksService } from 'src/app/services/api/quick-links.service';
 import { Role } from 'src/app/services/clients/api-client';
 import { ErrorService } from 'src/app/services/error.service';
@@ -44,11 +42,8 @@ export class QuickLinksComponent implements OnInit, OnDestroy {
         private formBuilder: UntypedFormBuilder,
         private readonly quickLinksService: QuickLinksService,
         private route: ActivatedRoute,
-        private errorService: ErrorService,
-        private securityConfigService: SecurityConfigSetupService
-    ) {
-        this.securityConfigService.setIdp(IdpProviders.quickLink);
-    }
+        private errorService: ErrorService
+    ) {}
 
     ngOnInit(): void {
         this.hearingId = this.route.snapshot.paramMap.get('hearingId');

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
@@ -37,6 +37,9 @@ export class AppInsightsLoggerService implements LogAdapter {
         ]).subscribe(([configSettings, securityService, idp]) => {
             this.currentIdp = idp;
             this.securityService = securityService;
+            if (this.currentIdp === 'quickLink') {
+                return;
+            }
             this.setupAppInsights(configSettings, configService, this.securityService).subscribe(() => {
                 this.checkIfVho();
                 this.trackNavigation();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
@@ -1,12 +1,11 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, ResolveEnd, Router, RouterEvent } from '@angular/router';
 import { ApplicationInsights, ITelemetryItem, SeverityLevel } from '@microsoft/applicationinsights-web';
-import { combineLatest } from 'rxjs';
 import { SecurityServiceProvider } from 'src/app/security/authentication/security-provider.service';
 import { ISecurityService } from 'src/app/security/authentication/security-service.interface';
 import { ConfigService } from '../../api/config.service';
 import { LogAdapter } from '../log-adapter';
-import { ClientSettingsResponse, Role } from '../../clients/api-client';
+import { Role } from '../../clients/api-client';
 import { filter, map } from 'rxjs/operators';
 import { ProfileService } from '../../api/profile.service';
 
@@ -29,21 +28,11 @@ export class AppInsightsLoggerService implements LogAdapter {
         private profileService: ProfileService
     ) {
         this.router = router;
+        securityServiceProviderService.currentSecurityService$.subscribe(securityService => (this.securityService = securityService));
 
-        combineLatest([
-            configService.getClientSettings(),
-            securityServiceProviderService.currentSecurityService$,
-            securityServiceProviderService.currentIdp$
-        ]).subscribe(([configSettings, securityService, idp]) => {
-            this.currentIdp = idp;
-            this.securityService = securityService;
-            if (this.currentIdp === 'quickLink') {
-                return;
-            }
-            this.setupAppInsights(configSettings, configService, this.securityService).subscribe(() => {
-                this.checkIfVho();
-                this.trackNavigation();
-            });
+        this.setupAppInsights(configService, this.securityService).subscribe(() => {
+            this.checkIfVho();
+            this.trackNavigation();
         });
     }
 
@@ -103,9 +92,9 @@ export class AppInsightsLoggerService implements LogAdapter {
         this.appInsights.context.user.id = userId;
     }
 
-    private setupAppInsights(configSettings: ClientSettingsResponse, configService: ConfigService, securityService: ISecurityService) {
-        return securityService?.getUserData(this.currentIdp).pipe(
-            map(ud => {
+    private setupAppInsights(configService: ConfigService, securityService: ISecurityService) {
+        return configService.getClientSettings().pipe(
+            map(configSettings => {
                 this.appInsights = new ApplicationInsights({
                     config: {
                         instrumentationKey: configSettings.app_insights_instrumentation_key,
@@ -113,10 +102,21 @@ export class AppInsightsLoggerService implements LogAdapter {
                     }
                 });
                 this.appInsights.loadAppInsights();
-                this.appInsights.addTelemetryInitializer((envelope: ITelemetryItem) => {
-                    envelope.tags['ai.cloud.role'] = 'vh-video-web';
-                    envelope.tags['ai.user.id'] = ud.preferred_username.toLowerCase();
-                });
+                securityService?.getUserData(this.currentIdp).pipe(
+                    map(ud => {
+                        this.appInsights = new ApplicationInsights({
+                            config: {
+                                instrumentationKey: configSettings.app_insights_instrumentation_key,
+                                isCookieUseDisabled: true
+                            }
+                        });
+                        this.appInsights.loadAppInsights();
+                        this.appInsights.addTelemetryInitializer((envelope: ITelemetryItem) => {
+                            envelope.tags['ai.cloud.role'] = 'vh-video-web';
+                            envelope.tags['ai.user.id'] = ud.preferred_username.toLowerCase();
+                        });
+                    })
+                );
             })
         );
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9941


### Change description ###
Fixes an error when using the quick links url to join a hearing.
This reverts some changes made as part of the angular 15 upgrade. By using `combineLatest` with the idp and security provider, it can return an invalid combination (quick link config + oidc service) as they can change independently, causing the error. To remedy this, revert back to the original mechanism where we get the client settings, and then the idp and security provider together.
Also removes an unused method (`checkAuth`) and its test.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
