### PR TITLE
VIH-10642 Reconnect user when linked participant list for user changes

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -1507,6 +1507,7 @@ describe('WaitingRoomComponent EventHub Call', () => {
         const testHearing = new Hearing(testConference);
         testParticipant.id = 'TestId';
         testParticipant.display_name = 'TestDisplayName';
+        testParticipant.linked_participants = [];
         let getLoggedParticipantSpy: jasmine.Spy<() => ParticipantResponse>;
 
         beforeEach(() => {
@@ -1669,10 +1670,16 @@ describe('WaitingRoomComponent EventHub Call', () => {
                 updatedParticipant.linked_participants = [
                     new LinkedParticipantResponse({
                         link_type: LinkType.Interpreter,
-                        linked_id: updatedParticipant.id.toString()
+                        linked_id: testParticipant.id.toString()
                     })
                 ];
                 getLoggedParticipantSpy.and.returnValue(updatedParticipant);
+                testParticipant.linked_participants = [
+                    new LinkedParticipantResponse({
+                        link_type: LinkType.Interpreter,
+                        linked_id: updatedParticipant.id.toString()
+                    })
+                ];
                 const testParticipantMessage = new ParticipantsUpdatedMessage(globalConference.id, [
                     testParticipant,
                     component.participant

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -12,7 +12,9 @@ import {
     RoomSummaryResponse,
     HearingLayout,
     Role,
-    VideoEndpointResponse
+    VideoEndpointResponse,
+    LinkedParticipantResponse,
+    LinkType
 } from 'src/app/services/clients/api-client';
 import { ConsultationRequestResponseMessage } from 'src/app/services/models/consultation-request-response-message';
 import { ConferenceStatusMessage } from 'src/app/services/models/conference-status-message';
@@ -1505,11 +1507,12 @@ describe('WaitingRoomComponent EventHub Call', () => {
         const testHearing = new Hearing(testConference);
         testParticipant.id = 'TestId';
         testParticipant.display_name = 'TestDisplayName';
+        let getLoggedParticipantSpy: jasmine.Spy<() => ParticipantResponse>;
 
         beforeEach(() => {
             component.hearing = testHearing;
             component.conference.participants = [];
-            spyOn(component, 'getLoggedParticipant');
+            getLoggedParticipantSpy = spyOn(component, 'getLoggedParticipant');
         });
 
         describe('when is not correct conference', () => {
@@ -1650,6 +1653,34 @@ describe('WaitingRoomComponent EventHub Call', () => {
                 expect(participants.length).toBe(testParticipantMessage.participants.length);
                 expect(participants).toEqual(jasmine.arrayContaining(testParticipantMessage.participants));
             }
+        });
+
+        describe('when participant is now linked', () => {
+            it('should re-join when participant is now linked', () => {
+                const conference = new ConferenceResponse(Object.assign({}, globalConference));
+                const participant = new ParticipantResponse(Object.assign({}, globalParticipant));
+                spyOn(component, 'callAndUpdateShowVideo');
+                component.hearing = new Hearing(conference);
+                component.conference = conference;
+                component.participant = participant;
+
+                const updatedParticipant = new ParticipantResponse(Object.assign({}, globalParticipant));
+
+                updatedParticipant.linked_participants = [
+                    new LinkedParticipantResponse({
+                        link_type: LinkType.Interpreter,
+                        linked_id: updatedParticipant.id.toString()
+                    })
+                ];
+                getLoggedParticipantSpy.and.returnValue(updatedParticipant);
+                const testParticipantMessage = new ParticipantsUpdatedMessage(globalConference.id, [
+                    testParticipant,
+                    component.participant
+                ]);
+                getParticipantsUpdatedSubjectMock.next(testParticipantMessage);
+
+                expect(component.callAndUpdateShowVideo).toHaveBeenCalled();
+            });
         });
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -1370,7 +1370,7 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
 
         const preUpdateLinkCount = this.hearing
             .getParticipants()
-            .filter(p => p.linked_participants.some(lp => lp.linked_id === this.participant.id)).length;
+            ?.filter(p => p.linked_participants?.some(lp => lp.linked_id === this.participant.id)).length;
 
         const updatedParticipantsList = [...participantsUpdatedMessage.participants].map(participant => {
             const currentParticipant = this.conference.participants.find(x => x.id === participant.id);
@@ -1385,7 +1385,7 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
 
         const postUpdateLinkCount = this.hearing
             .getParticipants()
-            .filter(p => p.linked_participants.some(lp => lp.linked_id === this.participant.id)).length;
+            ?.filter(p => p.linked_participants?.some(lp => lp.linked_id === this.participant.id)).length;
 
         // if the participant now has a link or no longer has a link, call with new join details
         if (preUpdateLinkCount !== postUpdateLinkCount) {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -1346,7 +1346,7 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
         }
     }
 
-    private handleParticipantsUpdatedMessage(participantsUpdatedMessage: ParticipantsUpdatedMessage) {
+    private async handleParticipantsUpdatedMessage(participantsUpdatedMessage: ParticipantsUpdatedMessage) {
         this.logger.debug('[WR] - Participants updated message recieved', participantsUpdatedMessage.participants);
 
         if (!this.validateIsForConference(participantsUpdatedMessage.conferenceId)) {
@@ -1368,6 +1368,10 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
             );
         });
 
+        const preUpdateLinkCount = this.hearing
+            .getParticipants()
+            .filter(p => p.linked_participants.some(lp => lp.linked_id === this.participant.id)).length;
+
         const updatedParticipantsList = [...participantsUpdatedMessage.participants].map(participant => {
             const currentParticipant = this.conference.participants.find(x => x.id === participant.id);
             participant.current_room = currentParticipant ? currentParticipant.current_room : null;
@@ -1378,6 +1382,16 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
         this.conference = { ...this.conference, participants: updatedParticipantsList } as ConferenceResponse;
         this.hearing.getConference().participants = updatedParticipantsList;
         this.participant = this.getLoggedParticipant();
+
+        const postUpdateLinkCount = this.hearing
+            .getParticipants()
+            .filter(p => p.linked_participants.some(lp => lp.linked_id === this.participant.id)).length;
+
+        // if the participant now has a link or no longer has a link, call with new join details
+        if (preUpdateLinkCount !== postUpdateLinkCount) {
+            this.logger.debug('[WR] - Participant has new link (or removed link), calling with new join details');
+            await this.callAndUpdateShowVideo();
+        }
     }
     private handleEndpointsUpdatedMessage(endpointsUpdatedMessage: EndpointsUpdatedMessage) {
         this.logger.debug('[WR] - Endpoints updated message received', {


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10642

### Change description ###

When updating a participant list, a user may need to re-connect to join as a VMR (if they are linked) or re-connect as a single participant (if they are unlinked)