### PR TITLE
VIH-10664 Fix for newly added panel members appearing in participants list twice

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.spec.ts
@@ -1174,7 +1174,8 @@ describe('ParticipantsPanelComponent', () => {
             first_name: 'Panel',
             role: Role.JudicialOfficeHolder,
             hearing_role: 'Panel Member',
-            user_name: 'panel.member@hmcts.net'
+            user_name: 'panel.member@hmcts.net',
+            id: '6666-1234-2345-3456'
         });
 
         const panelMember2 = new ParticipantForUserResponse({
@@ -1182,9 +1183,11 @@ describe('ParticipantsPanelComponent', () => {
             first_name: 'Panel',
             role: Role.JudicialOfficeHolder,
             hearing_role: 'Panel Member',
-            user_name: 'panel.member.2@hmcts.net'
+            user_name: 'panel.member.2@hmcts.net',
+            id: '6666-1234-2345-3457'
         });
 
+        participants = participants.filter(x => x.role !== Role.JudicialOfficeHolder);
         participants.push(panelMember1);
 
         component.nonEndpointParticipants = [];
@@ -1196,6 +1199,7 @@ describe('ParticipantsPanelComponent', () => {
         let message = new ParticipantsUpdatedMessage(conferenceId, participants);
         getParticipantsUpdatedSubjectMock.next(message);
 
+        panelMember1.interpreter_room = new RoomSummaryResponse({ id: '14682', label: 'Panel Member1', locked: false });
         participants.push(panelMember2);
         mappedParticipants = mapper.mapFromParticipantUserResponseArray(participants);
         participantPanelModelMapperSpy.mapFromParticipantUserResponseArray.and.returnValue(mappedParticipants);
@@ -1204,6 +1208,7 @@ describe('ParticipantsPanelComponent', () => {
 
         const linkedParticipantPanelModel = component.nonEndpointParticipants.filter(x => x.role === Role.JudicialOfficeHolder);
 
+        expect(linkedParticipantPanelModel.length).toBe(1);
         expect(linkedParticipantPanelModel[0].displayName).toContain(panelMember1DisplayName);
         expect(linkedParticipantPanelModel[0].displayName).toContain(panelMember2DisplayName);
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participants-panel/participants-panel.component.ts
@@ -248,7 +248,15 @@ export class ParticipantsPanelComponent implements OnInit, OnDestroy {
                     const newlyAddedParticipants = mappedList.filter(
                         ({ id: newId }) => !this.nonEndpointParticipants.some(({ id: oldId }) => newId === oldId)
                     );
-                    newlyAddedParticipants.forEach(np => this.nonEndpointParticipants.push(np));
+                    newlyAddedParticipants.forEach(np => {
+                        if (
+                            np.role === Role.JudicialOfficeHolder &&
+                            this.nonEndpointParticipants.some(x => x.role === Role.JudicialOfficeHolder)
+                        ) {
+                            return;
+                        }
+                        this.nonEndpointParticipants.push(np);
+                    });
 
                     const nonEndpointParticipantsLinkedParticipantPanelIndex = this.nonEndpointParticipants.findIndex(
                         x => x.role === Role.JudicialOfficeHolder


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10664


### Change description ###
Fixes an issue where adding a second panel member to a hearing once it is in session causes the 2 panel members to appear in the participants list twice.

There should only be one panel member model in the list, because all panel members are grouped under one item. So don't add a second one if one already exists