### PR TITLE
VIH-10375 Return empty list instead of 500 error when no hearings exist

### DIFF
--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForHostTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForHostTests.cs
@@ -171,7 +171,7 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
         }
 
         [Test]
-        public async Task Should_return_exception()
+        public async Task Should_forward_error_when_video_api_returns_error()
         {
             var apiException = new VideoApiException<ProblemDetails>("Internal Server Error",
                 (int) HttpStatusCode.InternalServerError,
@@ -183,6 +183,23 @@ namespace VideoWeb.UnitTests.Controllers.ConferenceController
             var result = await _controller.GetConferencesForHostAsync();
             var typedResult = result.Value;
             typedResult.Should().BeNull();
+        }
+        
+        [Test]
+        public async Task Should_forward_error_when_bookings_api_returns_error()
+        {
+            var apiException = new BookingsApiException<ProblemDetails>("Internal Server Error",
+                (int)HttpStatusCode.InternalServerError,
+                "Stacktrace goes here", null, default, null);
+            
+            _mocker.Mock<IBookingsApiClient>()
+                .Setup(x => x.GetConfirmedHearingsByUsernameForTodayAsync(It.IsAny<string>()))
+                .ThrowsAsync(apiException);
+
+            var result = await _controller.GetConferencesForHostAsync();
+
+            var typedResult = (ObjectResult)result.Result;
+            typedResult.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
         }
     }
 }

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -86,7 +86,7 @@ namespace VideoWeb.Controllers
                     return Ok(new List<ConferenceForHostResponse>());
                 }
 
-                throw;
+                return StatusCode(e.StatusCode, e.Response);
             }
             catch (VideoApiException e)
             {
@@ -118,6 +118,16 @@ namespace VideoWeb.Controllers
                     .Select(conferenceForHostResponseMapper.Map)
                     .ToList();
                 return Ok(response);
+            }
+            catch (BookingsApiException e)
+            {
+                if (e.StatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    _logger.LogWarning("No hearings found for staff member");
+                    return Ok(new List<ConferenceForHostResponse>());
+                }
+            
+                return StatusCode(e.StatusCode, e.Response);
             }
             catch (VideoApiException e)
             {
@@ -172,7 +182,7 @@ namespace VideoWeb.Controllers
                     return Ok(new List<ConferenceForIndividualResponse>());
                 }
 
-                throw;
+                return StatusCode(e.StatusCode, e.Response);
             }
             catch (VideoApiException e)
             {
@@ -221,6 +231,16 @@ namespace VideoWeb.Controllers
                 // display conferences in order of scheduled date time and then by case name. if a conference if closed then it should be at the bottom of the list. if a conference is closed at the same time then order by case name
                 responses.Sort(new SortConferenceForVhoOfficerHelper());
                 return Ok(responses);
+            }
+            catch (BookingsApiException e)
+            {
+                if (e.StatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    _logger.LogWarning("No hearings found for vh officer");
+                    return Ok(new List<ConferenceForVhOfficerResponse>());
+                }
+            
+                return StatusCode(e.StatusCode, e.Response);
             }
             catch (VideoApiException e)
             {

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -80,18 +80,11 @@ namespace VideoWeb.Controllers
             }
             catch (BookingsApiException e)
             {
-                if (e.StatusCode == (int)HttpStatusCode.NotFound)
-                {
-                    _logger.LogWarning("No hearings found for user");
-                    return Ok(new List<ConferenceForHostResponse>());
-                }
-
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleBookingsApiExceptionForHost(e);
             }
             catch (VideoApiException e)
             {
-                _logger.LogError(e, "Unable to get conferences for user");
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleVideoApiExceptionForHost(e);
             }
         }
 
@@ -121,18 +114,11 @@ namespace VideoWeb.Controllers
             }
             catch (BookingsApiException e)
             {
-                if (e.StatusCode == (int)HttpStatusCode.NotFound)
-                {
-                    _logger.LogWarning("No hearings found for staff member");
-                    return Ok(new List<ConferenceForHostResponse>());
-                }
-            
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleBookingsApiExceptionForHost(e);
             }
             catch (VideoApiException e)
             {
-                _logger.LogError(e, "Unable to get conferences for staff member");
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleVideoApiExceptionForHost(e);
             }
         }
 
@@ -398,6 +384,23 @@ namespace VideoWeb.Controllers
             await _conferenceCache.AddConferenceAsync(conference);
 
             return Ok(response);
+        }
+
+        private ActionResult HandleBookingsApiExceptionForHost(BookingsApiException e)
+        {
+            if (e.StatusCode == (int)HttpStatusCode.NotFound)
+            {
+                _logger.LogWarning("No hearings found for user");
+                return Ok(new List<ConferenceForHostResponse>());
+            }
+
+            return StatusCode(e.StatusCode, e.Response);
+        }
+
+        private ActionResult HandleVideoApiExceptionForHost(VideoApiException e)
+        {
+            _logger.LogError(e, "Unable to get conferences for user");
+            return StatusCode(e.StatusCode, e.Response);
         }
     }
 }

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -80,11 +80,11 @@ namespace VideoWeb.Controllers
             }
             catch (BookingsApiException e)
             {
-                return HandleBookingsApiExceptionForHost(e);
+                return HandleBookingsApiExceptionForGetHearings<ConferenceForHostResponse>(e);
             }
             catch (VideoApiException e)
             {
-                return HandleVideoApiExceptionForHost(e);
+                return HandleVideoApiExceptionForGetConferences(e);
             }
         }
 
@@ -114,11 +114,11 @@ namespace VideoWeb.Controllers
             }
             catch (BookingsApiException e)
             {
-                return HandleBookingsApiExceptionForHost(e);
+                return HandleBookingsApiExceptionForGetHearings<ConferenceForHostResponse>(e);
             }
             catch (VideoApiException e)
             {
-                return HandleVideoApiExceptionForHost(e);
+                return HandleVideoApiExceptionForGetConferences(e);
             }
         }
 
@@ -162,18 +162,11 @@ namespace VideoWeb.Controllers
             }
             catch (BookingsApiException e)
             {
-                if (e.StatusCode == (int)HttpStatusCode.NotFound)
-                {
-                    _logger.LogWarning("No hearings found for user");
-                    return Ok(new List<ConferenceForIndividualResponse>());
-                }
-
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleBookingsApiExceptionForGetHearings<ConferenceForIndividualResponse>(e);
             }
             catch (VideoApiException e)
             {
-                _logger.LogError(e, "Unable to get conferences for user");
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleVideoApiExceptionForGetConferences(e);
             }
         }
 
@@ -220,18 +213,11 @@ namespace VideoWeb.Controllers
             }
             catch (BookingsApiException e)
             {
-                if (e.StatusCode == (int)HttpStatusCode.NotFound)
-                {
-                    _logger.LogWarning("No hearings found for vh officer");
-                    return Ok(new List<ConferenceForVhOfficerResponse>());
-                }
-            
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleBookingsApiExceptionForGetHearings<ConferenceForVhOfficerResponse>(e);
             }
             catch (VideoApiException e)
             {
-                _logger.LogError(e, "Unable to get conferences for vh officer");
-                return StatusCode(e.StatusCode, e.Response);
+                return HandleVideoApiExceptionForGetConferences(e);
             }
         }
 
@@ -386,18 +372,18 @@ namespace VideoWeb.Controllers
             return Ok(response);
         }
 
-        private ActionResult HandleBookingsApiExceptionForHost(BookingsApiException e)
+        private ActionResult HandleBookingsApiExceptionForGetHearings<T>(BookingsApiException e) where T : class
         {
             if (e.StatusCode == (int)HttpStatusCode.NotFound)
             {
                 _logger.LogWarning("No hearings found for user");
-                return Ok(new List<ConferenceForHostResponse>());
+                return Ok(new List<T>());
             }
 
             return StatusCode(e.StatusCode, e.Response);
         }
 
-        private ActionResult HandleVideoApiExceptionForHost(VideoApiException e)
+        private ActionResult HandleVideoApiExceptionForGetConferences(VideoApiException e)
         {
             _logger.LogError(e, "Unable to get conferences for user");
             return StatusCode(e.StatusCode, e.Response);


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10375


### Change description ###
When bookings api returns no hearings for a vho or staff member, return an empty list instead of throwing a 500 error
Also update the error handling for querying by individual and host for consistency
