### PR TITLE
VIH-10496 Update to keep participant overlay text in sync with display name changes

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/mock-video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/mock-video-call.service.ts
@@ -88,7 +88,8 @@ export const videoCallServiceSpy = jasmine.createSpyObj<VideoCallService>(
         'onParticipantDeleted',
         'connectWowzaAgent',
         'disconnectWowzaAgent',
-        'onConferenceAdjourned'
+        'onConferenceAdjourned',
+        'setParticipantOverlayText'
     ],
     {
         pexipAPI: pexipApiMock,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -492,6 +492,16 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
         }
     }
 
+    syncDisplayName(pexipParticipant: ParticipantUpdated) {
+        const pexipDisplayModel = PexipDisplayNameModel.fromString(pexipParticipant.pexipDisplayName);
+        if (
+            pexipParticipant.pexipDisplayName.includes(this.participant.id) &&
+            this.participant.display_name !== pexipDisplayModel.displayName
+        ) {
+            this.videoCallService.setParticipantOverlayText(pexipParticipant.uuid, this.participant.display_name);
+        }
+    }
+
     private init() {
         this.destroyedSubject = new Subject();
         this.errorCount = 0;
@@ -535,6 +545,7 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
             .subscribe(updatedParticipant => {
                 this.assignPexipIdToRemoteStore(updatedParticipant);
                 this.updateWowzaParticipant(updatedParticipant);
+                this.syncDisplayName(updatedParticipant);
             });
 
         this.videoCallService.onParticipantDeleted().subscribe(deletedParticipant => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/tests/judge-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/tests/judge-waiting-room.component.spec.ts
@@ -1347,4 +1347,46 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
         expect(videoCallService.disconnectWowzaAgent).toHaveBeenCalledWith('uuid');
         expect(component.dialOutUUID.length).toBe(0);
     });
+
+    describe('syncDisplayName', () => {
+        beforeEach(() => {
+            videoCallService.setParticipantOverlayText.calls.reset();
+        });
+
+        it('Should call setParticipantOverlayText when is current participant and display name is differnt from update', () => {
+            const participant = new ParticipantResponse();
+            participant.id = '123';
+            participant.display_name = 'CorrectName';
+            participant.status = ParticipantStatus.Available;
+            component.participant = participant;
+            const participantUpdate = ParticipantUpdated.fromPexipParticipant(pexipParticipant);
+            participantUpdate.pexipDisplayName = 'JUDGE;HEARTBEAT;WrongName;123';
+            component.syncDisplayName(participantUpdate);
+            expect(videoCallService.setParticipantOverlayText).toHaveBeenCalledWith(participantUpdate.uuid, participant.display_name);
+        });
+
+        it('Should not call setParticipantOverlayText when is current participant but display name is not differnt from update', () => {
+            const participant = new ParticipantResponse();
+            participant.id = '123';
+            participant.display_name = 'CorrectName';
+            participant.status = ParticipantStatus.Available;
+            component.participant = participant;
+            const participantUpdate = ParticipantUpdated.fromPexipParticipant(pexipParticipant);
+            participantUpdate.pexipDisplayName = 'JUDGE;HEARTBEAT;CorrectName;123';
+            component.syncDisplayName(participantUpdate);
+            expect(videoCallService.setParticipantOverlayText).toHaveBeenCalledTimes(0);
+        });
+
+        it('Should not call setParticipantOverlayText when is current participant is not the one being updated', () => {
+            const participant = new ParticipantResponse();
+            participant.id = '123';
+            participant.display_name = 'CorrectName';
+            participant.status = ParticipantStatus.Available;
+            component.participant = participant;
+            const participantUpdate = ParticipantUpdated.fromPexipParticipant(pexipParticipant);
+            participantUpdate.pexipDisplayName = 'JUDGE;HEARTBEAT;CorrectName;ABC';
+            component.syncDisplayName(participantUpdate);
+            expect(videoCallService.setParticipantOverlayText).toHaveBeenCalledTimes(0);
+        });
+    });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -354,7 +354,7 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
     handleParticipantUpdatedInVideoCall(updatedParticipant: ParticipantUpdated): void {
         const participant = this.participants.find(x => updatedParticipant.pexipDisplayName.includes(x.id));
         if (!participant) {
-            this.logger.warn(`${this.loggerPrefix} could NOT update participant in call`, {
+            this.logger.info(`${this.loggerPrefix} could NOT update participant in call`, {
                 displayName: updatedParticipant.pexipDisplayName
             });
             return;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -105,7 +105,8 @@ describe('VideoCallService', () => {
             'stopPresentation',
             'renegotiate',
             'dialOut',
-            'disconnectParticipant'
+            'disconnectParticipant',
+            'setParticipantText'
         ]);
 
         streamMixerServiceSpy = jasmine.createSpyObj<StreamMixerService>('StreamMixerService', ['mergeAudioStreams']);
@@ -639,6 +640,16 @@ describe('VideoCallService', () => {
             const uuid = 'uuid';
             service.disconnectWowzaAgent(uuid);
             expect(pexipSpy.disconnectParticipant).toHaveBeenCalledOnceWith(uuid);
+        });
+    });
+
+    describe('setParticipantOverlayText', () => {
+        it('should call pexip setParticipantOverlayText', () => {
+            service.pexipAPI = pexipSpy;
+            const uuid = 'uuid';
+            const text = 'text';
+            service.setParticipantOverlayText(uuid, text);
+            expect(pexipSpy.setParticipantText).toHaveBeenCalledWith(uuid, text);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -510,6 +510,10 @@ export class VideoCallService {
         this.pexipAPI.disconnectParticipant(wowzaUUID);
     }
 
+    setParticipantOverlayText(uuid: string, text: string) {
+        this.pexipAPI.setParticipantText(uuid, text);
+    }
+
     private handleSetup(stream: MediaStream | URL) {
         this.onSetupSubject.next(new CallSetup(stream));
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/typings.d.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/typings.d.ts
@@ -119,6 +119,7 @@ declare interface PexipClient {
     clearBuzz(uuid?: string);
     clearAllBuzz(): () => void;
     getMediaStatistics(): any;
+    setParticipantText(uuid: string, text: string);
 
     /**
      * Activate or stop screen capture sharing.


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10496

### Change description ###
Exposed the setParticipantText function from the pexrtc, and created a method that calls it to keep the text overlay in the conference in sync with the what the users display name is (should it have changed since the hearing has begun)
