### PR TITLE
VIH-10653 Fix for newly added endpoints appearing in participants list twice

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/models/hearing.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/models/hearing.ts
@@ -94,11 +94,6 @@ export class Hearing extends HearingBase {
         this.updateParticipantList(participants);
     }
 
-    addEndpoint(ver: VideoEndpointResponse) {
-        const conference = this.conference as ConferenceResponse;
-        conference.endpoints.push(ver);
-    }
-
     updateEndpoint(ver: VideoEndpointResponse) {
         const conference = this.conference as ConferenceResponse;
         const index = conference.endpoints.findIndex(x => x.id === ver.id);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -1793,22 +1793,6 @@ describe('WaitingRoomComponent EventHub Call', () => {
                 expect(notificationToastrService.showEndpointAdded).toHaveBeenCalledWith(testAddVideoEndpointResponse, false);
             }));
 
-            it('should add new endpoint', fakeAsync(() => {
-                // Arrange
-                const existingEndpointCount = component.conference.endpoints.length;
-                component.participant.status = ParticipantStatus.Available;
-
-                // Act
-                getEndpointsUpdatedMessageSubjectMock.next(testEndpointMessageAdd);
-                tick();
-
-                // Assert
-                const addedEndpoint = component.conference.endpoints.find(x => x.id === testAddVideoEndpointResponse.id);
-                expect(component.conference.endpoints.length).toEqual(existingEndpointCount + 1);
-                expect(addedEndpoint.id).toBe(testAddVideoEndpointResponse.id);
-                expect(addedEndpoint.display_name).toBe(testAddVideoEndpointResponse.display_name);
-            }));
-
             it('should update existing endpoint', fakeAsync(() => {
                 // Arrange
                 component.participant.status = ParticipantStatus.Available;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -1406,7 +1406,6 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
         endpointsUpdatedMessage.endpoints.new_endpoints.forEach(endpoint => {
             this.logger.debug('[WR] - Endpoint added, showing notification', endpoint);
             this.notificationToastrService.showEndpointAdded(endpoint, this.isParticipantInConference);
-            this.hearing.addEndpoint(endpoint);
         });
 
         endpointsUpdatedMessage.endpoints.existing_endpoints.forEach((endpoint: VideoEndpointResponse) => {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10653


### Change description ###
Removes a redundant call to add a newly added endpoint to the conference endpoints array. The array has already been updated by this point as part of `getConference`, so no need to add it to the array a second time