### PR TITLE
VIH-10734 Bugfix claims and reducers

### DIFF
--- a/VideoWeb/VideoWeb.Common/Caching/DistributedUserClaimsCache.cs
+++ b/VideoWeb/VideoWeb.Common/Caching/DistributedUserClaimsCache.cs
@@ -38,7 +38,12 @@ namespace VideoWeb.Common.Caching
 
         public async Task<List<Claim>> GetAsync(string key)
         {
-            return await ReadFromCache(key);
+            var result = await ReadFromCache(key);
+            if(result?.Count == 0)
+            {
+                return null;
+            }
+            return result;
         }
 
         public async Task ClearFromCache(string key)

--- a/VideoWeb/VideoWeb.Common/UserProfileService.cs
+++ b/VideoWeb/VideoWeb.Common/UserProfileService.cs
@@ -65,7 +65,7 @@ namespace VideoWeb.Common
             return user.IsInRole(AppRoles.VhOfficerRole);
         }
 
-        private static List<Role> DetermineRolesFromClaims(ClaimsPrincipal user)
+        private List<Role> DetermineRolesFromClaims(ClaimsPrincipal user)
         {
             var roles = new List<Role>();
             var cliams = new List<Claim>();
@@ -99,6 +99,7 @@ namespace VideoWeb.Common
             }
             if (!roles.Any())
             {
+                _userProfileCache.ClearFromCache(user.Identity.Name);
                 throw new NotSupportedException($"No supported role for this application");
             }
 

--- a/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
+++ b/VideoWeb/VideoWeb.EventHub/Hub/EventHubClient.cs
@@ -95,22 +95,24 @@ namespace VideoWeb.EventHub.Hub
 
         public override async Task OnDisconnectedAsync(Exception exception)
         {
-            var userName = GetObfuscatedUsernameAsync(Context.User.Identity.Name.ToLowerInvariant());
+            var username = Context.User.Identity.Name.ToLowerInvariant();
+            var obfuscatedUsername = GetObfuscatedUsernameAsync(username);
+            
             if (exception == null)
             {
-                _logger.LogInformation("Disconnected from chat hub server-side: {Username}", userName);
+                _logger.LogInformation("Disconnected from chat hub server-side: {Username}", obfuscatedUsername);
             }
             else
             {
                 _logger.LogError(exception,
-                    "There was an error when disconnecting from chat hub server-side: {Username}", userName);
+                    "There was an error when disconnecting from chat hub server-side: {Username}", obfuscatedUsername);
             }
 
             var isAdmin = IsSenderAdmin();
             await RemoveUserFromUserGroup(isAdmin);
             await RemoveUserFromConferenceGroups(isAdmin);
-            await _userProfileService.ClearUserCache(userName);
-            await _appRoleService.ClearUserCache(userName);
+            await _userProfileService.ClearUserCache(username);
+            await _appRoleService.ClearUserCache(username);
 
             await base.OnDisconnectedAsync(exception);
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
@@ -760,6 +760,8 @@ describe('Conference Reducer', () => {
 
             expect(result.currentConference.participants[0].room.label).toEqual('Consultation Room 1');
             expect(result.currentConference.participants[0].room.locked).toBeFalse();
+
+            expect(result.availableRooms.length).toEqual(2);
         });
 
         it('should update the participant room and set current room when room is a hearing room', () => {


### PR DESCRIPTION
### Jira link (if applicable)

[VIH-10734](https://tools.hmcts.net/jira/browse/VIH-10734)

### Change description ###

**Claims Cache Bug 1**
If a user logs into video web with no roles to map, this resulted in the mappers failing and throw an unhandled exception resulting in the user to be redirected to the not authorised page.

Impact: the disconnect function that clears the cache did not execute. If a user were to change their role and sign back in, the cache would find the user and return an empty list. As before it would cause the claims mapper to fail and the user is caught in a loop where they cannot connect safely enough to trigger the disconnect function and so stuck with no claims and held in the not authorised page until the cache clears after 4 hours.

**Claims Cache Bug 2**
The disconnect function obfuscated the username before calling clear cache.

Impact: The cache would not clear on demand because the key to save would be `test@user.com` but cleared with `t***@u***.c**`

**State Reducer Bug**
The available rooms did not update with the `update participant room` action. This should update in line with participants in a room.