### PR TITLE
VIH-11136 remove unused vars and imports add unused imports to lint

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/.eslintrc.js
+++ b/VideoWeb/VideoWeb/ClientApp/.eslintrc.js
@@ -24,9 +24,17 @@ module.exports = {
         project: 'tsconfig.json',
         sourceType: 'module'
     },
-    plugins: ['eslint-plugin-import', '@angular-eslint/eslint-plugin', '@typescript-eslint', '@typescript-eslint/tslint', 'jasmine'],
+    plugins: [
+        'eslint-plugin-import',
+        '@angular-eslint/eslint-plugin',
+        '@typescript-eslint',
+        '@typescript-eslint/tslint',
+        'jasmine',
+        'unused-imports'
+    ],
     root: true,
     rules: {
+        'unused-imports/no-unused-imports': 'error',
         'jasmine/no-focused-tests': 'error',
         '@angular-eslint/component-class-suffix': 'error',
         '@angular-eslint/directive-class-suffix': 'error',

--- a/VideoWeb/VideoWeb/ClientApp/package-lock.json
+++ b/VideoWeb/VideoWeb/ClientApp/package-lock.json
@@ -81,6 +81,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jasmine": "^4.1.3",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "install-peers": "^1.0.3",
         "jasmine-core": "~4.6.0",
         "jasmine-marbles": "^0.8.0",
@@ -9320,6 +9321,21 @@
       "engines": {
         "node": ">=8",
         "npm": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/VideoWeb/VideoWeb/ClientApp/package.json
+++ b/VideoWeb/VideoWeb/ClientApp/package.json
@@ -99,6 +99,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jasmine": "^4.1.3",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "install-peers": "^1.0.3",
     "jasmine-core": "~4.6.0",
     "jasmine-marbles": "^0.8.0",

--- a/VideoWeb/VideoWeb/ClientApp/src/app/security/logout/logout.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/security/logout/logout.component.spec.ts
@@ -8,7 +8,7 @@ import { ISecurityService } from '../authentication/security-service.interface';
 import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { pageUrls } from '../../shared/page-url.constants';
-import { LaunchDarklyService, FEATURE_FLAGS } from 'src/app/services/launch-darkly.service';
+import { LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 import { IdpProviders } from '../idp-providers';
 
 describe('LogoutComponent', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/security/multiple-idp-interceptor.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/security/multiple-idp-interceptor.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { MultipleIdpInterceptorService } from './multiple-idp-interceptor.service';
 import { SecurityServiceProvider } from './authentication/security-provider.service';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/security/participant-waiting-room.guard.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/security/participant-waiting-room.guard.spec.ts
@@ -1,4 +1,3 @@
-import { async } from '@angular/core/testing';
 import { convertToParamMap, Router } from '@angular/router';
 import { VideoWebService } from '../services/api/video-web.service';
 import { ConferenceResponse, ConferenceStatus } from '../services/clients/api-client';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/conference.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/conference.service.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, flush } from '@angular/core/testing';
-import { ActivatedRoute, ActivatedRouteSnapshot, convertToParamMap, Event, NavigationEnd, ParamMap, Router } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, convertToParamMap, Event, NavigationEnd, Router } from '@angular/router';
 import { Guid } from 'guid-typescript';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache-local-storage.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control-cache-local-storage.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { fakeAsync, flush } from '@angular/core/testing';
 import { LoggerService } from '../logging/logger.service';
 import { LocalStorageService } from './local-storage.service';
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/conference/video-control.service.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
 import { Guid } from 'guid-typescript';
-import { Observable, of, Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 import { ParticipantModel } from 'src/app/shared/models/participant';
 import { HearingRole } from 'src/app/waiting-space/models/hearing-role-model';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/error.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/error.service.spec.ts
@@ -10,8 +10,7 @@ import { ErrorMessage } from '../shared/models/error-message';
 import { ConnectionStatusService } from './connection-status.service';
 import { connectionStatusServiceSpyFactory } from '../testing/mocks/mock-connection-status.service';
 import { LocationService } from './location.service';
-import { Observable, of } from 'rxjs';
-import { Subject } from 'rxjs';
+import { of } from 'rxjs';
 
 describe('ErrorService', () => {
     const mockLogger: Logger = new MockLogger();

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/user-media.service.spec.ts
@@ -3,7 +3,7 @@ import { MockLogger } from '../testing/mocks/mock-logger';
 import { UserMediaService } from './user-media.service';
 import { LocalStorageService } from './conference/local-storage.service';
 import { of, Subject, throwError } from 'rxjs';
-import { fakeAsync, flush, tick } from '@angular/core/testing';
+import { fakeAsync, flush } from '@angular/core/testing';
 import { UserMediaDevice } from '../shared/models/user-media-device';
 import { Guid } from 'guid-typescript';
 import { ConferenceSetting } from '../shared/models/conference-setting';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/accessibility/accessibility.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/accessibility/accessibility.component.spec.ts
@@ -1,4 +1,3 @@
-import { async, waitForAsync } from '@angular/core/testing';
 import { ScrolledEvent, ScrolledFooter } from '../models/scrolled-event';
 import { AccessibilityComponent } from './accessibility.component';
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/back-navigation/back-navigation.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/back-navigation/back-navigation.component.spec.ts
@@ -1,4 +1,3 @@
-import { Location } from '@angular/common';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/directives/desktop-only.directive.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/directives/desktop-only.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Directive, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Component } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DeviceTypeService } from 'src/app/services/device-type.service';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/directives/tooltip.directive.spec.ts
@@ -1,5 +1,4 @@
 import { ElementRef, Renderer2 } from '@angular/core';
-import * as exp from 'constants';
 import { DeviceTypeService } from 'src/app/services/device-type.service';
 import { TooltipDirective } from './tooltip.directive';
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/error/error.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/error/error.component.spec.ts
@@ -1,8 +1,8 @@
-import { Component, Pipe, PipeTransform } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync, getTestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NavigationEnd, NavigationExtras, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Logger } from 'src/app/services/logging/logger-base';
 import { PageTrackerService } from 'src/app/services/page-tracker.service';
 import { MockLogger } from 'src/app/testing/mocks/mock-logger';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/shared/models/judge-hearing-summary.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/shared/models/judge-hearing-summary.spec.ts
@@ -1,4 +1,4 @@
-import { ConferenceForHostResponse, ConferenceStatus, ParticipantForHostResponse, Role } from 'src/app/services/clients/api-client';
+import { ConferenceForHostResponse, ConferenceStatus, Role } from 'src/app/services/clients/api-client';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { HearingRole } from 'src/app/waiting-space/models/hearing-role-model';
 import { HearingSummary } from './hearing-summary';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/admin-hearing/admin-hearing.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/admin-hearing/admin-hearing.component.spec.ts
@@ -3,7 +3,7 @@ import { Hearing } from 'src/app/shared/models/hearing';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { AdminHearingComponent } from './admin-hearing.component';
 import { FEATURE_FLAGS, LaunchDarklyService } from '../../services/launch-darkly.service';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 describe('AdminHearingComponent', () => {
     let component: AdminHearingComponent;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/command-centre/tests/command-centre.component-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/command-centre/tests/command-centre.component-events.spec.ts
@@ -36,7 +36,6 @@ import {
 import { MockLogger } from 'src/app/testing/mocks/mock-logger';
 import { VhoQueryService } from '../../services/vho-query-service.service';
 import { CommandCentreComponent } from '../command-centre.component';
-import { FEATURE_FLAGS, LaunchDarklyService } from '../../../services/launch-darkly.service';
 import { NotificationToastrService } from '../../../waiting-space/services/notification-toastr.service';
 import { NewAllocationMessage } from '../../../services/models/new-allocation-message';
 import { HearingDetailRequest } from 'src/app/services/clients/api-client';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/copy-quick-link/copy-quick-link.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/copy-quick-link/copy-quick-link.component.spec.ts
@@ -5,9 +5,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateService } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 import { ClipboardService } from 'ngx-clipboard';
-import { ConferenceResponseVho } from 'src/app/services/clients/api-client';
 import { TranslatePipeMock } from 'src/app/testing/mocks/mock-translation-pipe';
-import { VhoQueryService } from '../services/vho-query-service.service';
 import { CopyQuickLinkComponent } from './copy-quick-link.component';
 
 describe('CopyQuickLinkComponent', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/court-rooms-filters/court-rooms-filters.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/court-rooms-filters/court-rooms-filters.component.spec.ts
@@ -1,5 +1,4 @@
 import { CourtRoomsFiltersComponent } from './court-rooms-filters.component';
-import { EventBusService } from 'src/app/services/event-bus.service';
 import { CourtRoomsAccounts } from '../services/models/court-rooms-accounts';
 import { VhoQueryService } from '../services/vho-query-service.service';
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/monitoring-graph/monitoring-graph.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/monitoring-graph/monitoring-graph.component.spec.ts
@@ -1,6 +1,5 @@
 import { MonitoringGraphComponent } from '../monitoring-graph/monitoring-graph.component';
 import { MonitorGraphService } from '../services/monitor-graph.service';
-import { GraphSettings } from '../services/models/graph-settings';
 import { PackageLost } from '../services/models/package-lost';
 import { ParticipantGraphInfo } from '../services/models/participant-graph-info';
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages-participant/unread-messages-participant.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/vh-officer/unread-messages-participant/unread-messages-participant.component.spec.ts
@@ -1,6 +1,5 @@
 import { VideoWebService } from 'src/app/services/api/video-web.service';
 import { UnreadAdminMessageResponse } from 'src/app/services/clients/api-client';
-import { EventsService } from 'src/app/services/events.service';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { MockLogger } from 'src/app/testing/mocks/mock-logger';
 import { Hearing } from '../../shared/models/hearing';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/joh-waiting-room/joh-waiting-room.component.spec.ts
@@ -1,5 +1,4 @@
 import { fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
 import {
     ConferenceResponse,
     ConferenceStatus,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.spec.ts
@@ -58,7 +58,6 @@ import { createParticipantRemoteMuteStoreServiceSpy } from '../services/mock-par
 import { ParticipantUpdated } from '../models/video-call-models';
 import { PexipDisplayNameModel } from '../../services/conference/models/pexip-display-name.model';
 import { WaitingRoomBaseDirective } from '../waiting-room-shared/waiting-room-base.component';
-import { videoCallServiceSpy } from '../../testing/mocks/mock-video-call.service';
 import { FEATURE_FLAGS } from 'src/app/services/launch-darkly.service';
 import { ConferenceStatusMessage } from '../../services/models/conference-status-message';
 import { audioRecordingServiceSpy } from '../../testing/mocks/mock-audio-recording.service';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/mute-microphone/mute-microphone.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/mute-microphone/mute-microphone.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture } from '@angular/core/testing';
 
 import { MuteMicrophoneComponent } from './mute-microphone.component';
 import { FormBuilder } from '@angular/forms';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participant-status/private-consultation-participant-status.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participant-status/private-consultation-participant-status.component.spec.ts
@@ -1,13 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MockComponent, MockPipe } from 'ng-mocks';
-import {
-    VideoEndpointResponse,
-    EndpointStatus,
-    ParticipantResponse,
-    ParticipantStatus,
-    RoomSummaryResponse
-} from 'src/app/services/clients/api-client';
+import { EndpointStatus, ParticipantStatus } from 'src/app/services/clients/api-client';
 import { RoomNamePipe } from 'src/app/shared/pipes/room-name.pipe';
 
 import { PrivateConsultationParticipantStatusComponent } from './private-consultation-participant-status.component';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/start-private-consultation/start-private-consultation.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/start-private-consultation/start-private-consultation.component.spec.ts
@@ -4,7 +4,6 @@ import {
     EndpointStatus,
     LinkType,
     LoggedParticipantResponse,
-    ParticipantResponse,
     ParticipantStatus,
     Role
 } from 'src/app/services/clients/api-client';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.analogue-time.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.analogue-time.spec.ts
@@ -33,7 +33,7 @@ import { of, Subject } from 'rxjs';
 import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 import { createParticipantRemoteMuteStoreServiceSpy } from '../../services/mock-participant-remote-mute-store.service';
 import { UserMediaService } from 'src/app/services/user-media.service';
-import { FEATURE_FLAGS, LaunchDarklyService } from 'src/app/services/launch-darkly.service';
+import { FEATURE_FLAGS } from 'src/app/services/launch-darkly.service';
 
 describe('ParticipantWaitingRoomComponent message and clock', () => {
     let component: ParticipantWaitingRoomComponent;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.eventhub.events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/tests/participant-waiting-room.component.eventhub.events.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { Guid } from 'guid-typescript';
-import { ConferenceResponse, ConferenceStatus, ParticipantResponse, Role } from 'src/app/services/clients/api-client';
+import { ConferenceResponse, ConferenceStatus, ParticipantResponse } from 'src/app/services/clients/api-client';
 import { ConferenceStatusMessage } from 'src/app/services/models/conference-status-message';
 import { hearingStatusSubjectMock } from 'src/app/testing/mocks/mock-events-service';
 import { Hearing } from '../../../shared/models/hearing';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-sounds.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/notification-sounds.service.spec.ts
@@ -1,6 +1,5 @@
 import { MockLogger } from 'src/app/testing/mocks/mock-logger';
 import { NotificationSoundsService } from './notification-sounds.service';
-import { fakeAsync, tick } from '@angular/core/testing';
 
 describe('NotificationSoundsService', () => {
     let service: NotificationSoundsService;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/room-closing-toast.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/room-closing-toast.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import * as moment from 'moment';
-import { ToastrService, ActiveToast, Toast } from 'ngx-toastr';
+import { ToastrService, ActiveToast } from 'ngx-toastr';
 import { Subject } from 'rxjs';
 import { ConferenceStatus } from 'src/app/services/clients/api-client';
 import { Logger } from 'src/app/services/logging/logger-base';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/conference.effects.spec.ts
@@ -5,7 +5,7 @@ import { Observable, of } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing'; // import this
 
 import { ConferenceEffects } from './conference.effects';
-import { ApiClient, ParticipantStatus, Role } from 'src/app/services/clients/api-client';
+import { ApiClient, ParticipantStatus } from 'src/app/services/clients/api-client';
 import { ConferenceActions } from '../actions/conference.actions';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { mapConferenceToVHConference, mapParticipantToVHParticipant } from '../models/api-contract-to-state-model-mappers';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.spec.ts
@@ -1,13 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { NotificationEffects } from './notification.effects';
 import { ConferenceActions } from '../actions/conference.actions';
 import { NotificationToastrService } from '../../services/notification-toastr.service';
-import { Store } from '@ngrx/store';
 import { ConferenceState } from '../reducers/conference.reducer';
 import * as ConferenceSelectors from '../selectors/conference.selectors';
-import { ParticipantStatus, Role } from 'src/app/services/clients/api-client';
+import { Role } from 'src/app/services/clients/api-client';
 import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
 import { mapConferenceToVHConference } from '../models/api-contract-to-state-model-mappers';
 import { createMockStore, MockStore, provideMockStore } from '@ngrx/store/testing';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.eventhub-events.spec.ts
@@ -96,7 +96,6 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { FEATURE_FLAGS, LaunchDarklyService } from 'src/app/services/launch-darkly.service';
 import { of } from 'rxjs';
 import { HearingDetailsUpdatedMessage } from 'src/app/services/models/hearing-details-updated-message';
-import { videoWebServiceSpy } from 'src/app/vh-officer/vho-shared/tests/participant-status-base-setup';
 
 describe('WaitingRoomComponent EventHub Call', () => {
     let fixture: ComponentFixture<WRTestComponent>;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.video-call-events.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/tests/waiting-room-base.component.video-call-events.spec.ts
@@ -1,7 +1,7 @@
 import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { Guid } from 'guid-typescript';
 import { BehaviorSubject, of, Subject } from 'rxjs';
-import { ConferenceResponse, ConferenceStatus, ParticipantResponse, TokenResponse } from 'src/app/services/clients/api-client';
+import { ConferenceResponse, ConferenceStatus, ParticipantResponse } from 'src/app/services/clients/api-client';
 import { HearingVenueFlagsService } from 'src/app/services/hearing-venue-flags.service';
 import { getSpiedPropertyGetter } from 'src/app/shared/jasmine-helpers/property-helpers';
 import { Hearing } from 'src/app/shared/models/hearing';
@@ -16,7 +16,6 @@ import {
     onPresentationConnectedMock,
     onPresentationDisconnectedMock,
     onPresentationMock,
-    videoCallServiceSpy,
     onParticipantUpdatedMock
 } from 'src/app/testing/mocks/mock-video-call.service';
 import {


### PR DESCRIPTION
### Jira link

VIH-11136

### Change description

Adding a new ESLint plugin for unused imports and cleaning up unused imports across multiple files.

### ESLint Plugin Addition:
* Added `eslint-plugin-unused-imports` to the list of plugins in `.eslintrc.js` and configured a rule to flag unused imports as errors.