### PR TITLE
VIH-10833 Fix for quick link users showing as disconnected when joining after the judge

### DIFF
--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ParticipantController/GetParticipantsByConferenceIdTest.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ParticipantController/GetParticipantsByConferenceIdTest.cs
@@ -48,7 +48,7 @@ namespace VideoWeb.UnitTests.Controllers.ParticipantController
             var response = CreateValidParticipantConferenceDto();
 
             _mocker.Mock<IConferenceService>()
-                .Setup(x => x.GetConference(It.IsAny<Guid>()))
+                .Setup(x => x.ForceGetConference(It.IsAny<Guid>()))
                 .ReturnsAsync(response);
 
             var result = await _sut.GetParticipantsByConferenceIdAsync(conferenceId);
@@ -67,7 +67,7 @@ namespace VideoWeb.UnitTests.Controllers.ParticipantController
                  "Please provide a valid conference Id", null, default, null);
 
             _mocker.Mock<IConferenceService>()
-                .Setup(x => x.GetConference(It.IsAny<Guid>()))
+                .Setup(x => x.ForceGetConference(It.IsAny<Guid>()))
                 .Throws(apiException);
 
             var result = await _sut.GetParticipantsByConferenceIdAsync(conferenceId);

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ParticipantController/GetParticipantsWithContactDetailsByConferenceIdAsync.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ParticipantController/GetParticipantsWithContactDetailsByConferenceIdAsync.cs
@@ -71,7 +71,7 @@ namespace VideoWeb.UnitTests.Controllers.ParticipantController
                 new () { Id = judge3DifferentHearing.Id, Username = judgeInHearing.Username, Status = ParticipantState.InHearing }
             };
             
-            _mocker.Mock<IConferenceService>().Setup(x => x.GetConference(conference.Id)).ReturnsAsync(conference);
+            _mocker.Mock<IConferenceService>().Setup(x => x.ForceGetConference(conference.Id)).ReturnsAsync(conference);
             _mocker.Mock<IVideoApiClient>()
                 .Setup(x => x.GetHostsInHearingsTodayAsync())
                 .ReturnsAsync(judgesInHearings);
@@ -110,7 +110,7 @@ namespace VideoWeb.UnitTests.Controllers.ParticipantController
             var conferenceId = Guid.NewGuid();
             var apiException = new VideoApiException<ProblemDetails>("Bad Request", (int)HttpStatusCode.BadRequest,
                 "Please provide a valid conference Id and participant Id", null, default, null);
-            _mocker.Mock<IConferenceService>().Setup(x => x.GetConference(conferenceId)).ThrowsAsync(apiException);
+            _mocker.Mock<IConferenceService>().Setup(x => x.ForceGetConference(conferenceId)).ThrowsAsync(apiException);
             var result = await _sut.GetParticipantsWithContactDetailsByConferenceIdAsync(conferenceId);
             var typedResult = (ObjectResult)result;
             typedResult.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ParticipantController/GetParticipantsWithContactDetailsByConferenceIdAsync.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ParticipantController/GetParticipantsWithContactDetailsByConferenceIdAsync.cs
@@ -71,7 +71,7 @@ namespace VideoWeb.UnitTests.Controllers.ParticipantController
                 new () { Id = judge3DifferentHearing.Id, Username = judgeInHearing.Username, Status = ParticipantState.InHearing }
             };
             
-            _mocker.Mock<IConferenceService>().Setup(x => x.ForceGetConference(conference.Id)).ReturnsAsync(conference);
+            _mocker.Mock<IConferenceService>().Setup(x => x.GetConference(conference.Id)).ReturnsAsync(conference);
             _mocker.Mock<IVideoApiClient>()
                 .Setup(x => x.GetHostsInHearingsTodayAsync())
                 .ReturnsAsync(judgesInHearings);
@@ -110,7 +110,7 @@ namespace VideoWeb.UnitTests.Controllers.ParticipantController
             var conferenceId = Guid.NewGuid();
             var apiException = new VideoApiException<ProblemDetails>("Bad Request", (int)HttpStatusCode.BadRequest,
                 "Please provide a valid conference Id and participant Id", null, default, null);
-            _mocker.Mock<IConferenceService>().Setup(x => x.ForceGetConference(conferenceId)).ThrowsAsync(apiException);
+            _mocker.Mock<IConferenceService>().Setup(x => x.GetConference(conferenceId)).ThrowsAsync(apiException);
             var result = await _sut.GetParticipantsWithContactDetailsByConferenceIdAsync(conferenceId);
             var typedResult = (ObjectResult)result;
             typedResult.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);

--- a/VideoWeb/VideoWeb/Controllers/ParticipantsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ParticipantsController.cs
@@ -75,9 +75,6 @@ namespace VideoWeb.Controllers
             try
             {
                 await videoApiClient.RaiseVideoEventAsync(conferenceEventRequest);
-                
-                // Refresh the conference in the cache
-                await conferenceService.ForceGetConference(conferenceId);
 
                 return NoContent();
             }
@@ -178,7 +175,7 @@ namespace VideoWeb.Controllers
             }
             try
             {
-                var conference = await conferenceService.GetConference(conferenceId);
+                var conference = await conferenceService.ForceGetConference(conferenceId);
 
                 logger.LogTrace("Retrieving booking participants for hearing {HearingId}", conference.HearingId);
                 
@@ -205,7 +202,7 @@ namespace VideoWeb.Controllers
         {
             try
             {
-                var conference = await conferenceService.GetConference(conferenceId);
+                var conference = await conferenceService.ForceGetConference(conferenceId);
                 var participantMapper = mapperFactory.Get<Participant, ParticipantResponse>();
                 var participants = conference.Participants.Select(participantMapper.Map).ToList();
                 return Ok(participants);

--- a/VideoWeb/VideoWeb/Controllers/ParticipantsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ParticipantsController.cs
@@ -175,7 +175,7 @@ namespace VideoWeb.Controllers
             }
             try
             {
-                var conference = await conferenceService.ForceGetConference(conferenceId);
+                var conference = await conferenceService.GetConference(conferenceId);
 
                 logger.LogTrace("Retrieving booking participants for hearing {HearingId}", conference.HearingId);
                 

--- a/VideoWeb/VideoWeb/Controllers/ParticipantsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ParticipantsController.cs
@@ -75,6 +75,9 @@ namespace VideoWeb.Controllers
             try
             {
                 await videoApiClient.RaiseVideoEventAsync(conferenceEventRequest);
+                
+                // Refresh the conference in the cache
+                await conferenceService.ForceGetConference(conferenceId);
 
                 return NoContent();
             }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10833


### Change description ###
Reverts a recent change to fetching participants - use `ForceGetConference` to get them from the db instead of the cache when building the participants list, to ensure participants have the latest statuses in the hearing
