### PR TITLE
VIH-9968 update order of messages when participant starts a consultation

### DIFF
--- a/VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs
@@ -27,8 +27,8 @@ namespace VideoWeb.EventHub.Handlers
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
             var endpointStatus = DeriveEndpointStatusForTransferEvent(callbackEvent);
-            await PublishEndpointStatusMessage(endpointStatus);
             await PublishRoomTransferMessage(new RoomTransfer { ParticipantId = callbackEvent.ParticipantId, FromRoom = callbackEvent.TransferFrom, ToRoom = callbackEvent.TransferTo });
+            await PublishEndpointStatusMessage(endpointStatus);
         }
 
         private static EndpointState DeriveEndpointStatusForTransferEvent(CallbackEvent callbackEvent)

--- a/VideoWeb/VideoWeb.EventHub/Handlers/TransferEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/TransferEventHandler.cs
@@ -27,8 +27,8 @@ namespace VideoWeb.EventHub.Handlers
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
             var participantStatus = DeriveParticipantStatusForTransferEvent(callbackEvent);
-            await PublishParticipantStatusMessage(participantStatus);
             await PublishRoomTransferMessage(new RoomTransfer { ParticipantId = callbackEvent.ParticipantId, FromRoom = callbackEvent.TransferFrom, ToRoom = callbackEvent.TransferTo });
+            await PublishParticipantStatusMessage(participantStatus);
         }
 
         private static ParticipantState DeriveParticipantStatusForTransferEvent(CallbackEvent callbackEvent)

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/individual-participant-status-list/individual-participant-status-list.component.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/individual-participant-status-list/individual-participant-status-list.component.html
@@ -127,7 +127,7 @@
                                     <ng-container *ngSwitchCase="ParticipantStatus.InConsultation">
                                         <span>{{ 'start-private-consultation.in' | translate}} </span>
                                         <span>{{ participant.current_room?.label | roomName | lowercase }} </span>
-                                        <fa-icon *ngIf="participant.current_room.locked" icon="lock"></fa-icon>
+                                        <fa-icon *ngIf="participant.current_room?.locked" icon="lock"></fa-icon>
                                     </ng-container>
                                     <ng-container *ngSwitchDefault>
                                         {{ "individual-participant-status-list.unavailable" | translate }}


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-9968

### Change description ###

The participant status change message to `InConsulation` triggered a change to display an icon based on a participant's room locked status. However the room property is updated via another message, which comes AFTER the participant status update message. The order has been updated so that the room change is published first and a null operator is applied in the template.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
