### PR TITLE
VIH-11040 redirect users detected on a another device from the waiting room too

### DIFF
--- a/VideoWeb/VideoWeb.EventHub/Handlers/LeaveEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/LeaveEventHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using VideoWeb.Common.Models;
@@ -17,8 +18,12 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            if (SourceParticipant.ParticipantStatus == ParticipantStatus.InHearing || SourceParticipant.ParticipantStatus == ParticipantStatus.InConsultation)
-                return PublishParticipantStatusMessage(ParticipantState.Disconnected, ParticipantStatus.Disconnected, callbackEvent.Reason);
+            var anotherDeviceDetected = callbackEvent.Reason.Contains("has connected on another device",
+                StringComparison.InvariantCultureIgnoreCase);
+            if (SourceParticipant.ParticipantStatus == ParticipantStatus.InHearing ||
+                SourceParticipant.ParticipantStatus == ParticipantStatus.InConsultation || anotherDeviceDetected)
+                return PublishParticipantStatusMessage(ParticipantState.Disconnected, ParticipantStatus.Disconnected,
+                    callbackEvent.Reason);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION


### Jira link

VIH-11040 

### Change description

This pull request introduces a new condition to handle participants who leave a conference because they have connected on another device.

Changes in event handling:

* [`VideoWeb/VideoWeb.EventHub/Handlers/LeaveEventHandler.cs`](diffhunk://#diff-446e63876be507cd5a344fd588b60fe84bff9a4e8f08b988bf92fc3e69d35dcdL20-R26): Added a check to detect if a participant has connected on another device and handle the `Leave` event accordingly.
