### PR TITLE
VIH-10868 refactor semaphores out of hot code path

### DIFF
--- a/VideoWeb/VideoWeb/AuthenticationSchemes/AadSchemeBase.cs
+++ b/VideoWeb/VideoWeb/AuthenticationSchemes/AadSchemeBase.cs
@@ -16,7 +16,6 @@ namespace VideoWeb.AuthenticationSchemes
 {
     public abstract class AadSchemeBase : ProviderSchemeBase, IProviderSchemes
     {
-        private static readonly ConcurrentDictionary<string, SemaphoreSlim> Semaphores = new();
         private readonly IdpConfiguration _idpConfiguration;
         
         protected AadSchemeBase(string eventhubPath, IdpConfiguration idpConfiguration) : base(eventhubPath)
@@ -63,22 +62,16 @@ namespace VideoWeb.AuthenticationSchemes
             }
         }
 
-        private static async Task<List<Claim>> GetAdditionalClaimsForUserByUsername(TokenValidatedContext context, Claim usernameClaim)
+        private static async Task<List<Claim>> GetAdditionalClaimsForUserByUsername(TokenValidatedContext context,
+            Claim usernameClaim)
         {
             var username = usernameClaim.Value;
-            var semaphore = Semaphores.GetOrAdd(username, _ => new SemaphoreSlim(1, 1));
 
-            await semaphore.WaitAsync();
-            try
-            {
-                var appRoleService = context.HttpContext.RequestServices.GetService(typeof(IAppRoleService)) as IAppRoleService;
-                var claims = await appRoleService!.GetClaimsForUserAsync(username);
-                return claims;
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            var appRoleService =
+                context.HttpContext.RequestServices.GetService(typeof(IAppRoleService)) as IAppRoleService;
+            var claims = await appRoleService!.GetClaimsForUserAsync(username);
+            return claims;
+
         }
 
         /// <summary>


### PR DESCRIPTION
### Jira link (if applicable)

VIH-10868

### Change description ###

* move Sempahores out from AadSchemeBase.cs and into AppRoleService.cs to check cache first before calling api, and then check cache again when the semaphore is gained
* Increase from 1 to 3 max concurrent requests. On app start the web app makes multiple concurrent requests, this should help alleviate blocking a hot code path
