### PR TITLE
VIH-10931 use the Vodafone feature flag to determine which callback secret to use

### DIFF
--- a/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/VideoEventsController.cs
@@ -41,7 +41,7 @@ public class VideoEventsController(
     {
         try
         {
-            telemetryClient.TrackCustomEvent("KinlyCallback", request);
+            telemetryClient.TrackCustomEvent("SupplierCallback", request);
             
             var conferenceId = Guid.Parse(request.ConferenceId);
             var conference = await conferenceService.GetConference(conferenceId, CancellationToken.None);

--- a/VideoWeb/VideoWeb/Startup.cs
+++ b/VideoWeb/VideoWeb/Startup.cs
@@ -47,7 +47,7 @@ namespace VideoWeb
 
             services.AddCustomTypes();
 
-            services.RegisterAuthSchemes(Configuration);
+            services.RegisterAuthSchemes(Configuration, featureToggles.Vodafone());
             services.AddMvc(opt =>
                 {
                     opt.Filters.Add(typeof(LoggingMiddleware));


### PR DESCRIPTION


### Jira link

VIH-10931

### Change description

This pull request includes various changes to the `VideoWeb` project, primarily focusing on updating authentication schemes and event tracking. The most important changes involve renaming telemetry events, adding a new configuration parameter for Vodafone, and modifying the authentication scheme setup to accommodate this new parameter.

### Telemetry and Event Tracking:

* [`VideoWeb/VideoWeb/Controllers/VideoEventsController.cs`](diffhunk://#diff-02a9a86219f48af5035f671441b5aba9d51928ce23ad0ad79e43c1a35fd85a2aL44-R44): Renamed the telemetry event from "KinlyCallback" to "SupplierCallback".

### Authentication Scheme Configuration:

* [`VideoWeb/VideoWeb/Extensions/ConfigureAuthSchemeExtensions.cs`](diffhunk://#diff-c0b96f0117c7188c9bc542a31a4d0e81c0b3dc5a2f08d41265f599e656f7147bL24-L31): Added a `vodafoneEnabled` parameter to the `RegisterAuthSchemes` method and updated the method to conditionally use Vodafone or Kinly callback secrets based on this parameter. 
