### PR TITLE
VIH-11125 bugfix QL unable to start a consultation

### DIFF
--- a/VideoWeb/VideoWeb.Common/Models/Conference.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Conference.cs
@@ -168,24 +168,35 @@ namespace VideoWeb.Common.Models
         /// <param name="endpointIds">List of endpoints to be in a consultation</param>
         public bool AreEntitiesScreenedFromEachOther(List<Guid> participantIds, List<Guid> endpointIds)
         {
-            var allExternalReferenceIds = Participants.Select(x => x.ExternalReferenceId)
+            var allExternalReferenceIds = Participants
+                .Where(SupportsScreening)
+                .Select(x => x.ExternalReferenceId)
                 .Union(Endpoints.Select(x => x.ExternalReferenceId)).ToList();
 
             foreach (var participantId in participantIds)
             {
                 var participant = Participants.Find(x => x.Id == participantId);
-                if (participant == null) continue;
-                if (participant.ProtectFrom.Exists(allExternalReferenceIds.Contains)) return true;
+                if (participant != null && participant.ProtectFrom.Exists(allExternalReferenceIds.Contains))
+                {
+                    return true;
+                }
             }
             
             foreach (var endpointId in endpointIds)
             {
                 var endpoint = Endpoints.Find(x => x.Id == endpointId);
-                if (endpoint == null) continue;
-                if (endpoint.ProtectFrom.Exists(allExternalReferenceIds.Contains)) return true;
+                if (endpoint != null && endpoint.ProtectFrom.Exists(allExternalReferenceIds.Contains))
+                {
+                    return true;
+                }
             }
 
             return false;
+        }
+
+        private static bool SupportsScreening(Participant participant1)
+        {
+            return !participant1.IsQuickLinkUser() && !participant1.IsHost() && !participant1.IsJudicialOfficeHolder();
         }
 
         /// <summary>

--- a/VideoWeb/VideoWeb.Common/Models/Conference.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Conference.cs
@@ -169,10 +169,10 @@ namespace VideoWeb.Common.Models
         public bool AreEntitiesScreenedFromEachOther(List<Guid> participantIds, List<Guid> endpointIds)
         {
             var allExternalReferenceIds = Participants
-                .Where(SupportsScreening)
+                .Where(p => participantIds.Contains(p.Id) && SupportsScreening(p))
                 .Select(x => x.ExternalReferenceId)
-                .Union(Endpoints.Select(x => x.ExternalReferenceId)).ToList();
-
+                .Union(Endpoints.Where(e => endpointIds.Contains(e.Id)).Select(e => e.ExternalReferenceId)).ToList();
+            
             foreach (var participantId in participantIds)
             {
                 var participant = Participants.Find(x => x.Id == participantId);

--- a/VideoWeb/VideoWeb.UnitTests/Models/Conference/AreEntitiesScreenedFromEachOtherTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Models/Conference/AreEntitiesScreenedFromEachOtherTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
@@ -13,6 +14,16 @@ public class AreEntitiesScreenedFromEachOtherTests
     {
         var conference = new ConferenceCacheModelBuilder()
             .Build();
+
+        var quickLinkParticipant = new Participant()
+        {
+            Id = Guid.NewGuid(),
+            ExternalReferenceId = null,
+            Role = Role.QuickLinkParticipant,
+            HearingRole = "Quick Link Participant",
+            DisplayName = "QL 1"
+        };
+        conference.AddParticipant(quickLinkParticipant);
         
         var participantIds = conference.Participants.Select(x => x.Id).ToList();
         var endpointIds = conference.Endpoints.Select(x => x.Id).ToList();

--- a/VideoWeb/VideoWeb.UnitTests/Models/Conference/CanParticipantJoinConsultationRoomTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Models/Conference/CanParticipantJoinConsultationRoomTests.cs
@@ -15,6 +15,7 @@ public class CanParticipantJoinConsultationRoomTests
         // Arrange
         var conference = new ConferenceCacheModelBuilder()
             .Build();
+        
         var nonHostParticipants = conference.Participants.Where(x => !x.IsHost()).ToList();
         var participant = nonHostParticipants[0];
         
@@ -26,6 +27,17 @@ public class CanParticipantJoinConsultationRoomTests
         conference.ConsultationRooms.Add(consultationRoom);
         patInRoom.CurrentRoom = consultationRoom;
         endpoint.CurrentRoom = consultationRoom;
+        
+        var quickLinkParticipant = new Participant()
+        {
+            Id = Guid.NewGuid(),
+            ExternalReferenceId = null,
+            Role = Role.QuickLinkParticipant,
+            HearingRole = "Quick Link Participant",
+            DisplayName = "QL 1",
+            CurrentRoom = consultationRoom
+        };
+        conference.AddParticipant(quickLinkParticipant);
 
         // Act
         var result = conference.CanParticipantJoinConsultationRoom(roomLabel, participant.Id);

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { from, Observable, of, ReplaySubject, zip } from 'rxjs';
-import 'webrtc-adapter';
 import { UserMediaDevice } from '../shared/models/user-media-device';
 import { Logger } from './logging/logger-base';
 import { catchError, filter, map, mergeMap, retry, take } from 'rxjs/operators';


### PR DESCRIPTION
### Jira link

VIH-11125

### Change description

Improvements to participant screening:

* [`VideoWeb/VideoWeb.Common/Models/Conference.cs`](diffhunk://#diff-3433ff3d66a049500148fe6ca52abe84dd11ba56e74ec1c271e44a315aef1598L171-R201): Modified the `AreEntitiesScreenedFromEachOther` method to exclude certain participant roles from screening and added a helper method `SupportsScreening` to encapsulate this logic.
