### PR TITLE
VIH-10308 Bugfix unable to send IM as Staff Member once joined to a conference

### DIFF
--- a/VideoWeb/VideoWeb.Common/Models/Conference.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Conference.cs
@@ -65,6 +65,11 @@ namespace VideoWeb.Common.Models
             return Participants.Exists(p => p.Username.Equals(username, StringComparison.InvariantCultureIgnoreCase));
         }
 
+        public Participant GetParticipant(string username)
+        {
+            return Participants.Find(p => p.Username.Equals(username, StringComparison.InvariantCultureIgnoreCase));
+        }
+
         public void UpdateParticipant(UpdateParticipant updateParticipant)
         {
             var participant = Participants.Find(x => x.RefId == updateParticipant.ParticipantRefId);

--- a/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
+++ b/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
@@ -152,7 +152,12 @@ namespace VideoWeb.EventHub.Hub
 
         private bool IsSenderAdmin(Conference conference)
         {
-            return !conference.IsParticipantInConference(Context.User.Identity!.Name) && IsSenderAdmin();
+            var username = Context.User.Identity!.Name;
+            var isStaffMember = conference.GetParticipant(username)?.Role == Role.StaffMember;
+            var isAdmin = IsSenderAdmin();
+            var isInConference = conference.IsParticipantInConference(username);
+            // once staff members join a hearing, they become participants so we have to exclude staff member in the is in conference check
+            return isInConference && isStaffMember || !isInConference && isAdmin;
         }
 
         private string GetObfuscatedUsernameAsync(string username)

--- a/azure-pipelines.sds.pr-release.yml
+++ b/azure-pipelines.sds.pr-release.yml
@@ -53,13 +53,15 @@ stages:
                           sonar.cs.opencover.reportsPaths=$(System.DefaultWorkingDirectory)/coverage.opencover.xml
                           sonar.javascript.lcov.reportPaths=**/ClientApp/coverage/lcov.info
                           sonar.cpd.exclusions=**/tests/WRTestComponent.ts, **/joh-waiting-room/**
-                          sonar.issue.ignore.multicriteria=e1, e2, e3
+                          sonar.issue.ignore.multicriteria=e1, e2, e3, e4
                           sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S107
                           sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts
                           sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S1874
                           sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.ts
                           sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S6544
                           sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.ts
+                          sonar.issue.ignore.multicriteria.e4.ruleKey=csharpsquid:S107
+                          sonar.issue.ignore.multicriteria.e4.resourceKey=**/*.cs
 
     #####################################################
     # Docker Build. #####################################


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10308

### Change description ###

When a SM with the VHO role joins a hearing, they will pass the condition `IsParticipantInConference`. This rule should be updated to check the role is not staff member so that the user can still be treated with their VHO role