### PR TITLE
VIH-11072 Fix flag evaluation issue with launch darkly service

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.spec.ts
@@ -55,4 +55,25 @@ describe('LaunchDarklyService', () => {
 
         expect(result).toBe(true);
     }));
+
+    it('should wait for flags to be loaded before returning requested flag', fakeAsync(() => {
+        // Arrange
+        service.client = ldClientSpy;
+        const flagKey = FEATURE_FLAGS.dom1SignIn;
+        const keyParam = `change:${flagKey}`;
+        const allFlags: LDFlagSet = { [flagKey]: true };
+        ldClientSpy.allFlags.and.returnValue(allFlags);
+        ldClientSpy.on.withArgs(keyParam, jasmine.anything()).and.returnValue();
+        ldClientSpy.variation.withArgs(flagKey, jasmine.any(Boolean)).and.returnValue(true);
+        let result: boolean;
+
+        // Act
+        service.getFlag<boolean>(flagKey).subscribe(val => (result = val));
+        service.loadAllFlagsAndSetupSubscriptions();
+        ldClientSpy.waitUntilReady.and.returnValue(Promise.resolve());
+        tick();
+
+        // Assert
+        expect(result).toBe(true);
+    }));
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
@@ -19,7 +19,7 @@ export const FEATURE_FLAGS = {
 export class LaunchDarklyService implements OnDestroy {
     client: LDClient;
     private flagSubjects: { [key: string]: BehaviorSubject<LDFlagValue> } = {};
-    private flagsReadySubject = new ReplaySubject<boolean>(1);
+    private readonly flagsReadySubject = new ReplaySubject<boolean>(1);
 
     constructor(private configService: ConfigService) {
         this.vhInitialize();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/launch-darkly.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { LDFlagValue, LDClient, LDContext, initialize } from 'launchdarkly-js-client-sdk';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, ReplaySubject } from 'rxjs';
 import { ConfigService } from './api/config.service';
-import { first, map } from 'rxjs/operators';
+import { first, map, switchMap } from 'rxjs/operators';
 
 export const FEATURE_FLAGS = {
     dom1SignIn: 'dom1',
@@ -19,6 +19,7 @@ export const FEATURE_FLAGS = {
 export class LaunchDarklyService implements OnDestroy {
     client: LDClient;
     private flagSubjects: { [key: string]: BehaviorSubject<LDFlagValue> } = {};
+    private flagsReadySubject = new ReplaySubject<boolean>(1);
 
     constructor(private configService: ConfigService) {
         this.vhInitialize();
@@ -57,12 +58,18 @@ export class LaunchDarklyService implements OnDestroy {
                 this.flagSubjects[flagKey].next(newValue);
             });
         });
+        this.flagsReadySubject.next(true);
+        this.flagsReadySubject.complete();
     }
 
     getFlag<T>(flagKey: string, defaultValue: LDFlagValue = false): Observable<T> {
-        if (!this.flagSubjects[flagKey]) {
-            this.flagSubjects[flagKey] = new BehaviorSubject<LDFlagValue>(defaultValue);
-        }
-        return this.flagSubjects[flagKey].asObservable().pipe(map(value => value as T));
+        return this.flagsReadySubject.asObservable().pipe(
+            switchMap(() => {
+                if (!this.flagSubjects[flagKey]) {
+                    this.flagSubjects[flagKey] = new BehaviorSubject<LDFlagValue>(defaultValue);
+                }
+                return this.flagSubjects[flagKey].asObservable().pipe(map(value => value as T));
+            })
+        );
     }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11072

### Change description
Fixes an issue where dom1 and other feature flags are being incorrectly determined as switched off

- Wait for the flags to load when retrieving a flag, to avoid prematurely evaluating it as unavailable and switched off
- Do this by emitting a value for the `flagsReadySubject` once the flags have been loaded