### PR TITLE
VIH-11130 bug fix initialise call tag on setup client rather than before each call

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -209,7 +209,6 @@ describe('VideoCallService', () => {
 
         await service.makeCall(node, conferenceAlias, participantDisplayName, maxBandwidth, null);
         expect(pexipSpy.makeCall).toHaveBeenCalledWith(node, conferenceAlias, participantDisplayName, maxBandwidth, callType);
-        expect(pexipSpy.call_tag).toBeDefined();
     });
 
     it('should call pexip with as receive only when user does not have devices', async () => {
@@ -223,7 +222,6 @@ describe('VideoCallService', () => {
 
         await service.makeCall(node, conferenceAlias, participantDisplayName, maxBandwidth, '12345');
         expect(pexipSpy.makeCall).toHaveBeenCalledWith(node, conferenceAlias, participantDisplayName, maxBandwidth, callType);
-        expect(pexipSpy.call_tag).toBeDefined();
         expect(userMediaService.updateStartWithAudioMuted).toHaveBeenCalledWith('12345', true);
     });
 
@@ -238,7 +236,6 @@ describe('VideoCallService', () => {
 
         await service.makeCall(node, conferenceAlias, participantDisplayName, maxBandwidth, '12345');
         expect(pexipSpy.makeCall).toHaveBeenCalledWith(node, conferenceAlias, participantDisplayName, maxBandwidth, callType);
-        expect(pexipSpy.call_tag).toBeDefined();
     });
 
     it('should init the call tag', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -188,6 +188,7 @@ export class VideoCallService {
 
     initCallTag() {
         this.pexipAPI.call_tag = Guid.create().toString();
+        this.logger.debug(`${this.loggerPrefix} call tag set to ${this.pexipAPI.call_tag}`);
     }
 
     async makeCall(pexipNode: string, conferenceAlias: string, participantDisplayName: string, maxBandwidth: number, conferenceId: string) {
@@ -579,7 +580,6 @@ export class VideoCallService {
             pexipNode: pexipNode
         });
         this.stopPresentation();
-        this.initCallTag();
         this.pexipAPI.makeCall(pexipNode, conferenceAlias, participantDisplayName, maxBandwidth, callType);
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
@@ -97,7 +97,7 @@ export class ConferenceEffects {
                         return of();
                     }
                     // the pexip info is not set when in the waiting room so we have to default to the video call service
-                    const callTag = participant?.pexipInfo?.callTag ?? this.videoCallService.pexipAPI?.call_tag;
+                    const callTag = this.videoCallService.pexipAPI?.call_tag ?? participant?.pexipInfo?.callTag;
                     if (action.reason.includes(`connected on another device ${callTag}`)) {
                         this.errorService.goToServiceError(
                             'error-service.unexpected-error',

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.ts
@@ -97,7 +97,7 @@ export class ConferenceEffects {
                         return of();
                     }
                     // the pexip info is not set when in the waiting room so we have to default to the video call service
-                    const callTag = participant?.pexipInfo?.callTag ?? this.videoCallService.pexipAPI.call_tag;
+                    const callTag = participant?.pexipInfo?.callTag ?? this.videoCallService.pexipAPI?.call_tag;
                     if (action.reason.includes(`connected on another device ${callTag}`)) {
                         this.errorService.goToServiceError(
                             'error-service.unexpected-error',


### PR DESCRIPTION
### Jira link

VIH-11130

### Change description

* **Bug fix**: initialise call tag on setup client rather than before each call
  * This will effectively give a participant the same call tag per session (i.e until they refresh the browser)

This change will need a bit of rigorous testing to avoid any uncertain side effects but should make connection less complex for the new supplier