### PR TITLE
VIH-9973 Error starting private consultation in Firefox

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/helpers/error-helper.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/helpers/error-helper.spec.ts
@@ -1,0 +1,51 @@
+import { ErrorHelper } from './error-helper';
+
+describe('ErrorHelper', () => {
+    let errorHelper: ErrorHelper;
+    const pexRtcGetStatsErrorMessage = 'An attempt was made to use an object that is not, or is no longer, usable';
+    const pexRtcGetStatsErrorStack = 'PexRTC.getStats';
+    const firefoxUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/114.0';
+
+    beforeEach(() => {
+        errorHelper = new ErrorHelper();
+    });
+
+    it('should identify PexRTC getStats error in Firefox', () => {
+        const error = new DOMException(pexRtcGetStatsErrorMessage);
+        error.stack = pexRtcGetStatsErrorStack;
+        spyOnProperty(navigator, 'userAgent').and.returnValue(firefoxUserAgent);
+
+        const result = errorHelper.isPexRtcGetStatsError(error);
+
+        expect(result).toBeTrue();
+    });
+
+    it('should not identify non-PexRTC getStats error', () => {
+        const error = new DOMException('Some other error');
+        error.stack = pexRtcGetStatsErrorStack;
+        spyOnProperty(navigator, 'userAgent').and.returnValue(firefoxUserAgent);
+
+        const result = errorHelper.isPexRtcGetStatsError(error);
+
+        expect(result).toBeFalse();
+    });
+
+    it('should not identify PexRTC getStats error in other browsers', () => {
+        const error = new DOMException(pexRtcGetStatsErrorMessage);
+        error.stack = pexRtcGetStatsErrorStack;
+        spyOnProperty(navigator, 'userAgent').and.returnValue('Some other browser user agent');
+
+        const result = errorHelper.isPexRtcGetStatsError(error);
+
+        expect(result).toBeFalse();
+    });
+
+    it('should not identify PexRTC getStats error when stack is null', () => {
+        const error = new DOMException(pexRtcGetStatsErrorMessage);
+        spyOnProperty(navigator, 'userAgent').and.returnValue(firefoxUserAgent);
+
+        const result = errorHelper.isPexRtcGetStatsError(error);
+
+        expect(result).toBeFalse();
+    });
+});

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/helpers/error-helper.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/helpers/error-helper.ts
@@ -1,11 +1,15 @@
 import { browsers } from '../browser.constants';
 
 export class ErrorHelper {
-    static isPexRtcGetStatsError(err: Error) {
+    public navigator: Navigator = navigator;
+
+    isPexRtcGetStatsError(err: Error) {
         // Detects a specific error thrown by PexRTC in Firefox which is not handled by the library
         return (
             err instanceof DOMException &&
             err.message === 'An attempt was made to use an object that is not, or is no longer, usable' &&
+            err.stack !== null &&
+            err.stack !== undefined &&
             err.stack.includes('PexRTC') &&
             err.stack.includes('getStats') &&
             navigator.userAgent.includes(browsers.Firefox)

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/helpers/error-helper.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/helpers/error-helper.ts
@@ -1,0 +1,14 @@
+import { browsers } from '../browser.constants';
+
+export class ErrorHelper {
+    static isPexRtcGetStatsError(err: Error) {
+        // Detects a specific error thrown by PexRTC in Firefox which is not handled by the library
+        return (
+            err instanceof DOMException &&
+            err.message === 'An attempt was made to use an object that is not, or is no longer, usable' &&
+            err.stack.includes('PexRTC') &&
+            err.stack.includes('getStats') &&
+            navigator.userAgent.includes(browsers.Firefox)
+        );
+    }
+}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/providers/global-error-handler.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/providers/global-error-handler.ts
@@ -6,7 +6,7 @@ import { ErrorHelper } from '../helpers/error-helper';
 
 @Injectable()
 export class GlobalErrorHandler implements ErrorHandler {
-    constructor(private injector: Injector, private zone: NgZone) {}
+    constructor(private injector: Injector, private zone: NgZone, private errorHelper: ErrorHelper) {}
 
     handleError(err: any) {
         const router: Router = this.injector.get(Router);
@@ -20,7 +20,7 @@ export class GlobalErrorHandler implements ErrorHandler {
             this.redirectTo(router, pageUrls.Unauthorised);
         } else {
             logger.error('Unhandled error occured', err, { url: router.url });
-            if (ErrorHelper.isPexRtcGetStatsError(err)) {
+            if (this.errorHelper.isPexRtcGetStatsError(err)) {
                 return;
             }
             this.redirectTo(router, pageUrls.ServiceError);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/providers/global-error-handler.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/providers/global-error-handler.ts
@@ -2,6 +2,7 @@ import { ErrorHandler, Injectable, Injector, NgZone } from '@angular/core';
 import { Router } from '@angular/router';
 import { Logger } from 'src/app/services/logging/logger-base';
 import { pageUrls } from '../page-url.constants';
+import { ErrorHelper } from '../helpers/error-helper';
 
 @Injectable()
 export class GlobalErrorHandler implements ErrorHandler {
@@ -19,6 +20,9 @@ export class GlobalErrorHandler implements ErrorHandler {
             this.redirectTo(router, pageUrls.Unauthorised);
         } else {
             logger.error('Unhandled error occured', err, { url: router.url });
+            if (ErrorHelper.isPexRtcGetStatsError(err)) {
+                return;
+            }
             this.redirectTo(router, pageUrls.ServiceError);
         }
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/shared.module.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/shared.module.ts
@@ -97,6 +97,7 @@ import { SecurityServiceProvider } from '../security/authentication/security-pro
 import { ProfileService } from '../services/api/profile.service';
 import { AppInsightsLoggerService } from '../services/logging/loggers/app-insights-logger.service';
 import { SecurityConfigSetupService } from '../security/security-config-setup.service';
+import { ErrorHelper } from './helpers/error-helper';
 
 export function getSettings(configService: ConfigService) {
     return () => configService.loadConfig();
@@ -174,7 +175,8 @@ export function getSettings(configService: ConfigService) {
         TestLanguageService,
         DatePipe,
         ParticipantPanelModelMapper,
-        VhoQueryService
+        VhoQueryService,
+        ErrorHelper
     ],
     exports: [
         HeaderComponent,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9973


### Change description ###
Addresses an issue where an error page is shown when starting a private consultation in Firefox.

When starting a consultation in Firefox an error is thrown when trying to getStats as part of the PexRTC. This error is harmless and until recently, we simply logged the error and continued.

However a change was made to the global error handler which now also sends the user to the error page. We don't want to do this for this error, so instead catch and suppress it. This has to be done via the global error handler rather than a try catch due to the error being sent directly to the global error handler.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
