### PR TITLE
VIH-10338 Fix - unable to log in to video web with ejud account

### DIFF
--- a/VideoWeb/VideoWeb.Common/UserProfileService.cs
+++ b/VideoWeb/VideoWeb.Common/UserProfileService.cs
@@ -44,8 +44,8 @@ namespace VideoWeb.Common
             var usernameClean = user.Identity.Name.ToLower().Trim();
             var userProfile = await _userProfileCache.GetOrAddAsync(usernameClean, new UserProfile
             {
-                FirstName = user.FindFirst(ClaimTypes.GivenName).Value,
-                LastName = user.FindFirst(ClaimTypes.Surname).Value,
+                FirstName = user.FindFirst(ClaimTypes.GivenName)?.Value,
+                LastName = user.FindFirst(ClaimTypes.Surname)?.Value,
                 Email = usernameClean,
                 UserName = usernameClean,
                 Roles = DetermineRolesFromClaims(user),

--- a/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
@@ -130,7 +130,7 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
         public async Task ShouldAddClaimsOnTokenValidation()
         {
             // Arrange
-            var claimsPrincipal = new ClaimsPrincipalBuilder().Build();
+            var claimsPrincipal = new EjudClaimsPrincipalBuilder().Build();
             var httpContext = new DefaultHttpContext
             {
                 User = claimsPrincipal,

--- a/VideoWeb/VideoWeb.UnitTests/Builders/ClaimsPrincipalBuilder.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Builders/ClaimsPrincipalBuilder.cs
@@ -8,16 +8,24 @@ namespace VideoWeb.UnitTests.Builders
         public static string Username = "john@hmcts.net";
 
         private readonly List<Claim> _claims;
-        public ClaimsPrincipalBuilder()
+        public ClaimsPrincipalBuilder(bool includeGivenName = true, bool includeSurname = true)
         {
             _claims = new List<Claim>
             { 
-                new Claim("preferred_username", Username),
-                new Claim(ClaimTypes.NameIdentifier, "userId"),
-                new Claim(ClaimTypes.GivenName, "John"),
-                new Claim(ClaimTypes.Surname, "Doe"),
-                new Claim(ClaimTypes.Name, "John Doe")
+                new("preferred_username", Username),
+                new(ClaimTypes.NameIdentifier, "userId"),
+                new(ClaimTypes.Name, "John Doe")
             };
+
+            if (includeGivenName)
+            {
+                _claims.Add(new Claim(ClaimTypes.GivenName, "John"));
+            }
+
+            if (includeSurname)
+            {
+                _claims.Add(new Claim(ClaimTypes.Surname, "Doe"));
+            }
         }
 
         public ClaimsPrincipalBuilder WithRole(params string[] roles)

--- a/VideoWeb/VideoWeb.UnitTests/Builders/EjudClaimsPrincipalBuilder.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Builders/EjudClaimsPrincipalBuilder.cs
@@ -1,0 +1,9 @@
+namespace VideoWeb.UnitTests.Builders
+{
+    public class EjudClaimsPrincipalBuilder : ClaimsPrincipalBuilder
+    {
+        public EjudClaimsPrincipalBuilder() : base(includeGivenName: false, includeSurname: false)
+        {
+        }
+    }
+}

--- a/VideoWeb/VideoWeb.UnitTests/Hub/UserProfileServiceTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Hub/UserProfileServiceTests.cs
@@ -116,5 +116,23 @@ namespace VideoWeb.UnitTests.Hub
             var userProfile = await _userProfileService.CacheUserProfileAsync(principal);
             userProfile.Should().BeNull();
         }
+
+        [Test]
+        public async Task Should_cache_profile_when_given_name_and_surname_claims_dont_exist()
+        {
+            var username = "Judge@hmcts.net";
+            var appRole = "Judge";
+
+            var identity = new ClaimsIdentity(new List<Claim> { 
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.Role, appRole),
+                new(ClaimTypes.Email, username),
+                new(ClaimTypes.NameIdentifier, username)}, "Basic" );
+
+            var principal = new ClaimsPrincipal(identity);
+
+            var userProfile = await _userProfileService.CacheUserProfileAsync(principal);
+            userProfile.Should().BeNull();
+        }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/Mappings/ClaimsPrincipalToUserProfileResponseMapperTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Mappings/ClaimsPrincipalToUserProfileResponseMapperTests.cs
@@ -78,5 +78,18 @@ namespace VideoWeb.UnitTests.Mappings
             response.Roles.Should().Contain(Role.VideoHearingsOfficer);
             response.Roles.Should().Contain(Role.StaffMember);
         }
+
+        [Test]
+        public void Should_map_ejud_claims()
+        {
+            const string displayName = "John Doe";
+            var username = ClaimsPrincipalBuilder.Username;
+            var user = new EjudClaimsPrincipalBuilder()
+                .WithClaim("name", displayName)
+                .WithUsername(username)
+                .WithRole(AppRoles.JudgeRole).Build();
+            var response = _sut.Map(user);
+            response.Roles.Should().Contain(Role.Judge);
+        }
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.spec.ts
@@ -113,6 +113,20 @@ describe('JudgeHearingListComponent', () => {
         expect(component.courtName).toBe('');
     });
 
+    it('should use profile display name if first name is null', async () => {
+        const profile = mockProfile;
+        profile.first_name = null;
+        component.profile = profile;
+        expect(component.courtName).toBe(`${profile.display_name}`);
+    });
+
+    it('should use profile display name if last name is null', async () => {
+        const profile = mockProfile;
+        profile.last_name = null;
+        component.profile = profile;
+        expect(component.courtName).toBe(`${profile.display_name}`);
+    });
+
     it('should navigate to judge waiting room when conference is selected for user as a judge in the conference', fakeAsync(() => {
         const conference = conferences[0];
         const judge = conference.participants.find(x => x.role === Role.Judge);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.ts
@@ -43,11 +43,14 @@ export abstract class HostHearingListBaseComponentDirective implements OnInit, O
     }
 
     get courtName(): string {
-        if (!this.profile) return '';
+        if (!this.profile) {
+            return '';
+        }
 
         if (!this.profile.first_name || !this.profile.last_name) {
             return this.profile.display_name;
         }
+
         return `${this.profile.first_name}, ${this.profile.last_name}`;
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.ts
@@ -43,10 +43,12 @@ export abstract class HostHearingListBaseComponentDirective implements OnInit, O
     }
 
     get courtName(): string {
+        if (!this.profile) return '';
+
         if (!this.profile.first_name || !this.profile.last_name) {
             return this.profile.display_name;
         }
-        return this.profile ? `${this.profile.first_name}, ${this.profile.last_name}` : '';
+        return `${this.profile.first_name}, ${this.profile.last_name}`;
     }
 
     @HostListener('window:beforeunload')

--- a/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/on-the-day/host-hearing-list/host-hearing-list.component-base.ts
@@ -43,6 +43,9 @@ export abstract class HostHearingListBaseComponentDirective implements OnInit, O
     }
 
     get courtName(): string {
+        if (!this.profile.first_name || !this.profile.last_name) {
+            return this.profile.display_name;
+        }
         return this.profile ? `${this.profile.first_name}, ${this.profile.last_name}` : '';
     }
 

--- a/VideoWeb/VideoWeb/Mappings/ClaimsPrincipalToUserProfileResponseMapper.cs
+++ b/VideoWeb/VideoWeb/Mappings/ClaimsPrincipalToUserProfileResponseMapper.cs
@@ -14,8 +14,8 @@ public class ClaimsPrincipalToUserProfileResponseMapper : IMapTo<ClaimsPrincipal
         var response = new UserProfileResponse
         {
             Roles = DetermineRolesFromClaims(user),
-            FirstName = user.Claims.First(c => c.Type == ClaimTypes.GivenName).Value,
-            LastName = user.Claims.First(c => c.Type == ClaimTypes.Surname).Value,
+            FirstName = user.Claims.FirstOrDefault(c => c.Type == ClaimTypes.GivenName)?.Value,
+            LastName = user.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Surname)?.Value,
             DisplayName = user.Claims.Last(c => c.Type == ClaimTypes.Name).Value,
             Username = user.Identity.Name.ToLower().Trim(),
             Name =  user.Claims.Last(c => c.Type == ClaimTypes.Name).Value


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10338


### Change description ###
The GivenName and Surname claims don't exist for Ejud issued tokens, so add handling for these being null.
Also show the Display Name on the hearing list page when the First Name or Last Name are null.