### PR TITLE
VIH-11052 Fix for audio recording setting not updating in waiting room

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -39,7 +39,8 @@ import {
     hearingLayoutChangedSubjectMock,
     getEndpointLinkedUpdatedMock,
     getEndpointUnlinkedUpdatedMock,
-    getEndpointDisconnectUpdatedMock
+    getEndpointDisconnectUpdatedMock,
+    getHearingDetailsUpdatedMock
 } from 'src/app/testing/mocks/mock-events-service';
 import {
     clockService,
@@ -94,6 +95,8 @@ import { EndpointRepMessage } from '../../../shared/models/endpoint-rep-message'
 import { provideMockStore } from '@ngrx/store/testing';
 import { FEATURE_FLAGS, LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 import { of } from 'rxjs';
+import { HearingDetailsUpdatedMessage } from 'src/app/services/models/hearing-details-updated-message';
+import { videoWebServiceSpy } from 'src/app/vh-officer/vho-shared/tests/participant-status-base-setup';
 
 describe('WaitingRoomComponent EventHub Call', () => {
     let fixture: ComponentFixture<WRTestComponent>;
@@ -1997,6 +2000,21 @@ describe('WaitingRoomComponent EventHub Call', () => {
                     expect(value).toEqual(vhContactDetails.englandAndWales.phoneNumber);
                 });
             });
+        });
+    });
+
+    describe('getHearingDetailsUpdated', () => {
+        it('should fetch and update the conference', () => {
+            // Arrange
+            const conferenceId = globalConference.id;
+            const hearingDetailsUpdatedMessage = new HearingDetailsUpdatedMessage(conferenceId);
+
+            // Act
+            getHearingDetailsUpdatedMock.next(hearingDetailsUpdatedMessage);
+
+            // Assert
+            expect(videoWebService.getConferenceById).toHaveBeenCalledWith(conferenceId);
+            expect(component.conferenceId).toBe(conferenceId);
         });
     });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/waiting-room-base.component.ts
@@ -616,6 +616,13 @@ export abstract class WaitingRoomBaseDirective implements AfterContentChecked {
                 this.handleHearingLayoutUpdatedMessage(hearingLayout);
             })
         );
+
+        this.logger.debug('[WR] - Subscribing to hearing details updated message');
+        this.eventHubSubscription$.add(
+            this.eventService.getHearingDetailsUpdated().subscribe(async () => {
+                await this.getConference();
+            })
+        );
     }
 
     resolveParticipant(participantId: any): Participant {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11052

### Change description
Fixes an issue where audio recording is still shown as disabled in the waiting room after changing it to enabled on the booking.
- Subscribe to the hearing details updated event, and update the conference when the event is received
