### PR TITLE
VIH-11151 retain local media status and retain pexip info for conference endpoints when conference is refreshed

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
@@ -58,7 +58,8 @@ describe('Conference Reducer', () => {
                     hearingRole: HearingRole.REPRESENTATIVE,
                     pexipInfo: undefined,
                     role: Role.Representative,
-                    linkedParticipants: []
+                    linkedParticipants: [],
+                    localMediaStatus: undefined
                 },
                 {
                     id: '7b875df1-bf37-4f5a-9d23-d3493f319a08',
@@ -72,7 +73,8 @@ describe('Conference Reducer', () => {
                     hearingRole: HearingRole.JUDGE,
                     pexipInfo: undefined,
                     role: Role.Judge,
-                    linkedParticipants: []
+                    linkedParticipants: [],
+                    localMediaStatus: undefined
                 },
                 {
                     id: '729ae52a-f894-4680-af4b-4d9fcc6ffdaf',
@@ -88,7 +90,8 @@ describe('Conference Reducer', () => {
                     hearingRole: HearingRole.REPRESENTATIVE,
                     pexipInfo: undefined,
                     role: Role.Representative,
-                    linkedParticipants: []
+                    linkedParticipants: [],
+                    localMediaStatus: undefined
                 },
                 {
                     id: 'Xf497ffa-802c-4dfb-a3f2-208de0c12345',
@@ -104,7 +107,8 @@ describe('Conference Reducer', () => {
                     hearingRole: undefined,
                     pexipInfo: undefined,
                     role: undefined,
-                    linkedParticipants: []
+                    linkedParticipants: [],
+                    localMediaStatus: undefined
                 }
             ],
             endpoints: [
@@ -113,14 +117,16 @@ describe('Conference Reducer', () => {
                     displayName: 'Endpoint 1',
                     status: EndpointStatus.InConsultation,
                     defenceAdvocate: 'john.doe@test.com',
-                    room: originalRoom
+                    room: originalRoom,
+                    pexipInfo: undefined
                 },
                 {
                     id: '197ced60-3cae-4214-8ba1-4465cffe4b5d',
                     displayName: 'Endpoint 2',
                     status: EndpointStatus.NotYetJoined,
                     defenceAdvocate: null,
-                    room: null
+                    room: null,
+                    pexipInfo: undefined
                 }
             ],
             supplier: Supplier.Vodafone
@@ -169,6 +175,10 @@ describe('Conference Reducer', () => {
                             role: 'Guest',
                             sentAudioMixes: [{ mix_name: 'main', prominent: false }],
                             receivingAudioMix: 'main'
+                        },
+                        localMediaStatus: {
+                            isCameraOff: true,
+                            isMicrophoneMuted: true
                         }
                     },
                     conferenceTestData.participants[1]
@@ -185,6 +195,46 @@ describe('Conference Reducer', () => {
 
             expect(result.currentConference.caseName).toEqual('Updating conference');
             expect(result.currentConference.participants[0].pexipInfo).toBeTruthy();
+            expect(result.currentConference.participants[0].localMediaStatus.isCameraOff).toBeTrue();
+            expect(result.currentConference.participants[0].localMediaStatus.isMicrophoneMuted).toBeTrue();
+        });
+
+        it('should replace the existing conference with the new conference and maintain pexip info for endpoints', () => {
+            const conferenceWithPexipInfo: VHConference = {
+                ...conferenceTestData,
+                endpoints: [
+                    {
+                        ...conferenceTestData.endpoints[0],
+                        pexipInfo: {
+                            isRemoteMuted: false,
+                            isSpotlighted: false,
+                            isVideoMuted: false,
+                            handRaised: false,
+                            pexipDisplayName: '1922_John Doe',
+                            uuid: '1922_John Doe',
+                            callTag: 'john-cal-tag',
+                            isAudioOnlyCall: false,
+                            isVideoCall: true,
+                            protocol: 'sip',
+                            role: 'Guest',
+                            sentAudioMixes: [{ mix_name: 'main', prominent: false }],
+                            receivingAudioMix: 'main'
+                        }
+                    },
+                    conferenceTestData.endpoints[1]
+                ]
+            };
+
+            const initialStateWithPexipInfo: ConferenceState = { ...initialState, currentConference: conferenceWithPexipInfo };
+
+            const conferenceWithoutPexipInfo: VHConference = { ...existingInitialState.currentConference, caseName: 'Updating conference' };
+            const result = conferenceReducer(
+                initialStateWithPexipInfo,
+                ConferenceActions.loadConferenceSuccess({ conference: conferenceWithoutPexipInfo })
+            );
+
+            expect(result.currentConference.caseName).toEqual('Updating conference');
+            expect(result.currentConference.endpoints[0].pexipInfo).toBeTruthy();
         });
     });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
@@ -34,12 +34,16 @@ function getCurrentConference(state: ConferenceState, conferenceId: string): VHC
 export const conferenceReducer = createReducer(
     initialState,
     on(ConferenceActions.loadConferenceSuccess, (state, { conference }) => {
-        // retain the pexip info for the participants (this does not come from the API)
+        // retain the pexip info and media device status for the participants (this does not come from the API)
         const updatedParticipants = conference.participants.map(p => {
             const existingParticipant = state.currentConference?.participants.find(cp => cp.id === p.id);
-            return { ...p, pexipInfo: existingParticipant?.pexipInfo };
+            return { ...p, pexipInfo: existingParticipant?.pexipInfo, localMediaStatus: existingParticipant?.localMediaStatus };
         });
-        const updatedConference: VHConference = { ...conference, participants: updatedParticipants };
+        const updatedEndpoints = conference.endpoints.map(e => {
+            const existingEndpoint = state.currentConference?.endpoints.find(ce => ce.id === e.id);
+            return { ...e, pexipInfo: existingEndpoint?.pexipInfo };
+        });
+        const updatedConference: VHConference = { ...conference, participants: updatedParticipants, endpoints: updatedEndpoints };
         const availableRooms = conference.participants.map(p => p.room).filter(r => r !== null);
         const countdownComplete = updatedConference.status === ConferenceStatus.InSession ? true : state.countdownComplete;
         return { ...state, currentConference: updatedConference, availableRooms: availableRooms, countdownComplete };


### PR DESCRIPTION
### Jira link

VIH-11151

### Change description

If a conference is refreshed, the redux store loses the original media device status for partcipants and pexip info for endpoints