### PR TITLE
VIH-10603 Fix - mic still audible when host chooses to enter hearing muted

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -1081,53 +1081,45 @@ describe('HearingControlsBaseComponent', () => {
         });
     });
 
-    describe('ngOnInit', () => {
+    describe('handleHearingCountdownComplete for host', () => {
         let conferenceSetting: ConferenceSetting;
 
         beforeEach(() => {
             conferenceSetting = new ConferenceSetting('conferenceId', true);
+            component.participant = globalConference.participants.find(x => x.role === Role.Judge);
+            component.isPrivateConsultation = false;
+            videoCallServiceSpy.toggleMute.calls.reset();
+            eventsServiceSpy.sendMediaStatus.calls.reset();
         });
 
-        it('should mute audio when starting with audio muted', () => {
+        it('should not unmute audio when host requests to start with audio muted', async () => {
             // Arrange
             conferenceSetting.startWithAudioMuted = true;
             userMediaServiceSpy.getConferenceSetting.and.returnValue(conferenceSetting);
+            videoCallServiceSpy.toggleMute.and.returnValue(true);
             // Act
             component.ngOnInit();
+            await component.handleHearingCountdownComplete(component.conferenceId);
             // Assert
-            expect(component.audioMuted).toBeTrue();
+            expect(videoCallServiceSpy.toggleMute).toHaveBeenCalledTimes(1);
+            expect(eventsServiceSpy.sendMediaStatus).toHaveBeenCalledWith(
+                jasmine.any(String),
+                jasmine.any(String),
+                jasmine.objectContaining({ is_local_audio_muted: true })
+            );
         });
 
-        it('should not mute audio when not starting with audio muted', () => {
+        it('should unmute audio when host requests to start without audio muted', async () => {
             // Arrange
             conferenceSetting.startWithAudioMuted = false;
             userMediaServiceSpy.getConferenceSetting.and.returnValue(conferenceSetting);
+            component.isPrivateConsultation = false;
             // Act
             component.ngOnInit();
-            // Assert
-            expect(component.audioMuted).toBeFalse();
-        });
-    });
-
-    describe('handleHearingCountdownComplete', () => {
-        let conferenceSetting: ConferenceSetting;
-
-        beforeEach(() => {
-            conferenceSetting = new ConferenceSetting('conferenceId', true);
-            videoCallService.toggleMute.calls.reset();
-        });
-
-        it('should not unmute audio when host is starting with audio muted', async () => {
-            // Arrange
-            component.participant = globalConference.participants.find(x => x.role === Role.Judge);
-            conferenceSetting.startWithAudioMuted = true;
-            userMediaServiceSpy.getConferenceSetting.and.returnValue(conferenceSetting);
-            component.isPrivateConsultation = false;
-            component.audioMuted = true;
-            // Act
             await component.handleHearingCountdownComplete(component.conferenceId);
             // Assert
-            expect(videoCallService.toggleMute).toHaveBeenCalledTimes(0);
+            expect(videoCallServiceSpy.toggleMute).toHaveBeenCalledTimes(0);
+            expect(eventsServiceSpy.sendMediaStatus).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -137,7 +137,7 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     ngOnInit(): void {
-        this.audioMuted = this.videoCallService.pexipAPI.call.mutedAudio || this.startWithAudioMuted;
+        this.audioMuted = this.videoCallService.pexipAPI.call.mutedAudio;
         this.videoMuted = this.videoCallService.pexipAPI.call.mutedVideo || this.audioOnly;
 
         this.userMediaService.isAudioOnly$.pipe(takeUntil(this.destroyedSubject)).subscribe(audioOnly => {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10603


### Change description ###
Fixes an issue where when the host requests to start a hearing muted, their mic is still audible.
The culprit is the `|| this.startWithAudioMuted`. Because `this.isAudioMuted` gets set to true, a call is not made to kinly API to physically mute the participant after the hearing countdown finishes, even though the icon shows they are muted.
