### PR TITLE
VIH-11123 Fix typo in hearing readiness message in English localization

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
+++ b/VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json
@@ -515,7 +515,7 @@
     "lock-the-room": "Lock the room to prevent others joining",
     "invite-others": "Invite others by calling them or unlock the room for others to join",
     "witness-transferring-warning-img": "Witness transferring warning image",
-    "hearing-ready": "Please get ready <br/> You'll &thinsp; join the hearing in a few seconds",
+    "hearing-ready": "Please get ready <br/> You'll join the hearing in a few seconds",
     "your-video-hearing": "Your video hearing",
     "choose-camera-and-microphone": "Choose camera and microphone",
     "choose-camera-and-microphone-aria-label": "Choose camera and microphone dialog",


### PR DESCRIPTION
### Jira link

VIH-11123

### Change description

This pull request includes a minor update to the `en.json` file to correct a typographical error.

* [`VideoWeb/VideoWeb/ClientApp/src/assets/i18n/en.json`](diffhunk://#diff-06ccab0b90df1765c8177815fedd9949b3ced4b1a38af1a26b9aaba47d134a77L518-R518): Removed an unnecessary non-breaking space (`&thinsp;`) from the "hearing-ready" message.