### PR TITLE
VIH-10773 create audio mixes when a participant is connected to a conference

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/participant.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/participant.service.spec.ts
@@ -1239,7 +1239,9 @@ describe('ParticipantService', () => {
                 handRaised: false,
                 isAudioOnlyCall: false,
                 isVideoCall: false,
-                protocol: ''
+                protocol: '',
+                receivingAudioMix: 'main',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }]
             };
 
             // Act

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/hearing-controls/hearing-controls-base.component.spec.ts
@@ -611,7 +611,9 @@ describe('HearingControlsBaseComponent', () => {
             uuid: undefined,
             isAudioOnlyCall: false,
             isVideoCall: false,
-            protocol: ''
+            protocol: '',
+            receivingAudioMix: 'main',
+            sentAudioMixes: [{ mix_name: 'main', prominent: false }]
         };
         component.audioMuted = true;
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/tests/judge-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/tests/judge-waiting-room.component.spec.ts
@@ -149,7 +149,14 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
         protocol: '',
         spotlight: 0,
         start_time: 0,
-        uuid: 'wowza_id'
+        uuid: 'wowza_id',
+        disconnect_supported: 'Yes',
+        transfer_supported: 'Yes',
+        is_main_video_dropped_out: false,
+        is_video_muted: false,
+        is_streaming_conference: false,
+        send_to_audio_mixes: [{ mix_name: 'main', prominent: false }],
+        receive_from_audio_mix: 'main'
     };
 
     const wowzaParticipantFailed: PexipParticipant = {
@@ -167,7 +174,14 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
         protocol: '',
         spotlight: 0,
         start_time: 0,
-        uuid: 'wowza_id'
+        uuid: 'wowza_id',
+        disconnect_supported: 'Yes',
+        transfer_supported: 'Yes',
+        is_main_video_dropped_out: false,
+        is_video_muted: false,
+        is_streaming_conference: false,
+        send_to_audio_mixes: [{ mix_name: 'main', prominent: false }],
+        receive_from_audio_mix: 'main'
     };
 
     let component: JudgeWaitingRoomComponent;
@@ -339,7 +353,14 @@ describe('JudgeWaitingRoomComponent when conference exists', () => {
         uuid: Guid.create().toString(),
         spotlight: 0,
         external_node_uuid: null,
-        protocol: 'webrtc'
+        protocol: 'webrtc',
+        disconnect_supported: 'Yes',
+        transfer_supported: 'Yes',
+        is_main_video_dropped_out: false,
+        is_video_muted: false,
+        is_streaming_conference: false,
+        send_to_audio_mixes: [{ mix_name: 'main', prominent: false }],
+        receive_from_audio_mix: 'main'
     };
 
     it('should call assignPexipId when uuid and pexip id contains in the participantDisplayName', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/video-call-models.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/video-call-models.ts
@@ -27,6 +27,8 @@ export class ParticipantUpdated {
     public isAudioOnlyCall: boolean;
     public isVideoCall: boolean;
     public protocol: string;
+    public receivingAudioMix: string;
+    public sentAudioMixes: PexipAudioMix[];
 
     private constructor(
         isRemoteMuted: string,
@@ -36,7 +38,9 @@ export class ParticipantUpdated {
         spotlightTime: number,
         isAudioOnlyCall: string,
         isVideoCall: string,
-        protocol: string
+        protocol: string,
+        receivingAudioMix?: string,
+        sentAudioMixes?: PexipAudioMix[]
     ) {
         this.isRemoteMuted = isRemoteMuted?.toUpperCase() === 'YES';
         this.isSpotlighted = spotlightTime !== 0;
@@ -46,6 +50,8 @@ export class ParticipantUpdated {
         this.isAudioOnlyCall = isAudioOnlyCall?.toUpperCase() === 'YES';
         this.isVideoCall = isVideoCall?.toUpperCase() === 'YES';
         this.protocol = protocol;
+        this.receivingAudioMix = receivingAudioMix;
+        this.sentAudioMixes = sentAudioMixes;
     }
 
     static fromPexipParticipant(pexipParticipant: PexipParticipant) {
@@ -57,7 +63,9 @@ export class ParticipantUpdated {
             pexipParticipant.spotlight,
             pexipParticipant.is_audio_only_call,
             pexipParticipant.is_video_call,
-            pexipParticipant.protocol
+            pexipParticipant.protocol,
+            pexipParticipant.receive_from_audio_mix,
+            pexipParticipant.send_to_audio_mixes
         );
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -113,7 +113,7 @@ describe('VideoCallService', () => {
             'dialOut',
             'disconnectParticipant',
             'setParticipantText',
-            'transformLayout'
+            'transformLayout',
             'setParticipantText',
             'setSendToAudioMixes',
             'setReceiveFromAudioMix'

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -514,7 +514,14 @@ describe('VideoCallService', () => {
                 call_tag: 'call_tag',
                 is_audio_only_call: 'is_audio_only_call',
                 is_video_call: 'is_video_call',
-                protocol: 'protocol'
+                protocol: 'protocol',
+                disconnect_supported: 'Yes',
+                transfer_supported: 'Yes',
+                is_main_video_dropped_out: false,
+                is_video_muted: false,
+                is_streaming_conference: false,
+                send_to_audio_mixes: [{ mix_name: 'main', prominent: false }],
+                receive_from_audio_mix: 'main'
             };
 
             const expectedUpdate = ParticipantUpdated.fromPexipParticipant(pexipParticipant);
@@ -548,7 +555,14 @@ describe('VideoCallService', () => {
                 call_tag: undefined,
                 is_audio_only_call: undefined,
                 is_video_call: undefined,
-                protocol: undefined
+                protocol: undefined,
+                disconnect_supported: undefined,
+                transfer_supported: undefined,
+                is_main_video_dropped_out: undefined,
+                is_video_muted: undefined,
+                is_streaming_conference: undefined,
+                send_to_audio_mixes: undefined,
+                receive_from_audio_mix: undefined
             };
 
             // Act
@@ -581,7 +595,14 @@ describe('VideoCallService', () => {
                 call_tag: 'call_tag',
                 is_audio_only_call: 'is_audio_only_call',
                 is_video_call: 'is_video_call',
-                protocol: 'protocol'
+                protocol: 'protocol',
+                disconnect_supported: 'Yes',
+                transfer_supported: 'Yes',
+                is_main_video_dropped_out: false,
+                is_video_muted: false,
+                is_streaming_conference: false,
+                send_to_audio_mixes: [{ mix_name: 'main', prominent: false }],
+                receive_from_audio_mix: 'main'
             };
 
             const expectedUpdate = ParticipantUpdated.fromPexipParticipant(pexipParticipant);
@@ -616,7 +637,14 @@ describe('VideoCallService', () => {
                 call_tag: undefined,
                 is_audio_only_call: undefined,
                 is_video_call: undefined,
-                protocol: undefined
+                protocol: undefined,
+                disconnect_supported: undefined,
+                transfer_supported: undefined,
+                is_main_video_dropped_out: undefined,
+                is_video_muted: undefined,
+                is_streaming_conference: undefined,
+                send_to_audio_mixes: undefined,
+                receive_from_audio_mix: undefined
             };
 
             // Act

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -114,6 +114,9 @@ describe('VideoCallService', () => {
             'disconnectParticipant',
             'setParticipantText',
             'transformLayout'
+            'setParticipantText',
+            'setSendToAudioMixes',
+            'setReceiveFromAudioMix'
         ]);
 
         streamMixerServiceSpy = jasmine.createSpyObj<StreamMixerService>('StreamMixerService', ['mergeAudioStreams']);
@@ -824,6 +827,26 @@ describe('VideoCallService', () => {
             const layout = HearingLayout.TwoPlus21;
             service.transformLayout(layout);
             expect(pexipSpy.transformLayout).toHaveBeenCalledOnceWith({ layout: layout });
+        });
+    });
+
+    describe('sendParticipantAudioToMixes', () => {
+        it('should call pexip sendParticipantAudioToMixes', () => {
+            service.pexipAPI = pexipSpy;
+            const uuid = 'uuid';
+            const mixes = [{ mix_name: 'main', prominent: false }];
+            service.sendParticipantAudioToMixes(mixes, uuid);
+            expect(pexipSpy.setSendToAudioMixes).toHaveBeenCalledWith(mixes, uuid);
+        });
+    });
+
+    describe('receiveAudioFromMix', () => {
+        it('should call pexip receiveAudioFromMix', () => {
+            service.pexipAPI = pexipSpy;
+            const uuid = 'uuid';
+            const mixName = 'main';
+            service.receiveAudioFromMix(mixName, uuid);
+            expect(pexipSpy.setReceiveFromAudioMix).toHaveBeenCalledWith(mixName, uuid);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -551,6 +551,15 @@ export class VideoCallService {
     transformLayout(layout: string) {
         return this.pexipAPI.transformLayout({ layout: layout });
     }
+
+    sendParticipantAudioToMixes(mixes: PexipAudioMix[], uuid: string) {
+        this.pexipAPI.setSendToAudioMixes(mixes, uuid);
+    }
+
+    receiveAudioFromMix(mixName: string, uuid: string) {
+        this.pexipAPI.setReceiveFromAudioMix(mixName, uuid);
+    }
+
     private makePexipCall(
         pexipNode: string,
         conferenceAlias: string,
@@ -596,7 +605,7 @@ export class VideoCallService {
             return;
         }
         this.store.dispatch(
-            ConferenceActions.upsertPexipParticipant({ participant: mapPexipParticipantToVHPexipParticipant(participant) })
+            ConferenceActions.createPexipParticipant({ participant: mapPexipParticipantToVHPexipParticipant(participant) })
         );
         this.onParticipantCreatedSubject.next(participant);
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/actions/conference.actions.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/actions/conference.actions.ts
@@ -27,6 +27,7 @@ export const ConferenceActions = createActionGroup({
         'Update Existing Endpoints': props<{ conferenceId: string; endpoints: VHEndpoint[] }>(),
         'Remove Existing Endpoints': props<{ conferenceId: string; removedEndpointIds: string[] }>(),
 
+        'Create Pexip Participant': props<{ participant: VHPexipParticipant }>(),
         'Upsert Pexip Participant': props<{ participant: VHPexipParticipant }>(),
         'Delete Pexip Participant': props<{ pexipUUID: string }>(),
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
@@ -8,24 +8,15 @@ import { ConferenceEffects } from './conference.effects';
 import { ApiClient } from 'src/app/services/clients/api-client';
 import { ConferenceActions } from '../actions/conference.actions';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
-import {
-    mapConferenceToVHConference,
-    mapParticipantToVHParticipant,
-    mapEndpointToVHEndpoint
-} from '../models/api-contract-to-state-model-mappers';
+import { mapConferenceToVHConference } from '../models/api-contract-to-state-model-mappers';
 import { VideoCallService } from '../../services/video-call.service';
-import { ConferenceState } from '../reducers/conference.reducer';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import * as ConferenceSelectors from '../selectors/conference.selectors';
-import { VHPexipParticipant } from '../models/vh-conference';
-import { HearingRole } from '../../models/hearing-role-model';
+import { provideMockStore } from '@ngrx/store/testing';
 
 describe('ConferenceEffectsEffects', () => {
     let actions$: Observable<any>;
     let effects: ConferenceEffects;
     let apiClient: jasmine.SpyObj<ApiClient>;
     let videoCallService: jasmine.SpyObj<VideoCallService>;
-    let mockConferenceStore: MockStore<ConferenceState>;
 
     beforeEach(() => {
         apiClient = jasmine.createSpyObj('ApiClient', ['getConferenceById']);
@@ -42,11 +33,6 @@ describe('ConferenceEffectsEffects', () => {
         });
 
         effects = TestBed.inject(ConferenceEffects);
-        mockConferenceStore = TestBed.inject(MockStore);
-    });
-
-    afterEach(() => {
-        mockConferenceStore.resetSelectors();
     });
 
     it('should be created', () => {
@@ -84,195 +70,5 @@ describe('ConferenceEffectsEffects', () => {
         const expected = cold('-b', { b: ConferenceActions.loadConferenceFailure({ error }) });
         expect(effects.loadConference$).toBeObservable(expected);
         expect(apiClient.getConferenceById).toHaveBeenCalledWith(conferenceId);
-    });
-
-    describe('createAudioMixes$', () => {
-        beforeEach(() => {
-            videoCallService.receiveAudioFromMix.calls.reset();
-            videoCallService.sendParticipantAudioToMixes.calls.reset();
-        });
-
-        afterEach(() => {
-            mockConferenceStore.resetSelectors();
-        });
-
-        it('should not create audio mixes if participant or endpoint is not found', () => {
-            // arrange
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, []);
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, []);
-            const pexipParticipant: VHPexipParticipant = {
-                isRemoteMuted: false,
-                isSpotlighted: false,
-                handRaised: false,
-                pexipDisplayName: '1922_John Doe',
-                uuid: 'doesnot_exist',
-                isAudioOnlyCall: false,
-                isVideoCall: true,
-                protocol: 'sip',
-                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                receivingAudioMix: 'main'
-            };
-            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
-
-            // act
-            actions$ = of(action);
-
-            // assert
-            effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledTimes(0);
-            });
-        });
-
-        it('should create audio mixes if non-interpreter participant is found and has verbal interpreter language', () => {
-            // arrange
-            const participants = new ConferenceTestData().getListOfParticipants();
-            let participant = mapParticipantToVHParticipant(participants[0]);
-            participant = {
-                ...participant,
-                hearingRole: HearingRole.APPELLANT,
-                pexipInfo: {
-                    isRemoteMuted: false,
-                    isSpotlighted: false,
-                    handRaised: false,
-                    pexipDisplayName: `1922_${participant.displayName}`,
-                    uuid: '1922_John Doe',
-                    isAudioOnlyCall: false,
-                    isVideoCall: true,
-                    protocol: 'sip',
-                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                    receivingAudioMix: 'main'
-                }
-            };
-
-            // mock the get participants since override selector does not work with params and the selector get participant by id used the getParticipantsSelector
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, [participant]);
-            const languageDescription = 'Spanish';
-            const pexipParticipant: VHPexipParticipant = {
-                isRemoteMuted: false,
-                isSpotlighted: false,
-                handRaised: false,
-                pexipDisplayName: `1922_John Doe${participants[0].id}`,
-                uuid: '1922_John Doe',
-                isAudioOnlyCall: false,
-                isVideoCall: true,
-                protocol: 'sip',
-                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                receivingAudioMix: 'main'
-            };
-            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
-
-            // act
-            actions$ = of(action);
-
-            // assert
-            effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
-            });
-        });
-
-        it('should create audio mixes and send audio to language mix if interpreter participant is found and has verbal interpreter language', () => {
-            // arrange
-            const participants = new ConferenceTestData().getListOfParticipants();
-            let participant = mapParticipantToVHParticipant(participants[0]);
-            participant = {
-                ...participant,
-                hearingRole: HearingRole.INTERPRETER,
-                pexipInfo: {
-                    isRemoteMuted: false,
-                    isSpotlighted: false,
-                    handRaised: false,
-                    pexipDisplayName: `1922_${participant.displayName}`,
-                    uuid: '1922_John Doe',
-                    isAudioOnlyCall: false,
-                    isVideoCall: true,
-                    protocol: 'sip',
-                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                    receivingAudioMix: 'main'
-                }
-            };
-
-            // mock the get participants since override selector does not work with params and the selector get participant by id used the getParticipantsSelector
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, [participant]);
-            const languageDescription = 'Spanish';
-            const pexipParticipant: VHPexipParticipant = {
-                isRemoteMuted: false,
-                isSpotlighted: false,
-                handRaised: false,
-                pexipDisplayName: `1922_John Doe${participants[0].id}`,
-                uuid: '1922_John Doe',
-                isAudioOnlyCall: false,
-                isVideoCall: true,
-                protocol: 'sip',
-                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                receivingAudioMix: 'main'
-            };
-            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
-            const expectedAudioMixes = [
-                {
-                    mix_name: 'main',
-                    prominent: false
-                },
-                {
-                    mix_name: languageDescription,
-                    prominent: true
-                }
-            ];
-
-            // act
-            actions$ = of(action);
-
-            // assert
-            effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
-                expect(videoCallService.sendParticipantAudioToMixes).toHaveBeenCalledWith(expectedAudioMixes, pexipParticipant.uuid);
-            });
-        });
-
-        it('should create audio mixes if endpoint is found and has verbal interpreter language', () => {
-            // act
-            const endpoints = new ConferenceTestData().getListOfEndpoints();
-            let endpoint = mapEndpointToVHEndpoint(endpoints[0]);
-            endpoint = {
-                ...endpoint,
-                pexipInfo: {
-                    isRemoteMuted: false,
-                    isSpotlighted: false,
-                    handRaised: false,
-                    pexipDisplayName: `PTSN;${endpoints[0].display_name};${endpoints[0].id}`,
-                    uuid: '1922_John Doe',
-                    isAudioOnlyCall: false,
-                    isVideoCall: true,
-                    protocol: 'sip',
-                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                    receivingAudioMix: 'main'
-                }
-            };
-
-            // mock the get endpoints since override selector does not work with params and the selector get endpoint by id used the getEndpointsSelector
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, [endpoint]);
-            const languageDescription = 'Spanish';
-            const pexipParticipant: VHPexipParticipant = {
-                isRemoteMuted: false,
-                isSpotlighted: false,
-                handRaised: false,
-                pexipDisplayName: `PTSN;${endpoints[0].display_name};${endpoints[0].id}`,
-                uuid: '1922_John Doe',
-                isAudioOnlyCall: false,
-                isVideoCall: true,
-                protocol: 'sip',
-                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
-                receivingAudioMix: 'main'
-            };
-
-            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
-
-            // act
-            actions$ = of(action);
-
-            // assert
-            effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
-            });
-        });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { addMatchers, cold, hot, initTestScheduler } from 'jasmine-marbles';
+import { cold, hot } from 'jasmine-marbles';
 import { Observable, of } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing'; // import this
 
@@ -8,21 +8,45 @@ import { ConferenceEffects } from './conference.effects';
 import { ApiClient } from 'src/app/services/clients/api-client';
 import { ConferenceActions } from '../actions/conference.actions';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
-import { mapConferenceToVHConference } from '../models/api-contract-to-state-model-mappers';
+import {
+    mapConferenceToVHConference,
+    mapParticipantToVHParticipant,
+    mapEndpointToVHEndpoint
+} from '../models/api-contract-to-state-model-mappers';
+import { VideoCallService } from '../../services/video-call.service';
+import { ConferenceState } from '../reducers/conference.reducer';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import * as ConferenceSelectors from '../selectors/conference.selectors';
+import { VHPexipParticipant } from '../models/vh-conference';
+import { HearingRole } from '../../models/hearing-role-model';
 
 describe('ConferenceEffectsEffects', () => {
     let actions$: Observable<any>;
     let effects: ConferenceEffects;
     let apiClient: jasmine.SpyObj<ApiClient>;
+    let videoCallService: jasmine.SpyObj<VideoCallService>;
+    let mockConferenceStore: MockStore<ConferenceState>;
 
     beforeEach(() => {
         apiClient = jasmine.createSpyObj('ApiClient', ['getConferenceById']);
+        videoCallService = jasmine.createSpyObj('VideoCallService', ['receiveAudioFromMix', 'sendParticipantAudioToMixes']);
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
-            providers: [ConferenceEffects, provideMockActions(() => actions$), { provide: ApiClient, useValue: apiClient }]
+            providers: [
+                ConferenceEffects,
+                provideMockStore(),
+                provideMockActions(() => actions$),
+                { provide: ApiClient, useValue: apiClient },
+                { provide: VideoCallService, useValue: videoCallService }
+            ]
         });
 
         effects = TestBed.inject(ConferenceEffects);
+        mockConferenceStore = TestBed.inject(MockStore);
+    });
+
+    afterEach(() => {
+        mockConferenceStore.resetSelectors();
     });
 
     it('should be created', () => {
@@ -60,5 +84,195 @@ describe('ConferenceEffectsEffects', () => {
         const expected = cold('-b', { b: ConferenceActions.loadConferenceFailure({ error }) });
         expect(effects.loadConference$).toBeObservable(expected);
         expect(apiClient.getConferenceById).toHaveBeenCalledWith(conferenceId);
+    });
+
+    describe('createAudioMixes$', () => {
+        beforeEach(() => {
+            videoCallService.receiveAudioFromMix.calls.reset();
+            videoCallService.sendParticipantAudioToMixes.calls.reset();
+        });
+
+        afterEach(() => {
+            mockConferenceStore.resetSelectors();
+        });
+
+        it('should not create audio mixes if participant or endpoint is not found', () => {
+            // arrange
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, []);
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, []);
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: '1922_John Doe',
+                uuid: 'doesnot_exist',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledTimes(0);
+            });
+        });
+
+        it('should create audio mixes if non-interpreter participant is found and has verbal interpreter language', () => {
+            // arrange
+            const participants = new ConferenceTestData().getListOfParticipants();
+            let participant = mapParticipantToVHParticipant(participants[0]);
+            participant = {
+                ...participant,
+                hearingRole: HearingRole.APPELLANT,
+                pexipInfo: {
+                    isRemoteMuted: false,
+                    isSpotlighted: false,
+                    handRaised: false,
+                    pexipDisplayName: `1922_${participant.displayName}`,
+                    uuid: '1922_John Doe',
+                    isAudioOnlyCall: false,
+                    isVideoCall: true,
+                    protocol: 'sip',
+                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                    receivingAudioMix: 'main'
+                }
+            };
+
+            // mock the get participants since override selector does not work with params and the selector get participant by id used the getParticipantsSelector
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, [participant]);
+            const languageDescription = 'Spanish';
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: `1922_John Doe${participants[0].id}`,
+                uuid: '1922_John Doe',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
+            });
+        });
+
+        it('should create audio mixes and send audio to language mix if interpreter participant is found and has verbal interpreter language', () => {
+            // arrange
+            const participants = new ConferenceTestData().getListOfParticipants();
+            let participant = mapParticipantToVHParticipant(participants[0]);
+            participant = {
+                ...participant,
+                hearingRole: HearingRole.INTERPRETER,
+                pexipInfo: {
+                    isRemoteMuted: false,
+                    isSpotlighted: false,
+                    handRaised: false,
+                    pexipDisplayName: `1922_${participant.displayName}`,
+                    uuid: '1922_John Doe',
+                    isAudioOnlyCall: false,
+                    isVideoCall: true,
+                    protocol: 'sip',
+                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                    receivingAudioMix: 'main'
+                }
+            };
+
+            // mock the get participants since override selector does not work with params and the selector get participant by id used the getParticipantsSelector
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, [participant]);
+            const languageDescription = 'Spanish';
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: `1922_John Doe${participants[0].id}`,
+                uuid: '1922_John Doe',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+            const expectedAudioMixes = [
+                {
+                    mix_name: 'main',
+                    prominent: false
+                },
+                {
+                    mix_name: languageDescription,
+                    prominent: true
+                }
+            ];
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
+                expect(videoCallService.sendParticipantAudioToMixes).toHaveBeenCalledWith(expectedAudioMixes, pexipParticipant.uuid);
+            });
+        });
+
+        it('should create audio mixes if endpoint is found and has verbal interpreter language', () => {
+            // act
+            const endpoints = new ConferenceTestData().getListOfEndpoints();
+            let endpoint = mapEndpointToVHEndpoint(endpoints[0]);
+            endpoint = {
+                ...endpoint,
+                pexipInfo: {
+                    isRemoteMuted: false,
+                    isSpotlighted: false,
+                    handRaised: false,
+                    pexipDisplayName: `PTSN;${endpoints[0].display_name};${endpoints[0].id}`,
+                    uuid: '1922_John Doe',
+                    isAudioOnlyCall: false,
+                    isVideoCall: true,
+                    protocol: 'sip',
+                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                    receivingAudioMix: 'main'
+                }
+            };
+
+            // mock the get endpoints since override selector does not work with params and the selector get endpoint by id used the getEndpointsSelector
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, [endpoint]);
+            const languageDescription = 'Spanish';
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: `PTSN;${endpoints[0].display_name};${endpoints[0].id}`,
+                uuid: '1922_John Doe',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
+            });
+        });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
@@ -10,7 +10,6 @@ import { ConferenceActions } from '../actions/conference.actions';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { mapConferenceToVHConference } from '../models/api-contract-to-state-model-mappers';
 import { VideoCallService } from '../../services/video-call.service';
-import { provideMockStore } from '@ngrx/store/testing';
 
 describe('ConferenceEffectsEffects', () => {
     let actions$: Observable<any>;
@@ -23,13 +22,7 @@ describe('ConferenceEffectsEffects', () => {
         videoCallService = jasmine.createSpyObj('VideoCallService', ['receiveAudioFromMix', 'sendParticipantAudioToMixes']);
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
-            providers: [
-                ConferenceEffects,
-                provideMockStore(),
-                provideMockActions(() => actions$),
-                { provide: ApiClient, useValue: apiClient },
-                { provide: VideoCallService, useValue: videoCallService }
-            ]
+            providers: [ConferenceEffects, provideMockActions(() => actions$), { provide: ApiClient, useValue: apiClient }]
         });
 
         effects = TestBed.inject(ConferenceEffects);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
@@ -49,56 +49,8 @@ export class ConferenceEffects {
         )
     );
 
-    createAudioMixes$ = createEffect(
-        () =>
-            this.actions$.pipe(
-                ofType(ConferenceActions.createPexipParticipant),
-                concatLatestFrom(action => [
-                    this.store.select(ConferenceSelectors.getParticipantByPexipId(action.participant.uuid)),
-                    this.store.select(ConferenceSelectors.getEndpointByPexipId(action.participant.uuid))
-                ]),
-                tap(([action, participant, endpoint]) => {
-                    // get participant or endpoint where action.participant.uuid === participant.pexipId
-                    if (!participant && !endpoint) {
-                        return;
-                    }
-
-                    // TODO: check if participant.interpreterLanguage is not null or endpoint.interpreterLanguage is not null
-                    const hasInterpretationLanguage = true;
-                    if (!hasInterpretationLanguage) {
-                        return;
-                    }
-
-                    // const languageDescription = null;
-                    // if (!languageDescription){
-                    //     return;
-                    // }
-
-                    const participantUuid = participant ? participant.pexipInfo.uuid : endpoint.pexipInfo.uuid;
-                    const languageDescription = 'Spanish';
-                    const audioMixes: PexipAudioMix[] = [
-                        {
-                            mix_name: 'main',
-                            prominent: false
-                        },
-                        {
-                            mix_name: languageDescription,
-                            prominent: true
-                        }
-                    ];
-                    this.videoCallService.receiveAudioFromMix(languageDescription, participantUuid);
-                    if (participant && participant.hearingRole === HearingRole.INTERPRETER) {
-                        this.videoCallService.sendParticipantAudioToMixes(audioMixes, participantUuid);
-                    }
-                })
-            ),
-        { dispatch: false }
-    );
-
     constructor(
         private actions$: Actions,
-        private apiClient: ApiClient,
-        private store: Store<ConferenceState>,
-        private videoCallService: VideoCallService
+        private apiClient: ApiClient
     ) {}
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
@@ -1,10 +1,16 @@
 import { Injectable } from '@angular/core';
 import { Actions, ofType, createEffect } from '@ngrx/effects';
-import { of } from 'rxjs';
-import { catchError, switchMap, map } from 'rxjs/operators';
+import { concatLatestFrom } from '@ngrx/operators';
+import { NEVER, of } from 'rxjs';
+import { catchError, switchMap, map, tap } from 'rxjs/operators';
 import { ApiClient, UpdateParticipantDisplayNameRequest } from 'src/app/services/clients/api-client';
 import { ConferenceActions } from '../actions/conference.actions';
 import { mapConferenceToVHConference } from '../models/api-contract-to-state-model-mappers';
+import { ConferenceState } from '../reducers/conference.reducer';
+import * as ConferenceSelectors from '../selectors/conference.selectors';
+import { Store } from '@ngrx/store';
+import { VideoCallService } from '../../services/video-call.service';
+import { HearingRole } from '../../models/hearing-role-model';
 
 @Injectable()
 export class ConferenceEffects {
@@ -43,8 +49,56 @@ export class ConferenceEffects {
         )
     );
 
+    createAudioMixes$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConferenceActions.createPexipParticipant),
+                concatLatestFrom(action => [
+                    this.store.select(ConferenceSelectors.getParticipantByPexipId(action.participant.uuid)),
+                    this.store.select(ConferenceSelectors.getEndpointByPexipId(action.participant.uuid))
+                ]),
+                tap(([action, participant, endpoint]) => {
+                    // get participant or endpoint where action.participant.uuid === participant.pexipId
+                    if (!participant && !endpoint) {
+                        return;
+                    }
+
+                    // TODO: check if participant.interpreterLanguage is not null or endpoint.interpreterLanguage is not null
+                    const hasInterpretationLanguage = true;
+                    if (!hasInterpretationLanguage) {
+                        return;
+                    }
+
+                    // const languageDescription = null;
+                    // if (!languageDescription){
+                    //     return;
+                    // }
+
+                    const participantUuid = participant ? participant.pexipInfo.uuid : endpoint.pexipInfo.uuid;
+                    const languageDescription = 'Spanish';
+                    const audioMixes: PexipAudioMix[] = [
+                        {
+                            mix_name: 'main',
+                            prominent: false
+                        },
+                        {
+                            mix_name: languageDescription,
+                            prominent: true
+                        }
+                    ];
+                    this.videoCallService.receiveAudioFromMix(languageDescription, participantUuid);
+                    if (participant && participant.hearingRole === HearingRole.INTERPRETER) {
+                        this.videoCallService.sendParticipantAudioToMixes(audioMixes, participantUuid);
+                    }
+                })
+            ),
+        { dispatch: false }
+    );
+
     constructor(
         private actions$: Actions,
-        private apiClient: ApiClient
+        private apiClient: ApiClient,
+        private store: Store<ConferenceState>,
+        private videoCallService: VideoCallService
     ) {}
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
@@ -1,16 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Actions, ofType, createEffect } from '@ngrx/effects';
-import { concatLatestFrom } from '@ngrx/operators';
-import { NEVER, of } from 'rxjs';
-import { catchError, switchMap, map, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { catchError, switchMap, map } from 'rxjs/operators';
 import { ApiClient, UpdateParticipantDisplayNameRequest } from 'src/app/services/clients/api-client';
 import { ConferenceActions } from '../actions/conference.actions';
 import { mapConferenceToVHConference } from '../models/api-contract-to-state-model-mappers';
-import { ConferenceState } from '../reducers/conference.reducer';
-import * as ConferenceSelectors from '../selectors/conference.selectors';
-import { Store } from '@ngrx/store';
-import { VideoCallService } from '../../services/video-call.service';
-import { HearingRole } from '../../models/hearing-role-model';
 
 @Injectable()
 export class ConferenceEffects {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.spec.ts
@@ -15,7 +15,7 @@ import { HearingRole } from '../../models/hearing-role-model';
 import { VideoCallEffects } from './video-call.effects';
 import { InterpreterType } from 'src/app/services/clients/api-client';
 
-fdescribe('ConferenceEffectsEffects', () => {
+describe('ConferenceEffectsEffects', () => {
     let actions$: Observable<any>;
     let effects: VideoCallEffects;
     let videoCallService: jasmine.SpyObj<VideoCallService>;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.spec.ts
@@ -15,7 +15,7 @@ import { HearingRole } from '../../models/hearing-role-model';
 import { VideoCallEffects } from './video-call.effects';
 import { InterpreterType } from 'src/app/services/clients/api-client';
 
-describe('ConferenceEffectsEffects', () => {
+describe('VideoCallEffects', () => {
     let actions$: Observable<any>;
     let effects: VideoCallEffects;
     let videoCallService: jasmine.SpyObj<VideoCallService>;
@@ -223,10 +223,7 @@ describe('ConferenceEffectsEffects', () => {
 
             // assert
             effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(
-                    interpretationLanguage.description,
-                    pexipParticipant.uuid
-                );
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith('main.spanish', pexipParticipant.uuid);
             });
         });
 
@@ -275,11 +272,11 @@ describe('ConferenceEffectsEffects', () => {
             const expectedAudioMixes = [
                 {
                     mix_name: 'main',
-                    prominent: false
+                    prominent: true
                 },
                 {
-                    mix_name: interpretationLanguage.description,
-                    prominent: true
+                    mix_name: 'main.spanish',
+                    prominent: false
                 }
             ];
 
@@ -288,10 +285,7 @@ describe('ConferenceEffectsEffects', () => {
 
             // assert
             effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(
-                    interpretationLanguage.description,
-                    pexipParticipant.uuid
-                );
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith('main', pexipParticipant.uuid);
                 expect(videoCallService.sendParticipantAudioToMixes).toHaveBeenCalledWith(expectedAudioMixes, pexipParticipant.uuid);
             });
         });
@@ -344,10 +338,7 @@ describe('ConferenceEffectsEffects', () => {
 
             // assert
             effects.createAudioMixes$.subscribe(() => {
-                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(
-                    interpretationLanguage.description,
-                    pexipParticipant.uuid
-                );
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith('main.spanish', pexipParticipant.uuid);
             });
         });
     });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.spec.ts
@@ -1,0 +1,236 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable, of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing'; // import this
+
+import { ConferenceActions } from '../actions/conference.actions';
+import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
+import { mapParticipantToVHParticipant, mapEndpointToVHEndpoint } from '../models/api-contract-to-state-model-mappers';
+import { VideoCallService } from '../../services/video-call.service';
+import { ConferenceState } from '../reducers/conference.reducer';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import * as ConferenceSelectors from '../selectors/conference.selectors';
+import { VHPexipParticipant } from '../models/vh-conference';
+import { HearingRole } from '../../models/hearing-role-model';
+import { VideoCallEffects } from './video-call.effects';
+
+describe('ConferenceEffectsEffects', () => {
+    let actions$: Observable<any>;
+    let effects: VideoCallEffects;
+    let videoCallService: jasmine.SpyObj<VideoCallService>;
+    let mockConferenceStore: MockStore<ConferenceState>;
+
+    beforeEach(() => {
+        videoCallService = jasmine.createSpyObj('VideoCallService', ['receiveAudioFromMix', 'sendParticipantAudioToMixes']);
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                VideoCallEffects,
+                provideMockStore(),
+                provideMockActions(() => actions$),
+                { provide: VideoCallService, useValue: videoCallService }
+            ]
+        });
+
+        effects = TestBed.inject(VideoCallEffects);
+        mockConferenceStore = TestBed.inject(MockStore);
+    });
+
+    afterEach(() => {
+        mockConferenceStore.resetSelectors();
+    });
+
+    it('should be created', () => {
+        expect(effects).toBeTruthy();
+    });
+
+    describe('createAudioMixes$', () => {
+        beforeEach(() => {
+            videoCallService.receiveAudioFromMix.calls.reset();
+            videoCallService.sendParticipantAudioToMixes.calls.reset();
+        });
+
+        afterEach(() => {
+            mockConferenceStore.resetSelectors();
+        });
+
+        it('should not create audio mixes if participant or endpoint is not found', () => {
+            // arrange
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, []);
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, []);
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: '1922_John Doe',
+                uuid: 'doesnot_exist',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledTimes(0);
+            });
+        });
+
+        it('should create audio mixes if non-interpreter participant is found and has verbal interpreter language', () => {
+            // arrange
+            const participants = new ConferenceTestData().getListOfParticipants();
+            let participant = mapParticipantToVHParticipant(participants[0]);
+            participant = {
+                ...participant,
+                hearingRole: HearingRole.APPELLANT,
+                pexipInfo: {
+                    isRemoteMuted: false,
+                    isSpotlighted: false,
+                    handRaised: false,
+                    pexipDisplayName: `1922_${participant.displayName}`,
+                    uuid: '1922_John Doe',
+                    isAudioOnlyCall: false,
+                    isVideoCall: true,
+                    protocol: 'sip',
+                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                    receivingAudioMix: 'main'
+                }
+            };
+
+            // mock the get participants since override selector does not work with params and the selector get participant by id used the getParticipantsSelector
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, [participant]);
+            const languageDescription = 'Spanish';
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: `1922_John Doe${participants[0].id}`,
+                uuid: '1922_John Doe',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
+            });
+        });
+
+        it('should create audio mixes and send audio to language mix if interpreter participant is found and has verbal interpreter language', () => {
+            // arrange
+            const participants = new ConferenceTestData().getListOfParticipants();
+            let participant = mapParticipantToVHParticipant(participants[0]);
+            participant = {
+                ...participant,
+                hearingRole: HearingRole.INTERPRETER,
+                pexipInfo: {
+                    isRemoteMuted: false,
+                    isSpotlighted: false,
+                    handRaised: false,
+                    pexipDisplayName: `1922_${participant.displayName}`,
+                    uuid: '1922_John Doe',
+                    isAudioOnlyCall: false,
+                    isVideoCall: true,
+                    protocol: 'sip',
+                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                    receivingAudioMix: 'main'
+                }
+            };
+
+            // mock the get participants since override selector does not work with params and the selector get participant by id used the getParticipantsSelector
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getParticipants, [participant]);
+            const languageDescription = 'Spanish';
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: `1922_John Doe${participants[0].id}`,
+                uuid: '1922_John Doe',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+            const expectedAudioMixes = [
+                {
+                    mix_name: 'main',
+                    prominent: false
+                },
+                {
+                    mix_name: languageDescription,
+                    prominent: true
+                }
+            ];
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
+                expect(videoCallService.sendParticipantAudioToMixes).toHaveBeenCalledWith(expectedAudioMixes, pexipParticipant.uuid);
+            });
+        });
+
+        it('should create audio mixes if endpoint is found and has verbal interpreter language', () => {
+            // act
+            const endpoints = new ConferenceTestData().getListOfEndpoints();
+            let endpoint = mapEndpointToVHEndpoint(endpoints[0]);
+            endpoint = {
+                ...endpoint,
+                pexipInfo: {
+                    isRemoteMuted: false,
+                    isSpotlighted: false,
+                    handRaised: false,
+                    pexipDisplayName: `PTSN;${endpoints[0].display_name};${endpoints[0].id}`,
+                    uuid: '1922_John Doe',
+                    isAudioOnlyCall: false,
+                    isVideoCall: true,
+                    protocol: 'sip',
+                    sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                    receivingAudioMix: 'main'
+                }
+            };
+
+            // mock the get endpoints since override selector does not work with params and the selector get endpoint by id used the getEndpointsSelector
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, [endpoint]);
+            const languageDescription = 'Spanish';
+            const pexipParticipant: VHPexipParticipant = {
+                isRemoteMuted: false,
+                isSpotlighted: false,
+                handRaised: false,
+                pexipDisplayName: `PTSN;${endpoints[0].display_name};${endpoints[0].id}`,
+                uuid: '1922_John Doe',
+                isAudioOnlyCall: false,
+                isVideoCall: true,
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
+            };
+
+            const action = ConferenceActions.createPexipParticipant({ participant: pexipParticipant });
+
+            // act
+            actions$ = of(action);
+
+            // assert
+            effects.createAudioMixes$.subscribe(() => {
+                expect(videoCallService.receiveAudioFromMix).toHaveBeenCalledWith(languageDescription, pexipParticipant.uuid);
+            });
+        });
+    });
+});

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.ts
@@ -8,6 +8,7 @@ import * as ConferenceSelectors from '../selectors/conference.selectors';
 import { Store } from '@ngrx/store';
 import { VideoCallService } from '../../services/video-call.service';
 import { HearingRole } from '../../models/hearing-role-model';
+import { InterpreterType } from 'src/app/services/clients/api-client';
 
 @Injectable()
 export class VideoCallEffects {
@@ -25,19 +26,13 @@ export class VideoCallEffects {
                         return;
                     }
 
-                    // TODO: check if participant.interpreterLanguage is not null or endpoint.interpreterLanguage is not null
-                    const hasInterpretationLanguage = true;
-                    if (!hasInterpretationLanguage) {
+                    const interpreterLanguage = participant ? participant.interpreterLanguage : endpoint.interpreterLanguage;
+                    if (!interpreterLanguage || interpreterLanguage.type !== InterpreterType.Verbal) {
                         return;
                     }
 
-                    // const languageDescription = null;
-                    // if (!languageDescription){
-                    //     return;
-                    // }
-
                     const participantUuid = participant ? participant.pexipInfo.uuid : endpoint.pexipInfo.uuid;
-                    const languageDescription = 'Spanish';
+                    const languageDescription = interpreterLanguage.description;
                     const audioMixes: PexipAudioMix[] = [
                         {
                             mix_name: 'main',

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/video-call.effects.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+import { Actions, ofType, createEffect } from '@ngrx/effects';
+import { concatLatestFrom } from '@ngrx/operators';
+import { tap } from 'rxjs/operators';
+import { ConferenceActions } from '../actions/conference.actions';
+import { ConferenceState } from '../reducers/conference.reducer';
+import * as ConferenceSelectors from '../selectors/conference.selectors';
+import { Store } from '@ngrx/store';
+import { VideoCallService } from '../../services/video-call.service';
+import { HearingRole } from '../../models/hearing-role-model';
+
+@Injectable()
+export class VideoCallEffects {
+    createAudioMixes$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConferenceActions.createPexipParticipant),
+                concatLatestFrom(action => [
+                    this.store.select(ConferenceSelectors.getParticipantByPexipId(action.participant.uuid)),
+                    this.store.select(ConferenceSelectors.getEndpointByPexipId(action.participant.uuid))
+                ]),
+                tap(([action, participant, endpoint]) => {
+                    // get participant or endpoint where action.participant.uuid === participant.pexipId
+                    if (!participant && !endpoint) {
+                        return;
+                    }
+
+                    // TODO: check if participant.interpreterLanguage is not null or endpoint.interpreterLanguage is not null
+                    const hasInterpretationLanguage = true;
+                    if (!hasInterpretationLanguage) {
+                        return;
+                    }
+
+                    // const languageDescription = null;
+                    // if (!languageDescription){
+                    //     return;
+                    // }
+
+                    const participantUuid = participant ? participant.pexipInfo.uuid : endpoint.pexipInfo.uuid;
+                    const languageDescription = 'Spanish';
+                    const audioMixes: PexipAudioMix[] = [
+                        {
+                            mix_name: 'main',
+                            prominent: false
+                        },
+                        {
+                            mix_name: languageDescription,
+                            prominent: true
+                        }
+                    ];
+                    this.videoCallService.receiveAudioFromMix(languageDescription, participantUuid);
+                    if (participant && participant.hearingRole === HearingRole.INTERPRETER) {
+                        this.videoCallService.sendParticipantAudioToMixes(audioMixes, participantUuid);
+                    }
+                })
+            ),
+        { dispatch: false }
+    );
+
+    constructor(
+        private actions$: Actions,
+        private store: Store<ConferenceState>,
+        private videoCallService: VideoCallService
+    ) {}
+}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/models/vh-conference.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/models/vh-conference.ts
@@ -50,6 +50,8 @@ export interface VHPexipParticipant {
     isAudioOnlyCall: boolean;
     isVideoCall: boolean;
     protocol: string;
+    receivingAudioMix: string;
+    sentAudioMixes: Array<PexipAudioMix>;
 }
 
 export interface VHRoom {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
@@ -142,7 +142,9 @@ describe('Conference Reducer', () => {
                             uuid: '1922_John Doe',
                             isAudioOnlyCall: false,
                             isVideoCall: true,
-                            protocol: 'sip'
+                            protocol: 'sip',
+                            sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                            receivingAudioMix: 'main'
                         }
                     },
                     conferenceTestData.participants[1]
@@ -612,7 +614,9 @@ describe('Conference Reducer', () => {
                 uuid: '1922_John Doe',
                 isAudioOnlyCall: false,
                 isVideoCall: true,
-                protocol: 'sip'
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
             };
             const result = conferenceReducer(
                 existingInitialState,
@@ -631,7 +635,9 @@ describe('Conference Reducer', () => {
                 uuid: '1922_John Doe',
                 isAudioOnlyCall: false,
                 isVideoCall: true,
-                protocol: 'sip'
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
             };
             const result = conferenceReducer(
                 existingInitialState,
@@ -650,7 +656,9 @@ describe('Conference Reducer', () => {
                 uuid: '1922_John Doe',
                 isAudioOnlyCall: false,
                 isVideoCall: true,
-                protocol: 'sip'
+                protocol: 'sip',
+                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                receivingAudioMix: 'main'
             };
             const result = conferenceReducer(
                 existingInitialState,
@@ -678,7 +686,9 @@ describe('Conference Reducer', () => {
                                 uuid: '1922_John Doe',
                                 isAudioOnlyCall: false,
                                 isVideoCall: true,
-                                protocol: 'sip'
+                                protocol: 'sip',
+                                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                                receivingAudioMix: 'main'
                             }
                         }
                     ]
@@ -708,7 +718,9 @@ describe('Conference Reducer', () => {
                                 uuid: '1922_John Doe',
                                 isAudioOnlyCall: false,
                                 isVideoCall: true,
-                                protocol: 'sip'
+                                protocol: 'sip',
+                                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                                receivingAudioMix: 'main'
                             }
                         }
                     ]
@@ -738,7 +750,9 @@ describe('Conference Reducer', () => {
                                 uuid: '1922_John Doe',
                                 isAudioOnlyCall: false,
                                 isVideoCall: true,
-                                protocol: 'sip'
+                                protocol: 'sip',
+                                sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                                receivingAudioMix: 'main'
                             }
                         }
                     ]

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
@@ -158,7 +158,7 @@ export const conferenceReducer = createReducer(
 
         return { ...state, currentConference: { ...conference, endpoints: updatedList } };
     }),
-    on(ConferenceActions.upsertPexipParticipant, (state, { participant }) => {
+    on(ConferenceActions.createPexipParticipant, ConferenceActions.upsertPexipParticipant, (state, { participant }) => {
         const conference = state.currentConference;
         const participants = conference.participants.map(p =>
             participant.pexipDisplayName?.includes(p.id) ? { ...p, pexipInfo: participant } : p

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/selectors/conference.selectors.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/selectors/conference.selectors.ts
@@ -4,3 +4,7 @@ import { activeConferenceFeature } from '../reducers/conference.reducer';
 export const getActiveConference = createSelector(activeConferenceFeature, state => state?.currentConference);
 export const getParticipants = createSelector(activeConferenceFeature, state => state?.currentConference?.participants);
 export const getEndpoints = createSelector(activeConferenceFeature, state => state?.currentConference?.endpoints);
+export const getParticipantByPexipId = (pexipId: string) =>
+    createSelector(getParticipants, participants => participants?.find(p => p?.pexipInfo?.uuid === pexipId));
+export const getEndpointByPexipId = (pexipId: string) =>
+    createSelector(getEndpoints, endpoints => endpoints?.find(e => e?.pexipInfo?.uuid === pexipId));

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.video-call-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.video-call-events.spec.ts
@@ -174,7 +174,14 @@ describe('WaitingRoomComponent Video Call', () => {
                 protocol: '',
                 spotlight: 0,
                 start_time: 0,
-                uuid: ''
+                uuid: '',
+                disconnect_supported: 'Yes',
+                transfer_supported: 'Yes',
+                is_main_video_dropped_out: false,
+                is_video_muted: false,
+                is_streaming_conference: false,
+                send_to_audio_mixes: [{ mix_name: 'main', prominent: false }],
+                receive_from_audio_mix: 'main'
             })
         );
         flush();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-space.module.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-space.module.ts
@@ -52,6 +52,7 @@ import { environment } from 'src/environments/environment';
 import { ParticipantsPanelItemComponent } from './participants-panel/participants-panel-item/participants-panel-item.component';
 import { WarnJoinHearingPopupComponent } from './confirmation/warn-join-hearing-popup.component';
 import { ChangeHearingLayoutPopupComponent } from './change-hearing-layout-popup/change-hearing-layout.component';
+import { VideoCallEffects } from './store/effects/video-call.effects';
 
 @NgModule({
     imports: [
@@ -60,7 +61,7 @@ import { ChangeHearingLayoutPopupComponent } from './change-hearing-layout-popup
         NgOptimizedImage,
         StoreModule.forFeature(conferenceFeatureKey, conferenceReducer),
         environment.production ? [] : StoreDevtoolsModule.instrument({ maxAge: 25, logOnly: !isDevMode() }),
-        EffectsModule.forFeature([ConferenceEffects])
+        EffectsModule.forFeature([ConferenceEffects, VideoCallEffects])
     ],
     declarations: [
         JudgeParticipantStatusListComponent,

--- a/VideoWeb/VideoWeb/ClientApp/src/typings.d.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/typings.d.ts
@@ -122,8 +122,8 @@ declare interface PexipClient {
     clearAllBuzz(): () => void;
     getMediaStatistics(): any;
     setParticipantText(uuid: string, text: string);
-    setSendToAudioMixes(mix: string, uuid: string);
-    setReceiveFromAudioMix(mix: string, uuid: string);
+    setSendToAudioMixes(mixes: PexipAudioMix[], uuid: string);
+    setReceiveFromAudioMix(mixName: string, uuid: string);
 
     /**
      * Activate or stop screen capture sharing.
@@ -208,8 +208,29 @@ declare interface PexipParticipant {
     /** Set to "YES" if the call has video capability. */
     is_video_call: string;
 
+    /** Boolean indicating whether this participant has muted their video. */
+    is_video_muted: boolean;
+
     /** The call protocol. Values: "api", "webrtc", "sip", "rtmp", "h323" or "mssip" */
     protocol: string;
+
+    /** Set to "YES" if this participant can be transferred into another VMR; "NO" if not. */
+    transfer_supported: string;
+
+    /** Set to "YES" if the participant can be disconnected, "NO" if not. */
+    disconnect_supported: string;
+
+    /** Boolean indicating if video from the user has been lost. */
+    is_main_video_dropped_out: boolean;
+
+    /** Boolean indicating whether this is a streaming/recording participant. */
+    is_streaming_conference: boolean;
+
+    /** list of mixes to be sent participant audio */
+    send_to_audio_mixes: PexipAudioMix[];
+
+    /** the name of the audio a participant is receiving a mix */
+    receive_from_audio_mix: string;
 }
 
 declare interface PexipConference {
@@ -233,4 +254,11 @@ declare interface PexRTCCall {
     recv_video: boolean;
     video_source: string;
     audio_source: string;
+}
+
+declare interface PexipAudioMix {
+    /** The name of of the mix. Will be the participant language in VH */
+    mix_name: string;
+    /** Should the audio be prominent. If false the volume will be lowered when other participants receive the audio */
+    prominent: boolean;
 }


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10773

### Change description ###
* create a new action for create a Pexip participant
* Use effects to subscribe to create Pexip participant to create audio mixes when a participant is connected to a conference
  * if the participant is an interpreter it will send the audio to the respective mixes