### PR TITLE
VIH-11134 bugfix additional handling of null streams

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/package-lock.json
+++ b/VideoWeb/VideoWeb/ClientApp/package-lock.json
@@ -96,7 +96,7 @@
         "ng-mocks": "^14.12.2",
         "nswag": "^14.1.0",
         "prettier": "^3.3.3",
-        "puppeteer": "^23.6.0",
+        "puppeteer": "^23.7.1",
         "run-script-os": "^1.1.6",
         "sass": "^1.77.8",
         "typescript": ">=5.2.0 <5.4.0"
@@ -5087,12 +5087,12 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
-      "integrity": "sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
+      "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.3.6",
+        "debug": "^4.3.7",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.4.0",
@@ -15317,17 +15317,17 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.6.0.tgz",
-      "integrity": "sha512-l+Fgo8SVFSd51STtq2crz8t1Y3VXowsuR4zfR64qDOn6oggz7YIZauWiNR4IJjczQ6nvFs3S4cgng55/nesxTQ==",
+      "version": "23.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.7.1.tgz",
+      "integrity": "sha512-jS6XehagMvxQ12etwY/4EOYZ0Sm8GAsrtGhdQn4AqpJAyHc3RYl7tGd4QYh/MmShDw8sF9FWYQqGidhoXaqokQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.4.0",
+        "@puppeteer/browsers": "2.4.1",
         "chromium-bidi": "0.8.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1354347",
-        "puppeteer-core": "23.6.0",
+        "puppeteer-core": "23.7.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -15338,12 +15338,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.6.0.tgz",
-      "integrity": "sha512-se1bhgUpR9C529SgHGr/eyT92mYyQPAhA2S9pGtGrVG2xob9qE6Pbp7TlqiSPlnnY1lINqhn6/67EwkdzOmKqQ==",
+      "version": "23.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.7.1.tgz",
+      "integrity": "sha512-Om/qCZhd+HLoAr7GltrRAZpS3uOXwHu7tXAoDbNcJADHjG2zeAlDArgyIPXYGG4QB/EQUHk13Q6RklNxGM73Pg==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.4.0",
+        "@puppeteer/browsers": "2.4.1",
         "chromium-bidi": "0.8.0",
         "debug": "^4.3.7",
         "devtools-protocol": "0.0.1354347",

--- a/VideoWeb/VideoWeb/ClientApp/package.json
+++ b/VideoWeb/VideoWeb/ClientApp/package.json
@@ -114,7 +114,7 @@
     "ng-mocks": "^14.12.2",
     "nswag": "^14.1.0",
     "prettier": "^3.3.3",
-    "puppeteer": "^23.6.0",
+    "puppeteer": "^23.7.1",
     "run-script-os": "^1.1.6",
     "sass": "^1.77.8",
     "typescript": ">=5.2.0 <5.4.0"

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream-v2.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream-v2.service.ts
@@ -89,8 +89,8 @@ export class UserMediaStreamServiceV2 {
 
         this.logger.debug(`${this.loggerPrefix} Creating and publishing new stream.`, {
             audioOnly: this.audioOnly,
-            currentMicDevice: this.currentMicDevice?.label,
-            currentCamDevice: this.currentCamDevice?.label
+            currentMicDevice: this.currentMicDevice?.label ?? 'No Microphone Device',
+            currentCamDevice: this.currentCamDevice?.label ?? 'No Camera Device'
         });
 
         zip(audioStream$, videoStream$)
@@ -113,6 +113,9 @@ export class UserMediaStreamServiceV2 {
     }
 
     private combineAudioAndVideoStreams(audioStream: MediaStream, videoStream: MediaStream): MediaStream {
-        return this.mediaStreamService.initialiseNewStream([...audioStream?.getAudioTracks(), ...videoStream?.getVideoTracks()]);
+        return this.mediaStreamService.initialiseNewStream([
+            ...(audioStream ? audioStream.getAudioTracks() : []),
+            ...(videoStream ? videoStream.getVideoTracks() : [])
+        ]);
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream-v2.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream-v2.service.ts
@@ -113,6 +113,6 @@ export class UserMediaStreamServiceV2 {
     }
 
     private combineAudioAndVideoStreams(audioStream: MediaStream, videoStream: MediaStream): MediaStream {
-        return this.mediaStreamService.initialiseNewStream([...audioStream.getAudioTracks(), ...videoStream.getVideoTracks()]);
+        return this.mediaStreamService.initialiseNewStream([...audioStream?.getAudioTracks(), ...videoStream?.getVideoTracks()]);
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts
@@ -88,9 +88,26 @@ export class UserMediaService {
                 const filteredDevices = devices.filter(
                     x => x.deviceId !== 'default' && x.deviceId !== 'communications' && (x.kind === 'videoinput' || x.kind === 'audioinput')
                 );
-                return filteredDevices.length > 0 ? filteredDevices : devices;
+                const defaultMicGroupId = devices.find(x => x.kind === 'audioinput' && x.deviceId === 'default')?.groupId;
+                const defaultCamGroupId = devices.find(x => x.kind === 'videoinput' && x.deviceId === 'default')?.groupId;
+                const resultDevices = filteredDevices.length > 0 ? filteredDevices : devices;
+                return {
+                    defaultCamGroupId,
+                    defaultMicGroupId,
+                    resultDevices
+                };
             }),
-            map(devices => devices.map(device => new UserMediaDevice(device.label, device.deviceId, device.kind, device.groupId)))
+            map(({ defaultCamGroupId, defaultMicGroupId, resultDevices }) => {
+                const sortedDevices = resultDevices
+                    .map(device => new UserMediaDevice(device.label, device.deviceId, device.kind, device.groupId))
+                    .sort((a, b) => {
+                        const aIsDefault = a.groupId === defaultCamGroupId || a.groupId === defaultMicGroupId;
+                        const bIsDefault = b.groupId === defaultCamGroupId || b.groupId === defaultMicGroupId;
+                        return aIsDefault === bIsDefault ? 0 : aIsDefault ? -1 : 1;
+                    });
+
+                return sortedDevices;
+            })
         );
     }
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts
@@ -103,7 +103,13 @@ export class UserMediaService {
                     .sort((a, b) => {
                         const aIsDefault = a.groupId === defaultCamGroupId || a.groupId === defaultMicGroupId;
                         const bIsDefault = b.groupId === defaultCamGroupId || b.groupId === defaultMicGroupId;
-                        return aIsDefault === bIsDefault ? 0 : aIsDefault ? -1 : 1;
+                        if (aIsDefault === bIsDefault) {
+                            return 0;
+                        } else if (aIsDefault) {
+                            return -1;
+                        } else {
+                            return 1;
+                        }
                     });
 
                 return sortedDevices;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/select-media-devices/select-media-devices.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/select-media-devices/select-media-devices.component.spec.ts
@@ -204,6 +204,14 @@ describe('SelectMediaDevicesComponent', () => {
             expect(component.connectWithCameraOn).toBeFalsy();
         }));
 
+        it('should handle null streams', fakeAsync(() => {
+            getSpiedPropertyGetter(userMediaStreamServiceSpy, 'currentStream$').and.returnValue(of(null));
+            component.ngOnInit();
+            flushMicrotasks();
+            expect(component.selectedCameraStream).toBeNull();
+            expect(component.selectedMicrophoneStream).toBeNull();
+        }));
+
         it('should initialise the device form on init', fakeAsync(() => {
             component.ngOnInit();
             flushMicrotasks();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/select-media-devices/select-media-devices.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/select-media-devices/select-media-devices.component.ts
@@ -82,6 +82,11 @@ export class SelectMediaDevicesComponent implements OnInit, OnDestroy, AfterView
         });
 
         this.userMediaStreamService.currentStream$.pipe(takeUntil(this.destroyedSubject)).subscribe(stream => {
+            if (!stream) {
+                this.selectedCameraStream = null;
+                this.selectedMicrophoneStream = null;
+                return;
+            }
             // Extract audio tracks and create a new MediaStream for the microphone
             const audioTracks = stream.getAudioTracks();
             this.selectedMicrophoneStream = new MediaStream(audioTracks);


### PR DESCRIPTION
### Jira link

VIH-11134
### Change description

This pull request includes several updates to improve the handling of media devices and streams in the `VideoWeb` application. The changes include adding null checks, restructuring the return values, and sorting devices to prioritize defaults.

### Improvements to media stream handling:

* [`VideoWeb/VideoWeb/ClientApp/src/app/services/user-media-stream-v2.service.ts`](diffhunk://#diff-d1c13d4b18580c21d3396394840f016430e319f6b81231036e79752bb26e911cL116-R116): Added null checks to ensure that audio and video tracks are safely accessed when combining streams.

### Enhancements to media device selection:

* [`VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.ts`](diffhunk://#diff-bb96c235363777c66ead262d9d70746c73e389898627b8c365e18d47492aae20L91-R110): Modified the device filtering logic to return an object containing default group IDs and devices, and added sorting to prioritize default devices.

### UI updates for media device selection:

* [`VideoWeb/VideoWeb/ClientApp/src/app/shared/select-media-devices/select-media-devices.component.ts`](diffhunk://#diff-6db0e16618a06b49a1b79ad4d942913762520bfc5944af3448802961d4b54a4fR85-R89): Added checks to handle cases where the stream is null, ensuring that selected camera and microphone streams are reset appropriately.