### PR TITLE
VIH-11050 disconnect from camera and microphone when user leaves the waiting room

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/heartbeat.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/heartbeat.service.spec.ts
@@ -93,6 +93,29 @@ describe('HeartbeatService', () => {
             expect(apiClientSpy.getHeartbeatConfigForParticipant).not.toHaveBeenCalled();
         }));
 
+        it('should do nothing if heartbeat is already initialised', fakeAsync(() => {
+            // arrange
+            const heartbeatSpy = jasmine.createSpyObj<HeartbeatClient>(['kill'], []);
+            sut.heartbeat = heartbeatSpy;
+
+            // Act
+            sut.initialiseHeartbeat(pexipApiMock);
+            flush();
+
+            expect(apiClientSpy.getHeartbeatConfigForParticipant).not.toHaveBeenCalled();
+        }));
+
+        it('should do nothing if the heartbeat is initialising', fakeAsync(() => {
+            // arrange
+            sut.initialising = true;
+
+            // Act
+            sut.initialiseHeartbeat(pexipApiMock);
+            flush();
+
+            expect(apiClientSpy.getHeartbeatConfigForParticipant).not.toHaveBeenCalled();
+        }));
+
         it('should do nothing if the current conference is null', fakeAsync(() => {
             // Act
             sut.initialiseHeartbeat(pexipApiMock);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/heartbeat.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/heartbeat.service.ts
@@ -16,6 +16,8 @@ import { environment } from 'src/environments/environment';
 })
 export class HeartbeatService {
     heartbeat: HeartbeatClient;
+    initialising = false;
+
     private loggerPrefix = '[KinlyHeartbeatService] -';
     private currentParticipant: ParticipantModel;
     private currentConference: ConferenceResponse;
@@ -35,6 +37,10 @@ export class HeartbeatService {
             this.currentConference = details.conference;
             this.currentParticipant = details.participant;
 
+            if (this.heartbeat || this.initialising) {
+                return;
+            }
+            this.initialising = true;
             this.apiClient.getHeartbeatConfigForParticipant(this.currentConference.id, this.currentParticipant.id).subscribe({
                 next: heartbeatConfiguration => {
                     this.logger.info(`${this.loggerPrefix} got heartbeat configuration`, {
@@ -84,6 +90,7 @@ export class HeartbeatService {
 
         this.heartbeat.kill();
         this.heartbeat = null;
+        this.initialising = false;
         this.logger.info(`${this.loggerPrefix} Should have stopped heartbeat`);
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream.service.ts
@@ -85,6 +85,12 @@ export class UserMediaStreamService {
         this.activeMicrophoneStreamSubject.next(stream);
     }
 
+    closeCurrentStream() {
+        this.currentStream?.getTracks().forEach(track => {
+            track.stop();
+        });
+    }
+
     private initialiseCurrentStream() {
         this.userMediaService.checkCameraAndMicrophonePresence().then(result => {
             const hasCameraDevices = result.hasACamera;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -86,7 +86,7 @@ describe('VideoCallService', () => {
         );
 
         userMediaStreamService = jasmine.createSpyObj<UserMediaStreamService>(
-            [],
+            ['closeCurrentStream'],
             ['currentStream$', 'streamModified$', 'activeMicrophoneStream$']
         );
         currentStreamSubject = new ReplaySubject<MediaStream>(1);
@@ -202,6 +202,7 @@ describe('VideoCallService', () => {
         expect(pexipSpy.disconnect).toHaveBeenCalled();
         expect(heartbeatServiceSpy.stopHeartbeat).toHaveBeenCalledTimes(1);
         expect(setupClientSpy).toHaveBeenCalledTimes(1);
+        expect(userMediaStreamService.closeCurrentStream).toHaveBeenCalledTimes(1);
     });
 
     it('should not disconnect from pexip when api has not been initialised', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -233,6 +233,7 @@ export class VideoCallService {
             this.stopPresentation();
             this.pexipAPI.disconnect();
             this.cleanUpConnection();
+            this.userMediaStreamService.closeCurrentStream();
         } else {
             throw new Error(`${this.loggerPrefix} Pexip Client has not been initialised.`);
         }


### PR DESCRIPTION
### Jira link

VIH-11050

### Change description

### HeartbeatService Improvements:
* Added an `initialising` flag to prevent multiple initializations of the heartbeat service. (`VideoWeb/VideoWeb/ClientApp/src/app/services/conference/heartbeat.service.ts`)

### UserMediaStreamService Enhancements:
* Introduced a `closeCurrentStream` method to stop all tracks of the current stream. (`VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream.service.ts`)

### VideoCallService Updates:
* Updated the `disconnect` method to call the new `closeCurrentStream` method from `UserMediaStreamService`. (`VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts`)
