### PR TITLE
VIH-9988 video web querying venues needs refactoring

### DIFF
--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="TestApi.Client" Version="1.31.10" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.AcceptanceTests.Common" Version="1.24.1" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="TestApi.Client" Version="1.31.10" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.AcceptanceTests.Common" Version="1.24.1" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.12-pr-0589-0011" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="TestApi.Client" Version="1.31.10" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.AcceptanceTests.Common" Version="1.24.1" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.9" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
+++ b/VideoWeb/VideoWeb.AcceptanceTests/VideoWeb.AcceptanceTests.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="TestApi.Client" Version="1.31.10" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.AcceptanceTests.Common" Version="1.24.1" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12-pr-0589-0011" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -228,9 +228,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.11-pr-0589-0007, )",
-        "resolved": "1.44.11-pr-0589-0007",
-        "contentHash": "iyHv6tcDEXcJO9yEwNF2uoCLP1N/auxusErL6abVh7ppnfmdYi2oWGKQ18WPKq3P95gqGUkCn+FuPGvCxc6ZXw==",
+        "requested": "[1.44.11-pr-0589-0009, )",
+        "resolved": "1.44.11-pr-0589-0009",
+        "contentHash": "WS6HUq16cyD4B+dp4urq8HOU57UBieJHS4atZQwfW8urZzv8uraN6LTTLnzztgQF25rD3gSJE2taJjxcAFp8rQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -287,8 +287,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.16-pr-0668-0009",
-        "contentHash": "htHrMV90Aer2xQIKJwB9oKnb3hSDydBIrp5+VHcpmCBMhtPzWYMVBmseNTQUY9Xb+EVee/UBZM4SaUQI2/Q00w==",
+        "resolved": "1.45.19-pr-0668-0012",
+        "contentHash": "QSEJPFZhrKBGYpc4z9GkLlE9zu3WCMUCfcJzH7dZJyMtcrL0ZyXv2amRRdqThdHGu8UtU3dr7AR1r0US7D4YWA==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2341,7 +2341,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
+          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -2351,7 +2351,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0007, )"
+          "VideoApi.Client": "[1.44.11-pr-0589-0009, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -228,9 +228,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.11-pr-0589-0009, )",
-        "resolved": "1.44.11-pr-0589-0009",
-        "contentHash": "WS6HUq16cyD4B+dp4urq8HOU57UBieJHS4atZQwfW8urZzv8uraN6LTTLnzztgQF25rD3gSJE2taJjxcAFp8rQ==",
+        "requested": "[1.44.12-pr-0589-0011, )",
+        "resolved": "1.44.12-pr-0589-0011",
+        "contentHash": "tUDxBUh6FcKrLSLyp7s34FG8d7yeMY5Edj0oix8D6uiurVnldx6koZW2Zbui6ub6lxd3j6vdd+dmUMO5PhPtYQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -287,8 +287,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.19-pr-0668-0012",
-        "contentHash": "QSEJPFZhrKBGYpc4z9GkLlE9zu3WCMUCfcJzH7dZJyMtcrL0ZyXv2amRRdqThdHGu8UtU3dr7AR1r0US7D4YWA==",
+        "resolved": "1.45.22-pr-0668-0013",
+        "contentHash": "NDr0vyLxD6tazP/eeXEUca2+MrQTWTGKQCB876sjVgfHgC2Inr8kYZGxDlwWnuOr3adZn8wpDkVkhMZa8bohxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2341,7 +2341,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
+          "BookingsApi.Client": "[1.45.22-pr-0668-0013, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -2351,7 +2351,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0009, )"
+          "VideoApi.Client": "[1.44.12-pr-0589-0011, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -228,9 +228,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.9, )",
-        "resolved": "1.44.9",
-        "contentHash": "sSg7dS9isysin04kgt9SZEhJIoyMoTaUG9s2vpXKsZX09xBK8kBhwpz+yMs+cA+RW/M0t3Egyzb32WCX98h7Zw==",
+        "requested": "[1.44.11-pr-0589-0007, )",
+        "resolved": "1.44.11-pr-0589-0007",
+        "contentHash": "iyHv6tcDEXcJO9yEwNF2uoCLP1N/auxusErL6abVh7ppnfmdYi2oWGKQ18WPKq3P95gqGUkCn+FuPGvCxc6ZXw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -287,8 +287,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.9",
-        "contentHash": "K63Oupjy9lZpFZfijlOtSt+XWCImkuDAyn8dtsoyE5Bn22kmzsTiGVzllCEuiVqGnN/y7N1tkFN+L+T5t0RHng==",
+        "resolved": "1.45.16-pr-0668-0009",
+        "contentHash": "htHrMV90Aer2xQIKJwB9oKnb3hSDydBIrp5+VHcpmCBMhtPzWYMVBmseNTQUY9Xb+EVee/UBZM4SaUQI2/Q00w==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2341,7 +2341,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.9, )",
+          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -2351,7 +2351,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.9, )"
+          "VideoApi.Client": "[1.44.11-pr-0589-0007, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.AcceptanceTests/packages.lock.json
@@ -228,9 +228,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.9, )",
-        "resolved": "1.44.9",
-        "contentHash": "sSg7dS9isysin04kgt9SZEhJIoyMoTaUG9s2vpXKsZX09xBK8kBhwpz+yMs+cA+RW/M0t3Egyzb32WCX98h7Zw==",
+        "requested": "[1.44.12, )",
+        "resolved": "1.44.12",
+        "contentHash": "e6gTb9EPYaaL5lVi/TG53NrSmAPjesZuDpnCSKACpTxocLvyynxIrEenT3tAFQ5v1XdaC+kQWR7TWRmIaCZv1Q==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -287,8 +287,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.21",
-        "contentHash": "fmmGE+E/5/xyy4n4x2ir+5yzCZ2KCKdV9sdzjPLVYwZPdHztk73sYvs52gAsN+eTEQg6XHoBQUuoPB/Oeh8bqA==",
+        "resolved": "1.45.24",
+        "contentHash": "cHqON2++rQwm7NSuVeKtKkWMcc38+i4ZUbEGuvX2GIAkqMvor2Ob5DVnU/1DIeOBeJWHWXAGIGvkoSBwNbPftg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2341,7 +2341,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.21, )",
+          "BookingsApi.Client": "[1.45.24, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -2351,7 +2351,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.9, )"
+          "VideoApi.Client": "[1.44.12, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.16-pr-0668-0009" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.19-pr-0668-0012" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
@@ -21,7 +21,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
   </ItemGroup>
     
 </Project>

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.9" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.16-pr-0668-0009" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
@@ -21,7 +21,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.9" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
   </ItemGroup>
     
 </Project>

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.19-pr-0668-0012" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.22-pr-0668-0013" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
@@ -21,7 +21,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12-pr-0589-0011" />
   </ItemGroup>
     
 </Project>

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.21" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.24" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
@@ -21,7 +21,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.9" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12" />
   </ItemGroup>
     
 </Project>

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForStaffMemberTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForStaffMemberTests.cs
@@ -14,6 +14,7 @@ using BookingsApi.Client;
 using BookingsApi.Contract.Responses;
 using VideoApi.Client;
 using VideoApi.Contract.Enums;
+using VideoApi.Contract.Requests;
 using VideoApi.Contract.Responses;
 using VideoWeb.Common.Models;
 using VideoWeb.Contract.Responses;
@@ -51,7 +52,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 "Stacktrace goes here", null, default, null);
             
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ThrowsAsync(apiException);
 
             var result = await _controller.GetConferencesForStaffMemberAsync(new List<string>());
@@ -79,7 +80,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 .Build().ToList();
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ReturnsAsync(conferences);
 
             var result = await _controller.GetConferencesForStaffMemberAsync(hearingVenueNamesQuery);
@@ -103,7 +104,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             var hearingVenueNamesQuery = new List<string>();
             var conferences = new List<Conference>();
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ReturnsAsync(conferences);
 
             var result = await _controller.GetConferencesForStaffMemberAsync(hearingVenueNamesQuery);

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForStaffMemberTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForStaffMemberTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using BookingsApi.Client;
 using BookingsApi.Contract.Responses;
 using VideoApi.Client;
 using VideoApi.Contract.Enums;
@@ -34,7 +35,10 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
         public void Setup()
         {
             _mocker = AutoMock.GetLoose();
-
+            _mocker.Mock<IBookingsApiClient>()
+                .Setup(x => x.GetHearingsForTodayByVenueAsync(It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(new List<HearingDetailsResponse>{Mock.Of<HearingDetailsResponse>()});
+            
             var claimsPrincipal = new ClaimsPrincipalBuilder().WithRole(AppRoles.StaffMember).Build();
             _controller = SetupControllerWithClaims(claimsPrincipal);
         }
@@ -42,15 +46,15 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
         [Test]
         public async Task Should_forward_error_when_video_api_returns_error()
         {
-            var hearingVenueNamesQuery = new List<string>();
             var apiException = new VideoApiException<ProblemDetails>("Internal Server Error",
                 (int)HttpStatusCode.InternalServerError,
                 "Stacktrace goes here", null, default, null);
+            
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForStaffMemberByHearingVenueNameAsync(hearingVenueNamesQuery))
+                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ThrowsAsync(apiException);
 
-            var result = await _controller.GetConferencesForStaffMemberAsync(hearingVenueNamesQuery);
+            var result = await _controller.GetConferencesForStaffMemberAsync(new List<string>());
 
             var typedResult = (ObjectResult)result.Result;
             typedResult.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
@@ -75,7 +79,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 .Build().ToList();
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForStaffMemberByHearingVenueNameAsync(hearingVenueNamesQuery))
+                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ReturnsAsync(conferences);
 
             var result = await _controller.GetConferencesForStaffMemberAsync(hearingVenueNamesQuery);
@@ -99,7 +103,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             var hearingVenueNamesQuery = new List<string>();
             var conferences = new List<Conference>();
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForStaffMemberByHearingVenueNameAsync(hearingVenueNamesQuery))
+                .Setup(x => x.GetConferencesForHostByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ReturnsAsync(conferences);
 
             var result = await _controller.GetConferencesForStaffMemberAsync(hearingVenueNamesQuery);

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForVHOfficerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForVHOfficerTests.cs
@@ -24,6 +24,7 @@ using VideoApi.Contract.Responses;
 using VideoWeb.UnitTests.Builders;
 using LinkedParticipantResponse = VideoApi.Contract.Responses.LinkedParticipantResponse;
 using VideoApi.Contract.Enums;
+using VideoApi.Contract.Requests;
 
 namespace VideoWeb.UnitTests.Controllers.ConferenceController
 {
@@ -51,7 +52,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 (int) HttpStatusCode.InternalServerError,
                 "Stacktrace goes here", null, default, null);
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ThrowsAsync(apiException);
 
             var result = await _controller.GetConferencesForVhOfficerAsync(new VhoConferenceFilterQuery());
@@ -101,7 +102,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 .Select(x => x.Id).ToList();
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ReturnsAsync(conferences);
 
             _mocker.Mock<IBookingsApiClient>()
@@ -196,7 +197,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             }
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ReturnsAsync(conferences);
 
             _mocker.Mock<IBookingsApiClient>()
@@ -299,7 +300,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             }
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<GetConferencesByHearingIdsRequest>()))
                 .ReturnsAsync(conferences);
 
             _mocker.Mock<IBookingsApiClient>()

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForVHOfficerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForVHOfficerTests.cs
@@ -36,6 +36,9 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
         public void Setup()
         {
             _mocker = AutoMock.GetLoose();
+            _mocker.Mock<IBookingsApiClient>()
+                .Setup(x => x.GetHearingsForTodayByVenueAsync(It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(new List<HearingDetailsResponse>{Mock.Of<HearingDetailsResponse>()});
 
             var claimsPrincipal = new ClaimsPrincipalBuilder().WithRole(AppRoles.VhOfficerRole).Build();
             _controller = SetupControllerWithClaims(claimsPrincipal);
@@ -48,7 +51,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 (int) HttpStatusCode.InternalServerError,
                 "Stacktrace goes here", null, default, null);
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForAdminByHearingVenueNameAsync(It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ThrowsAsync(apiException);
 
             var result = await _controller.GetConferencesForVhOfficerAsync(new VhoConferenceFilterQuery());
@@ -98,7 +101,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
                 .Select(x => x.Id).ToList();
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForAdminByHearingVenueNameAsync(It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ReturnsAsync(conferences);
 
             _mocker.Mock<IBookingsApiClient>()
@@ -193,7 +196,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             }
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForAdminByHearingVenueNameAsync(It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ReturnsAsync(conferences);
 
             _mocker.Mock<IBookingsApiClient>()
@@ -296,7 +299,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             }
 
             _mocker.Mock<IVideoApiClient>()
-                .Setup(x => x.GetConferencesTodayForAdminByHearingVenueNameAsync(It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.GetConferencesForAdminByHearingRefIdAsync(It.IsAny<IEnumerable<Guid>>()))
                 .ReturnsAsync(conferences);
 
             _mocker.Mock<IBookingsApiClient>()

--- a/VideoWeb/VideoWeb.UnitTests/Extensions/ConferenceForVhOfficerResponseExtensionsTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Extensions/ConferenceForVhOfficerResponseExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 using VideoWeb.Contract.Request;
@@ -40,12 +41,12 @@ public class ConferenceForVhOfficerResponseExtensionsTests
             new ConferenceForVhOfficerResponse()
             {
                 AllocatedCsoId = null,
-                HearingVenueName = "Ayr"
+                HearingVenueName = "Ayr Social Security and Child Support Tribunal"
             },
             new ConferenceForVhOfficerResponse()
             {
                 AllocatedCsoId = null,
-                HearingVenueName = "Dundee Tribunal Hearing Centre",
+                HearingVenueName = "Dundee Tribunal Hearing Centre - Endeavour House",
             },
             new ConferenceForVhOfficerResponse()
             {
@@ -69,7 +70,9 @@ public class ConferenceForVhOfficerResponseExtensionsTests
         var allocatedCsoId = Guid.NewGuid();
         unallocatedConferences.Add(
             new ConferenceForVhOfficerResponse { AllocatedCsoId = allocatedCsoId,  HearingVenueName = "Birmingham Magistrates Court" });
-        var filteredConferences = unallocatedConferences.ApplyCsoFilter(new VhoConferenceFilterQuery{IncludeUnallocated = true, AllocatedCsoIds = new[] {allocatedCsoId}});
+        var filteredConferences = unallocatedConferences
+            .ApplyCsoFilter(new VhoConferenceFilterQuery{IncludeUnallocated = true, AllocatedCsoIds = new[] {allocatedCsoId}})
+            .ToList();
         filteredConferences.Should().HaveCount(2);
     }    
     

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.9" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.12-pr-0589-0011" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12-pr-0589-0011" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -111,9 +111,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.9, )",
-        "resolved": "1.44.9",
-        "contentHash": "sSg7dS9isysin04kgt9SZEhJIoyMoTaUG9s2vpXKsZX09xBK8kBhwpz+yMs+cA+RW/M0t3Egyzb32WCX98h7Zw==",
+        "requested": "[1.44.11-pr-0589-0007, )",
+        "resolved": "1.44.11-pr-0589-0007",
+        "contentHash": "iyHv6tcDEXcJO9yEwNF2uoCLP1N/auxusErL6abVh7ppnfmdYi2oWGKQ18WPKq3P95gqGUkCn+FuPGvCxc6ZXw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -158,8 +158,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.9",
-        "contentHash": "K63Oupjy9lZpFZfijlOtSt+XWCImkuDAyn8dtsoyE5Bn22kmzsTiGVzllCEuiVqGnN/y7N1tkFN+L+T5t0RHng==",
+        "resolved": "1.45.16-pr-0668-0009",
+        "contentHash": "htHrMV90Aer2xQIKJwB9oKnb3hSDydBIrp5+VHcpmCBMhtPzWYMVBmseNTQUY9Xb+EVee/UBZM4SaUQI2/Q00w==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1886,7 +1886,7 @@
       "videoweb": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.9, )",
+          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
           "Castle.Core": "[5.1.1, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",
@@ -1910,7 +1910,7 @@
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.5.0, )",
           "UserApi.Client": "[1.44.2, )",
           "VH.Core.Configuration": "[0.1.13, )",
-          "VideoApi.Client": "[1.44.9, )",
+          "VideoApi.Client": "[1.44.11-pr-0589-0007, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -1919,7 +1919,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.9, )",
+          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1929,7 +1929,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.9, )"
+          "VideoApi.Client": "[1.44.11-pr-0589-0007, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -111,9 +111,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.9, )",
-        "resolved": "1.44.9",
-        "contentHash": "sSg7dS9isysin04kgt9SZEhJIoyMoTaUG9s2vpXKsZX09xBK8kBhwpz+yMs+cA+RW/M0t3Egyzb32WCX98h7Zw==",
+        "requested": "[1.44.12, )",
+        "resolved": "1.44.12",
+        "contentHash": "e6gTb9EPYaaL5lVi/TG53NrSmAPjesZuDpnCSKACpTxocLvyynxIrEenT3tAFQ5v1XdaC+kQWR7TWRmIaCZv1Q==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -158,8 +158,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.21",
-        "contentHash": "fmmGE+E/5/xyy4n4x2ir+5yzCZ2KCKdV9sdzjPLVYwZPdHztk73sYvs52gAsN+eTEQg6XHoBQUuoPB/Oeh8bqA==",
+        "resolved": "1.45.24",
+        "contentHash": "cHqON2++rQwm7NSuVeKtKkWMcc38+i4ZUbEGuvX2GIAkqMvor2Ob5DVnU/1DIeOBeJWHWXAGIGvkoSBwNbPftg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1886,7 +1886,7 @@
       "videoweb": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.21, )",
+          "BookingsApi.Client": "[1.45.24, )",
           "Castle.Core": "[5.1.1, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",
@@ -1910,7 +1910,7 @@
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.5.0, )",
           "UserApi.Client": "[1.44.2, )",
           "VH.Core.Configuration": "[0.1.13, )",
-          "VideoApi.Client": "[1.44.9, )",
+          "VideoApi.Client": "[1.44.12, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -1919,7 +1919,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.21, )",
+          "BookingsApi.Client": "[1.45.24, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1929,7 +1929,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.9, )"
+          "VideoApi.Client": "[1.44.12, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -111,9 +111,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.11-pr-0589-0007, )",
-        "resolved": "1.44.11-pr-0589-0007",
-        "contentHash": "iyHv6tcDEXcJO9yEwNF2uoCLP1N/auxusErL6abVh7ppnfmdYi2oWGKQ18WPKq3P95gqGUkCn+FuPGvCxc6ZXw==",
+        "requested": "[1.44.11-pr-0589-0009, )",
+        "resolved": "1.44.11-pr-0589-0009",
+        "contentHash": "WS6HUq16cyD4B+dp4urq8HOU57UBieJHS4atZQwfW8urZzv8uraN6LTTLnzztgQF25rD3gSJE2taJjxcAFp8rQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -158,8 +158,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.16-pr-0668-0009",
-        "contentHash": "htHrMV90Aer2xQIKJwB9oKnb3hSDydBIrp5+VHcpmCBMhtPzWYMVBmseNTQUY9Xb+EVee/UBZM4SaUQI2/Q00w==",
+        "resolved": "1.45.19-pr-0668-0012",
+        "contentHash": "QSEJPFZhrKBGYpc4z9GkLlE9zu3WCMUCfcJzH7dZJyMtcrL0ZyXv2amRRdqThdHGu8UtU3dr7AR1r0US7D4YWA==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1886,7 +1886,7 @@
       "videoweb": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
+          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
           "Castle.Core": "[5.1.1, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",
@@ -1910,7 +1910,7 @@
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.5.0, )",
           "UserApi.Client": "[1.44.2, )",
           "VH.Core.Configuration": "[0.1.13, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0007, )",
+          "VideoApi.Client": "[1.44.11-pr-0589-0009, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -1919,7 +1919,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
+          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1929,7 +1929,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0007, )"
+          "VideoApi.Client": "[1.44.11-pr-0589-0009, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -111,9 +111,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.11-pr-0589-0009, )",
-        "resolved": "1.44.11-pr-0589-0009",
-        "contentHash": "WS6HUq16cyD4B+dp4urq8HOU57UBieJHS4atZQwfW8urZzv8uraN6LTTLnzztgQF25rD3gSJE2taJjxcAFp8rQ==",
+        "requested": "[1.44.12-pr-0589-0011, )",
+        "resolved": "1.44.12-pr-0589-0011",
+        "contentHash": "tUDxBUh6FcKrLSLyp7s34FG8d7yeMY5Edj0oix8D6uiurVnldx6koZW2Zbui6ub6lxd3j6vdd+dmUMO5PhPtYQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -158,8 +158,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.45.19-pr-0668-0012",
-        "contentHash": "QSEJPFZhrKBGYpc4z9GkLlE9zu3WCMUCfcJzH7dZJyMtcrL0ZyXv2amRRdqThdHGu8UtU3dr7AR1r0US7D4YWA==",
+        "resolved": "1.45.22-pr-0668-0013",
+        "contentHash": "NDr0vyLxD6tazP/eeXEUca2+MrQTWTGKQCB876sjVgfHgC2Inr8kYZGxDlwWnuOr3adZn8wpDkVkhMZa8bohxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1886,7 +1886,7 @@
       "videoweb": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
+          "BookingsApi.Client": "[1.45.22-pr-0668-0013, )",
           "Castle.Core": "[5.1.1, )",
           "FluentValidation.AspNetCore": "[10.4.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[5.7.0, )",
@@ -1910,7 +1910,7 @@
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.5.0, )",
           "UserApi.Client": "[1.44.2, )",
           "VH.Core.Configuration": "[0.1.13, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0009, )",
+          "VideoApi.Client": "[1.44.12-pr-0589-0011, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -1919,7 +1919,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
+          "BookingsApi.Client": "[1.45.22-pr-0668-0013, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1929,7 +1929,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0009, )"
+          "VideoApi.Client": "[1.44.12-pr-0589-0011, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -157,7 +157,9 @@ namespace VideoWeb.Controllers
             _logger.LogDebug("GetConferencesForVhOfficer");
             try
             {
-                var conferences = await _videoApiClient.GetConferencesTodayForAdminByHearingVenueNameAsync(query.HearingVenueNames);
+                
+                var hearingsForToday = await _bookingApiClient.GetHearingsForTodayByVenueAsync(query.HearingVenueNames);
+                var conferences = await _videoApiClient.GetConferencesForAdminByHearingRefIdAsync(hearingsForToday.Select(e => e.Id));
                 var allocatedHearings =
                     await _bookingApiClient.GetAllocationsForHearingsAsync(conferences.Select(e => e.HearingRefId));
                 var conferenceForVhOfficerResponseMapper = _mapperFactory.Get<ConferenceForAdminResponse, AllocatedCsoResponse, ConferenceForVhOfficerResponse>();

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -17,6 +17,7 @@ using VideoWeb.Contract.Responses;
 using VideoWeb.Helpers;
 using VideoWeb.Mappings;
 using VideoApi.Client;
+using VideoApi.Contract.Requests;
 using VideoApi.Contract.Responses;
 using VideoWeb.Extensions;
 using HostConference = VideoApi.Contract.Responses.ConferenceForHostResponse;
@@ -99,7 +100,8 @@ namespace VideoWeb.Controllers
             {
                 var conferenceForHostResponseMapper = _mapperFactory.Get<HostConference, ConferenceForHostResponse>();
                 var hearingsForToday = await _bookingApiClient.GetHearingsForTodayByVenueAsync(hearingVenueNames);
-                var conferencesForStaffMember = await _videoApiClient.GetConferencesForHostByHearingRefIdAsync(hearingsForToday.Select(e => e.Id));
+                var request = new GetConferencesByHearingIdsRequest{ HearingRefIds = hearingsForToday.Select(x => x.Id).ToArray() };
+                var conferencesForStaffMember = await _videoApiClient.GetConferencesForHostByHearingRefIdAsync(request);
                 var response = conferencesForStaffMember
                     .Select(conferenceForHostResponseMapper.Map)
                     .ToList();
@@ -159,7 +161,8 @@ namespace VideoWeb.Controllers
             {
                 
                 var hearingsForToday = await _bookingApiClient.GetHearingsForTodayByVenueAsync(query.HearingVenueNames);
-                var conferences = await _videoApiClient.GetConferencesForAdminByHearingRefIdAsync(hearingsForToday.Select(e => e.Id));
+                var request = new GetConferencesByHearingIdsRequest { HearingRefIds = hearingsForToday.Select(e => e.Id).ToArray() };
+                var conferences = await _videoApiClient.GetConferencesForAdminByHearingRefIdAsync(request);
                 var allocatedHearings =
                     await _bookingApiClient.GetAllocationsForHearingsAsync(conferences.Select(e => e.HearingRefId));
                 var conferenceForVhOfficerResponseMapper = _mapperFactory.Get<ConferenceForAdminResponse, AllocatedCsoResponse, ConferenceForVhOfficerResponse>();

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -98,7 +98,8 @@ namespace VideoWeb.Controllers
             try
             {
                 var conferenceForHostResponseMapper = _mapperFactory.Get<HostConference, ConferenceForHostResponse>();
-                var conferencesForStaffMember = await _videoApiClient.GetConferencesTodayForStaffMemberByHearingVenueNameAsync(hearingVenueNames);
+                var hearingsForToday = await _bookingApiClient.GetHearingsForTodayByVenueAsync(hearingVenueNames);
+                var conferencesForStaffMember = await _videoApiClient.GetConferencesForHostByHearingRefIdAsync(hearingsForToday.Select(e => e.Id));
                 var response = conferencesForStaffMember
                     .Select(conferenceForHostResponseMapper.Map)
                     .ToList();

--- a/VideoWeb/VideoWeb/Controllers/UserDataController.cs
+++ b/VideoWeb/VideoWeb/Controllers/UserDataController.cs
@@ -13,6 +13,7 @@ using VideoWeb.Contract.Responses;
 using VideoWeb.Mappings;
 using UserApi.Client;
 using VideoApi.Client;
+using VideoApi.Contract.Requests;
 using VideoApi.Contract.Responses;
 using VideoWeb.Extensions;
 
@@ -51,10 +52,10 @@ namespace VideoWeb.Controllers
             try
             {
                 var allocatedHearings = await _bookingApiClient.GetAllocationsForHearingsByVenueAsync(query.HearingVenueNames);
-                if(allocatedHearings == null || !allocatedHearings.Any())
-                    return NotFound();
-                
-                var conferences = await _videoApiClient.GetConferencesForAdminByHearingRefIdAsync(allocatedHearings.Select(e => e.HearingId));
+                if (allocatedHearings == null || !allocatedHearings.Any())
+                    return new List<CourtRoomsAccountResponse>();
+                var request = new GetConferencesByHearingIdsRequest{ HearingRefIds = allocatedHearings.Select(x => x.HearingId).ToArray() };
+                var conferences = await _videoApiClient.GetConferencesForAdminByHearingRefIdAsync(request);
                 var conferenceForVhOfficerResponseMapper = _mapperFactory.Get<ConferenceForAdminResponse, AllocatedCsoResponse, ConferenceForVhOfficerResponse>();
      
                 var responses = conferences

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.9" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.16-pr-0668-0009" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
@@ -65,7 +65,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.Core.Configuration" Version="0.1.13" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.9" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.16-pr-0668-0009" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.19-pr-0668-0012" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
@@ -65,7 +65,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.Core.Configuration" Version="0.1.13" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0007" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.19-pr-0668-0012" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.22-pr-0668-0013" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
@@ -65,7 +65,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.Core.Configuration" Version="0.1.13" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.11-pr-0589-0009" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12-pr-0589-0011" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.45.21" />
+    <PackageReference Include="BookingsApi.Client" Version="1.45.24" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
@@ -65,7 +65,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
     <PackageReference Include="UserApi.Client" Version="1.44.2" />
     <PackageReference Include="VH.Core.Configuration" Version="0.1.13" />
-    <PackageReference Include="VideoApi.Client" Version="1.44.9" />
+    <PackageReference Include="VideoApi.Client" Version="1.44.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.45.9, )",
-        "resolved": "1.45.9",
-        "contentHash": "K63Oupjy9lZpFZfijlOtSt+XWCImkuDAyn8dtsoyE5Bn22kmzsTiGVzllCEuiVqGnN/y7N1tkFN+L+T5t0RHng==",
+        "requested": "[1.45.16-pr-0668-0009, )",
+        "resolved": "1.45.16-pr-0668-0009",
+        "contentHash": "htHrMV90Aer2xQIKJwB9oKnb3hSDydBIrp5+VHcpmCBMhtPzWYMVBmseNTQUY9Xb+EVee/UBZM4SaUQI2/Q00w==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -267,9 +267,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.9, )",
-        "resolved": "1.44.9",
-        "contentHash": "sSg7dS9isysin04kgt9SZEhJIoyMoTaUG9s2vpXKsZX09xBK8kBhwpz+yMs+cA+RW/M0t3Egyzb32WCX98h7Zw==",
+        "requested": "[1.44.11-pr-0589-0007, )",
+        "resolved": "1.44.11-pr-0589-0007",
+        "contentHash": "iyHv6tcDEXcJO9yEwNF2uoCLP1N/auxusErL6abVh7ppnfmdYi2oWGKQ18WPKq3P95gqGUkCn+FuPGvCxc6ZXw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1707,7 +1707,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.9, )",
+          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1717,7 +1717,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.9, )"
+          "VideoApi.Client": "[1.44.11-pr-0589-0007, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.45.16-pr-0668-0009, )",
-        "resolved": "1.45.16-pr-0668-0009",
-        "contentHash": "htHrMV90Aer2xQIKJwB9oKnb3hSDydBIrp5+VHcpmCBMhtPzWYMVBmseNTQUY9Xb+EVee/UBZM4SaUQI2/Q00w==",
+        "requested": "[1.45.19-pr-0668-0012, )",
+        "resolved": "1.45.19-pr-0668-0012",
+        "contentHash": "QSEJPFZhrKBGYpc4z9GkLlE9zu3WCMUCfcJzH7dZJyMtcrL0ZyXv2amRRdqThdHGu8UtU3dr7AR1r0US7D4YWA==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -267,9 +267,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.11-pr-0589-0007, )",
-        "resolved": "1.44.11-pr-0589-0007",
-        "contentHash": "iyHv6tcDEXcJO9yEwNF2uoCLP1N/auxusErL6abVh7ppnfmdYi2oWGKQ18WPKq3P95gqGUkCn+FuPGvCxc6ZXw==",
+        "requested": "[1.44.11-pr-0589-0009, )",
+        "resolved": "1.44.11-pr-0589-0009",
+        "contentHash": "WS6HUq16cyD4B+dp4urq8HOU57UBieJHS4atZQwfW8urZzv8uraN6LTTLnzztgQF25rD3gSJE2taJjxcAFp8rQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1707,7 +1707,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.16-pr-0668-0009, )",
+          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1717,7 +1717,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0007, )"
+          "VideoApi.Client": "[1.44.11-pr-0589-0009, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.45.19-pr-0668-0012, )",
-        "resolved": "1.45.19-pr-0668-0012",
-        "contentHash": "QSEJPFZhrKBGYpc4z9GkLlE9zu3WCMUCfcJzH7dZJyMtcrL0ZyXv2amRRdqThdHGu8UtU3dr7AR1r0US7D4YWA==",
+        "requested": "[1.45.22-pr-0668-0013, )",
+        "resolved": "1.45.22-pr-0668-0013",
+        "contentHash": "NDr0vyLxD6tazP/eeXEUca2+MrQTWTGKQCB876sjVgfHgC2Inr8kYZGxDlwWnuOr3adZn8wpDkVkhMZa8bohxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -267,9 +267,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.11-pr-0589-0009, )",
-        "resolved": "1.44.11-pr-0589-0009",
-        "contentHash": "WS6HUq16cyD4B+dp4urq8HOU57UBieJHS4atZQwfW8urZzv8uraN6LTTLnzztgQF25rD3gSJE2taJjxcAFp8rQ==",
+        "requested": "[1.44.12-pr-0589-0011, )",
+        "resolved": "1.44.12-pr-0589-0011",
+        "contentHash": "tUDxBUh6FcKrLSLyp7s34FG8d7yeMY5Edj0oix8D6uiurVnldx6koZW2Zbui6ub6lxd3j6vdd+dmUMO5PhPtYQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1707,7 +1707,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.19-pr-0668-0012, )",
+          "BookingsApi.Client": "[1.45.22-pr-0668-0013, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1717,7 +1717,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.11-pr-0589-0009, )"
+          "VideoApi.Client": "[1.44.12-pr-0589-0011, )"
         }
       },
       "videoweb.contract": {

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.45.21, )",
-        "resolved": "1.45.21",
-        "contentHash": "fmmGE+E/5/xyy4n4x2ir+5yzCZ2KCKdV9sdzjPLVYwZPdHztk73sYvs52gAsN+eTEQg6XHoBQUuoPB/Oeh8bqA==",
+        "requested": "[1.45.24, )",
+        "resolved": "1.45.24",
+        "contentHash": "cHqON2++rQwm7NSuVeKtKkWMcc38+i4ZUbEGuvX2GIAkqMvor2Ob5DVnU/1DIeOBeJWHWXAGIGvkoSBwNbPftg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -267,9 +267,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.44.9, )",
-        "resolved": "1.44.9",
-        "contentHash": "sSg7dS9isysin04kgt9SZEhJIoyMoTaUG9s2vpXKsZX09xBK8kBhwpz+yMs+cA+RW/M0t3Egyzb32WCX98h7Zw==",
+        "requested": "[1.44.12, )",
+        "resolved": "1.44.12",
+        "contentHash": "e6gTb9EPYaaL5lVi/TG53NrSmAPjesZuDpnCSKACpTxocLvyynxIrEenT3tAFQ5v1XdaC+kQWR7TWRmIaCZv1Q==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1707,7 +1707,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[1.45.21, )",
+          "BookingsApi.Client": "[1.45.24, )",
           "Microsoft.ApplicationInsights": "[2.16.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.16.0, )",
           "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
@@ -1717,7 +1717,7 @@
           "StackExchange.Redis": "[2.6.111, )",
           "System.IdentityModel.Tokens.Jwt": "[5.6.0, )",
           "UserApi.Client": "[1.44.2, )",
-          "VideoApi.Client": "[1.44.9, )"
+          "VideoApi.Client": "[1.44.12, )"
         }
       },
       "videoweb.contract": {

--- a/charts/vh-video-web/values.dev.template.yaml
+++ b/charts/vh-video-web/values.dev.template.yaml
@@ -11,5 +11,3 @@ java:
         EJUDAD__REDIRECTURI: https://${SERVICE_FQDN}/home
         DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
         DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
-        VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-589.dev.platform.hmcts.net/
-        VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-668.dev.platform.hmcts.net/

--- a/charts/vh-video-web/values.dev.template.yaml
+++ b/charts/vh-video-web/values.dev.template.yaml
@@ -12,4 +12,4 @@ java:
         DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
         DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
         VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-589.dev.platform.hmcts.net/
-        VHSERVICES__BOOKINGSAPIURL: https://vh-booking-api-pr-668.dev.platform.hmcts.net/
+        VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-668.dev.platform.hmcts.net/

--- a/charts/vh-video-web/values.dev.template.yaml
+++ b/charts/vh-video-web/values.dev.template.yaml
@@ -11,3 +11,5 @@ java:
         EJUDAD__REDIRECTURI: https://${SERVICE_FQDN}/home
         DOM1__POSTLOGOUTREDIRECTURI: https://${SERVICE_FQDN}/logout
         DOM1__REDIRECTURI: https://${SERVICE_FQDN}/home
+        VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-589.dev.platform.hmcts.net/
+        VHSERVICES__BOOKINGSAPIURL: https://vh-booking-api-pr-668.dev.platform.hmcts.net/


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9988

### Change description ###
Updated implementation where conferences are queried with hearing venue names, via video api - to query via booking api instead. Added test coverage

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
