### PR TITLE
VIH-10787 bugfix endpoints not listed when no participants are booked in a hearing

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -88,7 +88,7 @@ export abstract class WRParticipantStatusListDirective implements OnChanges {
             return;
         }
         this.initParticipants();
-        this.displayParticipantList = this.participantCount > 0;
+        this.displayParticipantList = this.participantCount > 0 || this.endpoints.length > 0;
     }
 
     initParticipants() {


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10787

### Change description ###

* Fix display of participant list in waiting room when there are endpoints present


<img width="1055" alt="image" src="https://github.com/hmcts/vh-video-web/assets/41630528/743a8f3e-7bcc-48da-af1e-5b322f901ffe">
