### PR TITLE
VIH-10746 Fix for not being able to access panel member waiting room as ejud user

### DIFF
--- a/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
@@ -151,7 +152,9 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
 
             // Assert
             var identity = tokenValidatedContext.Principal.Identity.Should().BeOfType<ClaimsIdentity>().Which;
-            identity.FindFirst(identity.RoleClaimType).Value.Should().Be("Judge");
+            var roleClaims = identity.Claims.Where(c => c.Type == identity.RoleClaimType).ToList();
+            roleClaims.Should().Contain(c => c.Value == "Judge");
+            roleClaims.Should().Contain(c => c.Value == "JudicialOfficeHolder");
         }
         
         [Test]
@@ -186,7 +189,9 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
             
             // Assert
             var identity = tokenValidatedContext.Principal.Identity.Should().BeOfType<ClaimsIdentity>().Which;
-            identity.FindFirst(identity.RoleClaimType).Value.Should().Be("Judge");
+            var roleClaims = identity.Claims.Where(c => c.Type == identity.RoleClaimType).ToList();
+            roleClaims.Should().Contain(c => c.Value == "Judge");
+            roleClaims.Should().Contain(c => c.Value == "JudicialOfficeHolder");
         }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
@@ -152,7 +152,7 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
 
             // Assert
             var identity = tokenValidatedContext.Principal.Identity.Should().BeOfType<ClaimsIdentity>().Which;
-            AssertRoleClaimsAdded(identity);
+            AssertClaimsAdded(identity);
         }
         
         [Test]
@@ -187,10 +187,10 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
             
             // Assert
             var identity = tokenValidatedContext.Principal.Identity.Should().BeOfType<ClaimsIdentity>().Which;
-            AssertRoleClaimsAdded(identity);
+            AssertClaimsAdded(identity);
         }
         
-        private static void AssertRoleClaimsAdded(ClaimsIdentity identity)
+        private static void AssertClaimsAdded(ClaimsIdentity identity)
         {
             var roleClaims = identity.Claims.Where(c => c.Type == identity.RoleClaimType).ToList();
             roleClaims.Count.Should().Be(2);

--- a/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
@@ -152,9 +152,7 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
 
             // Assert
             var identity = tokenValidatedContext.Principal.Identity.Should().BeOfType<ClaimsIdentity>().Which;
-            var roleClaims = identity.Claims.Where(c => c.Type == identity.RoleClaimType).ToList();
-            roleClaims.Should().Contain(c => c.Value == "Judge");
-            roleClaims.Should().Contain(c => c.Value == "JudicialOfficeHolder");
+            AssertRoleClaimsAdded(identity);
         }
         
         [Test]
@@ -189,6 +187,11 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
             
             // Assert
             var identity = tokenValidatedContext.Principal.Identity.Should().BeOfType<ClaimsIdentity>().Which;
+            AssertRoleClaimsAdded(identity);
+        }
+        
+        private static void AssertRoleClaimsAdded(ClaimsIdentity identity)
+        {
             var roleClaims = identity.Claims.Where(c => c.Type == identity.RoleClaimType).ToList();
             roleClaims.Should().Contain(c => c.Value == "Judge");
             roleClaims.Should().Contain(c => c.Value == "JudicialOfficeHolder");

--- a/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/AuthenticationSchemes/EJudiciarySchemeTests.cs
@@ -193,6 +193,7 @@ namespace VideoWeb.UnitTests.AuthenticationSchemes
         private static void AssertRoleClaimsAdded(ClaimsIdentity identity)
         {
             var roleClaims = identity.Claims.Where(c => c.Type == identity.RoleClaimType).ToList();
+            roleClaims.Count.Should().Be(2);
             roleClaims.Should().Contain(c => c.Value == "Judge");
             roleClaims.Should().Contain(c => c.Value == "JudicialOfficeHolder");
         }

--- a/VideoWeb/VideoWeb/AuthenticationSchemes/EJudiciaryScheme.cs
+++ b/VideoWeb/VideoWeb/AuthenticationSchemes/EJudiciaryScheme.cs
@@ -25,6 +25,7 @@ namespace VideoWeb.AuthenticationSchemes
                 // Cache can expire the at the same time the token does.
                 var claimsIdentity = context.Principal.Identity as ClaimsIdentity;
                 claimsIdentity?.AddClaim(new Claim(claimsIdentity.RoleClaimType, "Judge"));
+                claimsIdentity?.AddClaim(new Claim(claimsIdentity.RoleClaimType, "JudicialOfficeHolder"));
             }
         }
     }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10746


### Change description ###
A change was made recently to prevent panel members accessing the judge waiting room, and vice versa. Subsequently johs on V2, who can double as both panel members and judges, require both the judge and judicial office holder claims in order to access the waiting room as either role