### PR TITLE
VIH-8905 Invoke hand lowered via EventHubClient after dismissal

### DIFF
--- a/VideoWeb/VideoWeb.EventHub/Services/ConferenceManagementService.cs
+++ b/VideoWeb/VideoWeb.EventHub/Services/ConferenceManagementService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using VideoApi.Client;
+using VideoWeb.Common.Caching;
+using VideoWeb.Common.Models;
+using VideoWeb.EventHub.Exceptions;
+using VideoWeb.EventHub.Hub;
+
+namespace VideoWeb.EventHub.Services;
+
+public interface IConferenceManagementService
+{
+    /// <summary>
+    /// Update the hand raised status of a participant in a conference
+    /// </summary>
+    /// <param name="conferenceId"></param>
+    /// <param name="participantId"></param>
+    /// <param name="isRaised"></param>
+    /// <returns></returns>
+    Task UpdateParticipantHandStatusInConference(Guid conferenceId, Guid participantId, bool isRaised);
+}
+
+public class ConferenceManagementService : IConferenceManagementService
+{
+    private readonly IConferenceCache _conferenceCache;
+    private readonly IVideoApiClient _videoApiClient;
+    private readonly IHubContext<VideoWeb.EventHub.Hub.EventHub, IEventHubClient> _hubContext;
+    private readonly ILogger<ConferenceManagementService> _logger;
+
+    public ConferenceManagementService(IConferenceCache conferenceCache, IVideoApiClient videoApiClient, IHubContext<Hub.EventHub, IEventHubClient> hubContext, ILogger<ConferenceManagementService> logger)
+    {
+        _conferenceCache = conferenceCache;
+        _videoApiClient = videoApiClient;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    public async Task UpdateParticipantHandStatusInConference(Guid conferenceId, Guid participantId, bool isRaised)
+    {
+        var conference = await GetConference(conferenceId);
+        var participant = conference.Participants.Find(x => x.Id == participantId);
+        if (participant == null) throw new ParticipantNotFoundException(conferenceId, participantId);
+        var linkedParticipants = GetLinkedParticipants(conference, participant);
+
+        var groupNames = new List<string> { participant.Username.ToLowerInvariant() };
+        groupNames.AddRange(conference.Participants.Where(x => x.IsHost()).Select(h => h.Username.ToLowerInvariant()));
+
+        foreach (var groupName in groupNames)
+        {
+            
+            await _hubContext.Clients.Group(groupName)
+                .ParticipantHandRaiseMessage(participantId, conferenceId, isRaised);
+        }
+               
+        _logger.LogTrace(
+            "Participant hand status updated: Participant Id: {ParticipantId} | Conference Id: {ConferenceId} to {IsHandRaised}",
+            participantId, conferenceId, isRaised);
+        foreach (var linkedParticipant in linkedParticipants)
+        {
+            await _hubContext.Clients
+                .Group(linkedParticipant.Username.ToLowerInvariant())
+                .ParticipantHandRaiseMessage(linkedParticipant.Id, conferenceId, isRaised);
+            _logger.LogTrace(
+                "Participant hand status updated: Participant Id: {ParticipantId} | Conference Id: {ConferenceId} to {IsHandRaised}",
+                linkedParticipant.Id, conferenceId, isRaised);
+        }
+    }
+    
+    private async Task<Conference> GetConference(Guid conferenceId)
+    {
+        var conference = await _conferenceCache.GetOrAddConferenceAsync
+        (
+            conferenceId,
+            () => _videoApiClient.GetConferenceDetailsByIdAsync(conferenceId)
+        );
+        return conference;
+    }
+    
+    private List<Participant> GetLinkedParticipants(Conference conference, Participant participant)
+    {
+        if (participant.IsJudicialOfficeHolder())
+        {
+            return conference.Participants
+                .Where(x => x.IsJudicialOfficeHolder() && x.Id != participant.Id).ToList();
+        }
+
+        return conference.Participants
+            .Where(p => participant.LinkedParticipants.Select(x => x.LinkedId)
+                .Contains(p.Id)
+            ).ToList();
+    }
+}

--- a/VideoWeb/VideoWeb.UnitTests/Builders/ConferenceCacheModelBuilder.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Builders/ConferenceCacheModelBuilder.cs
@@ -20,14 +20,19 @@ namespace VideoWeb.UnitTests.Builders
                 {
                     Builder<Participant>.CreateNew()
                         .With(x => x.Role = Role.Judge).With(x => x.Id = Guid.NewGuid())
+                        .With(x => x.Username = Faker.Internet.Email())
                         .Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
+                        .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
+                        .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
+                        .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
+                        .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build()
                 },
                 Endpoints = new List<Endpoint>
@@ -41,6 +46,18 @@ namespace VideoWeb.UnitTests.Builders
             };
         }
 
+        public ConferenceCacheModelBuilder WithJudicialOfficeHolders(int count = 2)
+        {
+            var participants = Builder<Participant>.CreateListOfSize(count)
+                .All().With(x => x.Id = Guid.NewGuid())
+                .With(x => x.Username = Faker.Internet.Email())
+                .With(x => x.LinkedParticipants = new List<LinkedParticipant>())
+                .With(x => x.Role = Role.JudicialOfficeHolder).Build().ToList();
+            _conference.Participants.AddRange(participants);
+            
+            return this;
+        }
+
         public ConferenceCacheModelBuilder WithLinkedParticipantsInRoom()
         {
             _conference.CivilianRooms = new List<CivilianRoom>
@@ -52,8 +69,8 @@ namespace VideoWeb.UnitTests.Builders
             participantA.LinkedParticipants.Add(new LinkedParticipant{LinkedId = participantB.Id, LinkType = LinkType.Interpreter});
             participantB.LinkedParticipants.Add(new LinkedParticipant{LinkedId = participantA.Id, LinkType = LinkType.Interpreter});
             
-            _conference.CivilianRooms.First().Participants.Add(participantA.Id);
-            _conference.CivilianRooms.First().Participants.Add(participantB.Id);
+            _conference.CivilianRooms[0].Participants.Add(participantA.Id);
+            _conference.CivilianRooms[0].Participants.Add(participantB.Id);
 
             return this;
         }

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceManagement/ConferenceManagementControllerTestBase.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceManagement/ConferenceManagementControllerTestBase.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Autofac;
 using FizzWare.NBuilder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,9 +12,6 @@ using VideoWeb.Common.Models;
 using VideoWeb.Controllers;
 using VideoApi.Contract.Responses;
 using Autofac.Extras.Moq;
-using Microsoft.AspNetCore.SignalR;
-using VideoWeb.EventHub.Hub;
-using VideoWeb.UnitTests.Builders;
 
 namespace VideoWeb.UnitTests.Controllers.ConferenceManagement
 {
@@ -23,23 +19,10 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceManagement
     {
         protected AutoMock _mocker;
         protected Conference TestConference;
-        protected EventComponentHelper EventComponentHelper;
 
         protected ConferenceManagementController SetupControllerWithClaims(ClaimsPrincipal claimsPrincipal)
         {
-            EventComponentHelper = new EventComponentHelper
-            {
-                EventHubContextMock = new Mock<IHubContext<EventHub.Hub.EventHub, IEventHubClient>>(),
-                EventHubClientMock = new Mock<IEventHubClient>()
-            };
-            EventComponentHelper.RegisterUsersForHubContext(TestConference.Participants);
-            EventComponentHelper.EventHubContextMock.Setup(x => x.Clients.Group(TestConference.Id.ToString()))
-                .Returns(EventComponentHelper.EventHubClientMock.Object);
-            _mocker = AutoMock.GetLoose(builder =>
-            {
-                builder.RegisterInstance(EventComponentHelper.EventHubContextMock.Object);
-                builder.RegisterInstance(EventComponentHelper.EventHubClientMock.Object);
-            });
+            _mocker = AutoMock.GetLoose();
             var sut = _mocker.Create<ConferenceManagementController>();
             sut.ControllerContext = new ControllerContext
             {

--- a/VideoWeb/VideoWeb.UnitTests/Hub/EventHubBaseTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Hub/EventHubBaseTests.cs
@@ -36,6 +36,7 @@ namespace VideoWeb.UnitTests.Hub
         protected Mock<IConferenceCache> ConferenceCacheMock;
         protected Mock<IHeartbeatRequestMapper> HeartbeatMapper;
         protected Mock<IConferenceVideoControlStatusService> ConferenceVideoControlStatusService;
+        protected Mock<IConferenceManagementService> ConferenceManagementServiceMock;
 
         [SetUp]
         public void Setup()
@@ -49,6 +50,7 @@ namespace VideoWeb.UnitTests.Hub
             HeartbeatMapper = new Mock<IHeartbeatRequestMapper>();
             ConferenceCacheMock = new Mock<IConferenceCache>();
             ConferenceVideoControlStatusService = new Mock<IConferenceVideoControlStatusService>();
+            ConferenceManagementServiceMock = new Mock<IConferenceManagementService>();
 
             Claims = new ClaimsPrincipalBuilder().Build();
             HubCallerContextMock.Setup(x => x.User).Returns(Claims);
@@ -64,7 +66,9 @@ namespace VideoWeb.UnitTests.Hub
             });
 
             Hub = new EventHub.Hub.EventHub(UserProfileServiceMock.Object, VideoApiClientMock.Object,
-                LoggerMock.Object, ConferenceCacheMock.Object, HeartbeatMapper.Object, vhServicesConfigurationOptions, ConferenceVideoControlStatusService.Object)
+                LoggerMock.Object, ConferenceCacheMock.Object, HeartbeatMapper.Object, vhServicesConfigurationOptions,
+                ConferenceVideoControlStatusService.Object,
+                conferenceManagementService: ConferenceManagementServiceMock.Object)
             {
                 Context = HubCallerContextMock.Object,
                 Groups = GroupManagerMock.Object,
@@ -108,7 +112,7 @@ namespace VideoWeb.UnitTests.Hub
                 .ReturnsAsync(conferences);
 
             return conferences
-                .Where(x => x.Participants.Any(p => p.Username == Claims.Identity.Name))
+                .Where(x => x.Participants.Exists(p => p.Username == Claims.Identity.Name))
                 .Select(c => c.Id.ToString()).ToArray();
         }
         

--- a/VideoWeb/VideoWeb.UnitTests/Services/ConferenceManagementServiceTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Services/ConferenceManagementServiceTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Extras.Moq;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using NUnit.Framework;
+using VideoApi.Contract.Responses;
+using VideoWeb.Common.Caching;
+using VideoWeb.Common.Models;
+using VideoWeb.EventHub.Exceptions;
+using VideoWeb.EventHub.Hub;
+using VideoWeb.EventHub.Services;
+using VideoWeb.UnitTests.Builders;
+
+namespace VideoWeb.UnitTests.Services;
+
+public class ConferenceManagementServiceTests
+{
+    private ConferenceManagementService _sut;
+    public Mock<IHubContext<EventHub.Hub.EventHub, IEventHubClient>> EventHubContextMock { get; set; }
+    public Mock<IEventHubClient> EventHubClientMock { get; set; }
+    private Conference _conference;
+    private AutoMock _mocker;
+
+    [SetUp]
+    public void Setup()
+    {
+        _conference = new ConferenceCacheModelBuilder().WithJudicialOfficeHolders().WithLinkedParticipantsInRoom()
+            .Build();
+
+        EventHubContextMock = new Mock<IHubContext<EventHub.Hub.EventHub, IEventHubClient>>();
+        EventHubClientMock = new Mock<IEventHubClient>();
+        
+        
+        _mocker = AutoMock.GetLoose(builder =>
+        {
+            builder.RegisterInstance(EventHubContextMock.Object);
+            builder.RegisterInstance(EventHubClientMock.Object);
+        });
+
+        _mocker.Mock<IConferenceCache>().Setup(x =>
+                x.GetOrAddConferenceAsync(_conference.Id, It.IsAny<Func<Task<ConferenceDetailsResponse>>>()))
+            .Callback(async (Guid anyGuid, Func<Task<ConferenceDetailsResponse>> factory) => await factory())
+            .ReturnsAsync(_conference);
+        
+        RegisterUsersForHubContext(_conference.Participants);
+        
+        _sut = _mocker.Create<ConferenceManagementService>();
+    }
+    
+    [Test]
+    public void should_not_send_message_when_participant_does_not_exist()
+    {
+        var conferenceId = _conference.Id;
+        var participantId = Guid.NewGuid();
+        const bool handRaised = true;
+
+
+        Func<Task> action = async () => await _sut.UpdateParticipantHandStatusInConference(conferenceId, participantId, handRaised);
+        action.Should().Throw<ParticipantNotFoundException>();
+        
+        EventHubClientMock.Verify(
+            x => x
+                .ParticipantHandRaiseMessage(participantId, _conference.Id, handRaised), Times.Never);
+    }
+    
+    [Test]
+    public async Task should_publish_hand_raised_to_participants_and_linked_and_judge()
+    {
+        var conferenceId = _conference.Id;
+        var participant = _conference.Participants.First(x => !x.IsJudge());
+        const bool handRaised = true;
+        
+
+        await _sut.UpdateParticipantHandStatusInConference(conferenceId, participant.Id, handRaised);
+            
+            
+        var judge = _conference.Participants.Single(x => x.IsJudge());
+        EventHubContextMock.Verify(
+            x => x.Clients.Group(It.Is<string>(s => s == judge.Username.ToLowerInvariant()))
+                .ParticipantHandRaiseMessage(participant.Id, conferenceId, handRaised), Times.Once);
+            
+        EventHubContextMock.Verify(
+            x => x.Clients.Group(participant.Username.ToLowerInvariant())
+                .ParticipantHandRaiseMessage(participant.Id, _conference.Id, handRaised), Times.Once);
+
+        foreach (var lp in participant.LinkedParticipants)
+        {
+            var linkedPat = _conference.Participants.Single(p => p.Id == lp.LinkedId);
+            EventHubContextMock.Verify(
+                x => x.Clients.Group(linkedPat.Username.ToLowerInvariant())
+                    .ParticipantHandRaiseMessage(lp.LinkedId, _conference.Id, handRaised), Times.Once);
+        }
+    }
+    
+    [Test]
+    public async Task should_publish_hand_raised_to_all_johs_when_one_joh_is_is_raised()
+    {
+        var conferenceId = _conference.Id;
+        var allJohs = _conference.Participants.Where(x => x.IsJudicialOfficeHolder()).ToList();
+        var participant = _conference.Participants.First(x => x.IsJudicialOfficeHolder());
+        const bool handRaised = true;
+     
+        await _sut.UpdateParticipantHandStatusInConference(conferenceId, participant.Id, handRaised);
+        
+        var judge = _conference.Participants.Single(x => x.IsJudge());
+            
+        EventHubContextMock.Verify(
+            x => x.Clients.Group(judge.Username.ToLowerInvariant())
+                .ParticipantHandRaiseMessage(participant.Id, _conference.Id, handRaised),  Times.Once);
+            
+        foreach (var joh in allJohs)
+        {
+            EventHubContextMock.Verify(
+                x => x.Clients.Group(joh.Username.ToLowerInvariant())
+                    .ParticipantHandRaiseMessage(joh.Id, _conference.Id, handRaised), Times.Once);
+        }
+    }
+
+    private void RegisterUsersForHubContext(List<Participant> participants)
+    {
+        foreach (var participant in participants)
+        {
+            EventHubContextMock.Setup(x => x.Clients.Group(participant.Username.ToLowerInvariant()))
+                .Returns(new Mock<IEventHubClient>().Object);
+        }
+
+        EventHubContextMock.Setup(x => x.Clients.Group(EventHub.Hub.EventHub.VhOfficersGroupName))
+            .Returns(new Mock<IEventHubClient>().Object);
+    }
+}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/logging/loggers/app-insights-logger.service.ts
@@ -133,6 +133,14 @@ export class AppInsightsLoggerService implements LogAdapter {
                 }
                 this.appInsights.loadAppInsights();
                 this.appInsights.addTelemetryInitializer((envelope: ITelemetryItem) => {
+                    const remoteDepedencyType = 'RemoteDependencyData';
+                    if (envelope.baseType === remoteDepedencyType && (envelope.baseData.name as string)) {
+                        const name = envelope.baseData.name as string;
+                        if (name.startsWith('HEAD /assets/images/favicons/favicon.ico?')) {
+                            // ignore favicon requests used to poll for availability
+                            return false;
+                        }
+                    }
                     envelope.tags['ai.cloud.role'] = 'vh-video-web';
                 });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/index.html
+++ b/VideoWeb/VideoWeb/ClientApp/src/index.html
@@ -17,9 +17,10 @@
     <link rel="apple-touch-icon" sizes="152x152" href="assets/images/favicons/apple-icon-152x152.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="assets/images/favicons/apple-icon-180x180.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="assets/images/favicons/android-icon-192x192.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="assets/images/favicons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="36x36" href="assets/images/favicons/favicon-36x36.png" />
+    <link rel="icon" type="image/png" sizes="48x48" href="assets/images/favicons/favicon-48x48.png" />
+    <link rel="icon" type="image/png" sizes="72x72" href="assets/images/favicons/favicon-72x72png" />
     <link rel="icon" type="image/png" sizes="96x96" href="assets/images/favicons/favicon-96x96.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicons/favicon-16x16.png" />
     <link rel="manifest" href="assets/images/favicons/manifest.json" />
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="msapplication-TileImage" content="assets/images/favicons/ms-icon-144x144.png" />

--- a/VideoWeb/VideoWeb/Controllers/ConferenceManagementController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferenceManagementController.cs
@@ -445,7 +445,7 @@ namespace VideoWeb.Controllers
         private async Task<bool> IsConferenceHost(Guid conferenceId)
         {
             var conference = await GetConference(conferenceId);
-            return conference.Participants.Exists(x => x.Username.Equals(User.Identity?.Name?.Trim(), StringComparison.InvariantCultureIgnoreCase) && x.IsHost());
+            return conference.Participants.Exists(x => x.Username.Equals(User.Identity!.Name?.Trim(), StringComparison.InvariantCultureIgnoreCase) && x.IsHost());
         }
 
         private async Task<bool> IsParticipantCallable(Guid conferenceId, Guid participantId)

--- a/VideoWeb/VideoWeb/Controllers/ConferenceManagementController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferenceManagementController.cs
@@ -445,7 +445,7 @@ namespace VideoWeb.Controllers
         private async Task<bool> IsConferenceHost(Guid conferenceId)
         {
             var conference = await GetConference(conferenceId);
-            return conference.Participants.Exists(x => x.Username.Equals(User?.Identity?.Name?.Trim(), StringComparison.InvariantCultureIgnoreCase) && x.IsHost());
+            return conference.Participants.Exists(x => x.Username.Equals(User.Identity?.Name?.Trim(), StringComparison.InvariantCultureIgnoreCase) && x.IsHost());
         }
 
         private async Task<bool> IsParticipantCallable(Guid conferenceId, Guid participantId)

--- a/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
+++ b/VideoWeb/VideoWeb/Extensions/ConfigureServicesExtensions.cs
@@ -118,6 +118,7 @@ namespace VideoWeb.Extensions
             services.AddScoped<IConferenceVideoControlStatusCache, DistributedConferenceVideoControlStatusCache>();
             services.AddScoped<IParticipantService, ParticipantService>();
             services.AddScoped<IDistributedJOHConsultationRoomLockCache, DistributedJOHConsultationRoomLockCache>();
+            services.AddScoped<IConferenceManagementService, ConferenceManagementService>();
             
             RegisterMappers(services);
 


### PR DESCRIPTION
### Change description ###

* Invoke hand lowered via EventHubClient after dismissal (forcing UI to lower hand in instance where message is lost)
* Set rule to ignore connection check request to app insights
* update incorrect favicon paths

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
