### PR TITLE
VIH-11084 if there is no screening then only judges and SMs are hosts

### DIFF
--- a/VideoWeb/VideoWeb.Common/Models/Conference.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Conference.cs
@@ -212,6 +212,12 @@ namespace VideoWeb.Common.Models
 
         public List<Guid> GetNonScreenedParticipantsAndEndpoints()
         {
+            var hasScreening = Participants.Exists(x => x.ProtectFrom.Count > 0) ||
+                               Endpoints.Exists(x => x.ProtectFrom.Count > 0);
+            if (!hasScreening)
+            {
+                return Participants.Where(x=> x.IsHost()).Select(x=> x.Id).ToList();
+            }
             var participants = GetNonScreenedParticipants();
             var endpoints = GetNonScreenedEndpoints();
             

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -4,7 +4,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="2.3.10" />
+    <PackageReference Include="BookingsApi.Client" Version="3.0.3" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
-    <PackageReference Include="VideoApi.Client" Version="2.2.28" />
+    <PackageReference Include="VideoApi.Client" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>

--- a/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
+++ b/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
@@ -8,12 +8,12 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="2.3.10" />
+    <PackageReference Include="BookingsApi.Client" Version="3.0.3" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VideoApi.Client" Version="2.2.28" />
+    <PackageReference Include="VideoApi.Client" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/Builders/ConferenceCacheModelBuilder.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Builders/ConferenceCacheModelBuilder.cs
@@ -24,22 +24,28 @@ namespace VideoWeb.UnitTests.Builders
                         .Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
                         .With(x => x.Username = Faker.Internet.Email())
+                        .With(x => x.ExternalReferenceId = Guid.NewGuid().ToString())
                         .With(x => x.Id = Guid.NewGuid()).Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
+                        .With(x => x.ExternalReferenceId = Guid.NewGuid().ToString())
                         .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Individual)
+                        .With(x => x.ExternalReferenceId = Guid.NewGuid().ToString())
                         .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build(),
                     Builder<Participant>.CreateNew().With(x => x.Role = Role.Representative)
+                        .With(x => x.ExternalReferenceId = Guid.NewGuid().ToString())
                         .With(x => x.Username = Faker.Internet.Email())
                         .With(x => x.Id = Guid.NewGuid()).Build()
                 },
                 Endpoints = new List<Endpoint>
                 {
-                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid()).With(x => x.DisplayName = "EP1")
+                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid())
+                        .With(x => x.ExternalReferenceId = Guid.NewGuid().ToString()).With(x => x.DisplayName = "EP1")
                         .Build(),
-                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid()).With(x => x.DisplayName = "EP2")
+                    Builder<Endpoint>.CreateNew().With(x => x.Id = Guid.NewGuid())
+                        .With(x => x.ExternalReferenceId = Guid.NewGuid().ToString()).With(x => x.DisplayName = "EP2")
                         .Build()
                 },
                 HearingVenueName = "Hearing Venue Test"

--- a/VideoWeb/VideoWeb.UnitTests/Common/Models/GetNonScreenedParticipantsAndEndpointsTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Common/Models/GetNonScreenedParticipantsAndEndpointsTests.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using VideoWeb.Common.Models;
+using VideoWeb.UnitTests.Builders;
+
+namespace VideoWeb.UnitTests.Common.Models;
+
+public class GetNonScreenedParticipantsAndEndpointsTests
+{
+    private Conference _conference;
+        
+    [SetUp]
+    public void SetUp()
+    {
+        _conference = new ConferenceCacheModelBuilder().Build();
+        _conference.Participants.ForEach(p => p.ProtectFrom.Clear());
+        _conference.Endpoints.ForEach(e => e.ProtectFrom.Clear());
+    }
+
+    [Test]
+    public void should_return_hosts_only_if_no_participants_have_screening()
+    {
+        _conference.Participants.ForEach(p => p.ProtectFrom.Clear());
+        _conference.Endpoints.ForEach(e => e.ProtectFrom.Clear());
+            
+        var nonScreenedParticipantsAndEndpoints = _conference.GetNonScreenedParticipantsAndEndpoints();
+            
+        nonScreenedParticipantsAndEndpoints.Should().BeEquivalentTo([_conference.GetJudge().Id]);
+    }
+
+    [Test]
+    public void should_return_all_non_protected_participants_when_there_is_screening()
+    {
+        var participant1 = _conference.Participants[0];
+        var endpoint1 = _conference.Endpoints[0];
+            
+        participant1.ProtectFrom.Add(endpoint1.ExternalReferenceId);
+            
+        var nonScreenedParticipantsAndEndpoints = _conference.GetNonScreenedParticipantsAndEndpoints();
+        var expectedParticipants = _conference.Participants.Where(p => p.Id != participant1.Id).Select(p => p.Id);
+        var expectedEndpoints = _conference.Endpoints.Where(e => e.Id != endpoint1.Id).Select(e => e.Id);
+            
+        nonScreenedParticipantsAndEndpoints.Should().BeEquivalentTo(expectedParticipants.Union(expectedEndpoints));
+    }
+}

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="2.2.28" />
+    <PackageReference Include="VideoApi.Client" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -108,9 +108,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[2.2.28, )",
-        "resolved": "2.2.28",
-        "contentHash": "4ctvbUIgzlt7H4jFCdYOup2sTWExFTc27llV3VSY3sjbyVJkKt/9S/CnnJGEUZIOd50dfKiDU+GuFZI1lw5H4w==",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "CZg1mB21pKJyG+x3rFaSD+h0iunmF067eTCHjjYCjh1VYmeJ/dAWnbSLewEnloqlL36ZnKFQcBj1tDDQzVZ/TQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.4"
@@ -173,18 +173,18 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "2.3.10",
-        "contentHash": "VJTd1w16Kp1ipAjMqFOxjGaQHfOyoX+Y6J3cOAvypHCUAkT0vN6RJ3GHpyUT3jbixo7qC/VFa+CVRPNV2dq/uw==",
+        "resolved": "3.0.3",
+        "contentHash": "LhYCQo4ot4cepjL8y659VAi/UD1R6ujIUjpklutyoCwGGPx9kLp3IEyiZXYywojUGUJl6EHx8o/he2IbZKbsBQ==",
         "dependencies": {
-          "BookingsApi.Common.DotNet6": "2.3.10",
+          "BookingsApi.Common.DotNet6": "3.0.3",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.0"
         }
       },
       "BookingsApi.Common.DotNet6": {
         "type": "Transitive",
-        "resolved": "2.3.10",
-        "contentHash": "3IOexrZzkYq+JbaWYs0vXsiFDwIPHttSy1mjxyGHYGoeLk0cndoBZDjJLxP+jnYQfsmEbDM9zAjIGCrB0UKyLA==",
+        "resolved": "3.0.3",
+        "contentHash": "gkiALOAs+FD6Zn6vsgKqI6R+Ko+qGY6vm+WyIPsuXpaZQ4jqGJ6Z56rNmfNXD87KrKwtwk7uE/B63HIS1ZKX/w==",
         "dependencies": {
           "System.Text.Json": "8.0.0"
         }
@@ -2352,7 +2352,7 @@
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "[8.0.1, )",
           "AspNetCore.HealthChecks.Uris": "[8.0.1, )",
-          "BookingsApi.Client": "[2.3.10, )",
+          "BookingsApi.Client": "[3.0.3, )",
           "Castle.Core": "[5.1.1, )",
           "FluentValidation.AspNetCore": "[11.3.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[6.0.0, )",
@@ -2371,7 +2371,7 @@
           "Swashbuckle.AspNetCore": "[6.6.1, )",
           "Swashbuckle.AspNetCore.Annotations": "[6.6.1, )",
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.6.1, )",
-          "VideoApi.Client": "[2.2.28, )",
+          "VideoApi.Client": "[3.0.1, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -2380,7 +2380,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[2.3.10, )",
+          "BookingsApi.Client": "[3.0.3, )",
           "LaunchDarkly.ServerSdk": "[8.5.0, )",
           "Microsoft.ApplicationInsights": "[2.22.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
@@ -2390,14 +2390,14 @@
           "Microsoft.Identity.Client": "[4.61.0, )",
           "StackExchange.Redis": "[2.8.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.2, )",
-          "VideoApi.Client": "[2.2.28, )"
+          "VideoApi.Client": "[3.0.1, )"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[2.3.10, )",
-          "VideoApi.Client": "[2.2.28, )",
+          "BookingsApi.Client": "[3.0.3, )",
+          "VideoApi.Client": "[3.0.1, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
       },

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
-    <PackageReference Include="BookingsApi.Client" Version="2.3.10" />
+    <PackageReference Include="BookingsApi.Client" Version="3.0.3" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
@@ -48,7 +48,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.1" />
-    <PackageReference Include="VideoApi.Client" Version="2.2.28" />
+    <PackageReference Include="VideoApi.Client" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.7" />

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -24,11 +24,11 @@
       },
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[2.3.10, )",
-        "resolved": "2.3.10",
-        "contentHash": "VJTd1w16Kp1ipAjMqFOxjGaQHfOyoX+Y6J3cOAvypHCUAkT0vN6RJ3GHpyUT3jbixo7qC/VFa+CVRPNV2dq/uw==",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "LhYCQo4ot4cepjL8y659VAi/UD1R6ujIUjpklutyoCwGGPx9kLp3IEyiZXYywojUGUJl6EHx8o/he2IbZKbsBQ==",
         "dependencies": {
-          "BookingsApi.Common.DotNet6": "2.3.10",
+          "BookingsApi.Common.DotNet6": "3.0.3",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.0"
         }
@@ -229,9 +229,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[2.2.28, )",
-        "resolved": "2.2.28",
-        "contentHash": "4ctvbUIgzlt7H4jFCdYOup2sTWExFTc27llV3VSY3sjbyVJkKt/9S/CnnJGEUZIOd50dfKiDU+GuFZI1lw5H4w==",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "CZg1mB21pKJyG+x3rFaSD+h0iunmF067eTCHjjYCjh1VYmeJ/dAWnbSLewEnloqlL36ZnKFQcBj1tDDQzVZ/TQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.4"
@@ -268,8 +268,8 @@
       },
       "BookingsApi.Common.DotNet6": {
         "type": "Transitive",
-        "resolved": "2.3.10",
-        "contentHash": "3IOexrZzkYq+JbaWYs0vXsiFDwIPHttSy1mjxyGHYGoeLk0cndoBZDjJLxP+jnYQfsmEbDM9zAjIGCrB0UKyLA==",
+        "resolved": "3.0.3",
+        "contentHash": "gkiALOAs+FD6Zn6vsgKqI6R+Ko+qGY6vm+WyIPsuXpaZQ4jqGJ6Z56rNmfNXD87KrKwtwk7uE/B63HIS1ZKX/w==",
         "dependencies": {
           "System.Text.Json": "8.0.0"
         }
@@ -1896,7 +1896,7 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[2.3.10, )",
+          "BookingsApi.Client": "[3.0.3, )",
           "LaunchDarkly.ServerSdk": "[8.5.0, )",
           "Microsoft.ApplicationInsights": "[2.22.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
@@ -1906,14 +1906,14 @@
           "Microsoft.Identity.Client": "[4.61.0, )",
           "StackExchange.Redis": "[2.8.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.2, )",
-          "VideoApi.Client": "[2.2.28, )"
+          "VideoApi.Client": "[3.0.1, )"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[2.3.10, )",
-          "VideoApi.Client": "[2.2.28, )",
+          "BookingsApi.Client": "[3.0.3, )",
+          "VideoApi.Client": "[3.0.1, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
### Jira link

VIH-11084

### Change description

This pull request includes several updates to the `VideoWeb` project, focusing on enhancing the functionality of the `GetNonScreenedParticipantsAndEndpoints` method, updating package dependencies, and adding unit tests.

### Enhancements to `GetNonScreenedParticipantsAndEndpoints` method:

* [`VideoWeb/VideoWeb.Common/Models/Conference.cs`](diffhunk://#diff-3433ff3d66a049500148fe6ca52abe84dd11ba56e74ec1c271e44a315aef1598R215-R220): Modified the `GetNonScreenedParticipantsAndEndpoints` method to return only host participants if no participants or endpoints have screening.

### Package updates:

* Update API Clients
