### PR TITLE
VIH-10709 bug fix toggle mute not reliable

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -146,7 +146,7 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
 
         this.userMediaService.isAudioOnly$.pipe(takeUntil(this.destroyedSubject)).subscribe(audioOnly => {
             this.audioOnly = audioOnly;
-            this.videoMuted = this.videoCallService.pexipAPI.call.mutedVideo || this.audioOnly;
+            this.videoMuted = this.videoCallService.pexipAPI.call?.mutedVideo || this.audioOnly;
         });
 
         this.setupVideoCallSubscribers();
@@ -183,39 +183,40 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     setupEventhubSubscribers() {
+        const self = this;
         this.eventService
             .getParticipantStatusMessage()
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(message => {
-                this.handleParticipantStatusChange(message);
+                self.handleParticipantStatusChange(message);
             });
 
         this.eventService
             .getHearingCountdownCompleteMessage()
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(conferenceId => {
-                this.handleHearingCountdownComplete(conferenceId).then();
+                self.handleHearingCountdownComplete(conferenceId).then();
             });
 
         this.eventService
             .getParticipantHandRaisedMessage()
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(message => {
-                this.handleParticipantHandRaiseChange(message);
+                self.handleParticipantHandRaiseChange(message);
             });
 
         this.eventService
             .getParticipantRemoteMuteStatusMessage()
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(message => {
-                this.handleParticipantRemoteMuteChange(message);
+                self.handleParticipantRemoteMuteChange(message);
             });
 
         this.eventService
             .getParticipantToggleLocalMuteMessage()
             .pipe(takeUntil(this.destroyedSubject))
             .subscribe(message => {
-                this.handleParticipantToggleLocalMuteChange(message).then();
+                self.handleParticipantToggleLocalMuteChange(message).then();
             });
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -141,8 +141,8 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
     }
 
     ngOnInit(): void {
-        this.audioMuted = this.videoCallService.pexipAPI.call.mutedAudio;
-        this.videoMuted = this.videoCallService.pexipAPI.call.mutedVideo || this.audioOnly;
+        this.audioMuted = this.videoCallService.pexipAPI.call?.mutedAudio;
+        this.videoMuted = this.videoCallService.pexipAPI.call?.mutedVideo || this.audioOnly;
 
         this.userMediaService.isAudioOnly$.pipe(takeUntil(this.destroyedSubject)).subscribe(audioOnly => {
             this.audioOnly = audioOnly;
@@ -214,8 +214,8 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
         this.eventService
             .getParticipantToggleLocalMuteMessage()
             .pipe(takeUntil(this.destroyedSubject))
-            .subscribe(async message => {
-                await this.handleParticipantToggleLocalMuteChange(message);
+            .subscribe(message => {
+                this.handleParticipantToggleLocalMuteChange(message).then();
             });
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.ts
@@ -193,8 +193,8 @@ export abstract class HearingControlsBaseComponent implements OnInit, OnDestroy 
         this.eventService
             .getHearingCountdownCompleteMessage()
             .pipe(takeUntil(this.destroyedSubject))
-            .subscribe(async conferenceId => {
-                await this.handleHearingCountdownComplete(conferenceId);
+            .subscribe(conferenceId => {
+                this.handleHearingCountdownComplete(conferenceId).then();
             });
 
         this.eventService


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10709 

### Change description ###

* handle null for pexipApi call object
* using an arrow function in the subscribe call. This will ensure that `this` inside the subscribe callback refers to the component instance. the current implementation meant that `this` was `undefined` when debugging and so the code blocks would not trigger as expected