### PR TITLE
VIH-10354 VHO Command centre Alerts section zoom in overlapping

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/command-centre/command-centre.component.scss
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/command-centre/command-centre.component.scss
@@ -27,8 +27,6 @@
 
 .selected-menu-content {
   @include govuk-grid-column(two-thirds);
-  height: 70vh;
-  max-height: 100vh;
 }
 
 .title {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10354


### Change description ###
Fix overlapping elements on the command centre page.
The cause is these height styles which apply a fixed height to the container. This styling had been added as part of a previous ticket to add a scrollbar. It is not needed as it is already part of the `im-participant-list` css class.

```
.im-participant-list {
  @include govuk-grid-column(one-third);
  overflow-y: auto;
  height: 70vh;
  max-height: 100vh;
}

```