### PR TITLE
VIH-11037 Fix for 400 error when no hearings

### DIFF
--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForHostTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConferenceController/GetConferencesForHostTests.cs
@@ -160,4 +160,27 @@ public class GetConferencesForHostTests
             conferencesForUser[i].CaseName.Should().Be($"CaseName{position}");
         }
     }
+
+    [Test]
+    public async Task Should_return_empty_list_when_no_hearings_found()
+    {
+        // Arrange
+        _mocker.Mock<IBookingsApiClient>()
+            .Setup(x => x.GetConfirmedHearingsByUsernameForTodayV2Async(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConfirmedHearingsTodayResponseV2>());
+        _mocker.Mock<IVideoApiClient>()
+            .Setup(x => x.GetConferencesByHearingRefIdsAsync(It.IsAny<GetConferencesByHearingIdsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConferenceCoreResponse>());
+        
+        // Act
+        var result = await _controller.GetConferencesForHostAsync(CancellationToken.None);
+        
+        // Assert
+        var typedResult = (OkObjectResult)result.Result;
+        typedResult.Should().NotBeNull();
+        _mocker.Mock<IVideoApiClient>()
+            .Verify(x => x.GetConferencesByHearingRefIdsAsync(It.IsAny<GetConferencesByHearingIdsRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        var conferencesForUser = (List<ConferenceForHostResponse>) typedResult.Value;
+        conferencesForUser.Should().BeEmpty();
+    }
 }

--- a/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConferencesController.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using VideoApi.Client;
 using VideoApi.Contract.Requests;
+using VideoApi.Contract.Responses;
 using VideoWeb.Common;
 using VideoWeb.Common.Models;
 using VideoWeb.Contract.Request;
@@ -54,7 +55,9 @@ public class ConferencesController(
         var hearings =
             await bookingApiClient.GetConfirmedHearingsByUsernameForTodayV2Async(username, cancellationToken);
         var request = new GetConferencesByHearingIdsRequest { HearingRefIds = hearings.Select(x => x.Id).ToArray() };
-        var conferences = await videoApiClient.GetConferencesByHearingRefIdsAsync(request, cancellationToken);
+        ICollection<ConferenceCoreResponse> conferences = new List<ConferenceCoreResponse>();
+        if (hearings.Count > 0)
+            conferences = await videoApiClient.GetConferencesByHearingRefIdsAsync(request, cancellationToken);
 
         if (conferences.Count != hearings.Count)
             logger.LogError(
@@ -88,7 +91,9 @@ public class ConferencesController(
             await bookingApiClient.GetHearingsForTodayByVenueV2Async(hearingVenueNames, cancellationToken);
         var request = new GetConferencesByHearingIdsRequest
             { HearingRefIds = hearingsForToday.Select(x => x.Id).ToArray() };
-        var conferences = await videoApiClient.GetConferencesByHearingRefIdsAsync(request, cancellationToken);
+        ICollection<ConferenceCoreResponse> conferences = new List<ConferenceCoreResponse>();
+        if (hearingsForToday.Count > 0)
+            conferences = await videoApiClient.GetConferencesByHearingRefIdsAsync(request, cancellationToken);
         var response = hearingsForToday
             .Select(hearing =>
                 BookingForHostResponseMapper.Map(hearing, conferences.First(c => hearing.Id == c.HearingId)))


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11037

### Change description
Fixes a 400 error received when loading the hearing list page for a staff member or judge, when there are no hearings
Avoid calling video api to fetch the conferences, when there are no hearings
