### PR TITLE
VIH-11189 add InHearing value to endpoint status enum

### DIFF
--- a/VideoWeb/VideoWeb.Common/Models/EndpointStatus.cs
+++ b/VideoWeb/VideoWeb.Common/Models/EndpointStatus.cs
@@ -8,6 +8,7 @@ namespace VideoWeb.Common.Models
         NotYetJoined = 1,
         Connected = 2,
         Disconnected = 3,
-        InConsultation = 4
+        InConsultation = 4,
+        InHearing = 5
     }
 }

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
-    <PackageReference Include="VideoApi.Client" Version="3.1.4" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
-    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -1,14 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ProjectGuid>{8DB35AEF-80FC-4A54-B253-D5A2236A0AF6}</ProjectGuid>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="3.0.5" />
+    <PackageReference Include="BookingsApi.Client" Version="3.1.8" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167">
       <PrivateAssets>all</PrivateAssets>

--- a/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
+++ b/VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{8DB35AEF-80FC-4A54-B253-D5A2236A0AF6}</ProjectGuid>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BookingsApi.Client" Version="3.1.8" />

--- a/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
+++ b/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
@@ -8,7 +8,7 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="3.0.5" />
+    <PackageReference Include="BookingsApi.Client" Version="3.1.8" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
+++ b/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
+++ b/VideoWeb/VideoWeb.Contract/VideoWeb.Contract.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VideoApi.Client" Version="3.1.4" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.EventHub/Enums/EndpointState.cs
+++ b/VideoWeb/VideoWeb.EventHub/Enums/EndpointState.cs
@@ -5,6 +5,7 @@ namespace VideoWeb.EventHub.Enums
         NotYetJoined = 1,
         Connected = 2,
         Disconnected = 3,
-        InConsultation = 4
+        InConsultation = 4,
+        InHearing = 5
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs
@@ -41,8 +41,9 @@ namespace VideoWeb.EventHub.Handlers
             switch (transferTo)
             {
                 case VHRoom.WaitingRoom:
-                case VHRoom.HearingRoom:
                     return (EndpointState.Connected, EndpointStatus.Connected);
+                case VHRoom.HearingRoom:
+                    return (EndpointState.InHearing, EndpointStatus.InHearing);
                 case VHRoom.ConsultationRoom:
                     return (EndpointState.InConsultation, EndpointStatus.InConsultation);
                 default:

--- a/VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj
+++ b/VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>371E895D-1CDC-4872-BCCC-7199DD3AA519</ProjectGuid>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj
+++ b/VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj
@@ -1,11 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ProjectGuid>371E895D-1CDC-4872-BCCC-7199DD3AA519</ProjectGuid>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/EndpointTransferEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/EndpointTransferEventHandlerTests.cs
@@ -17,7 +17,7 @@ namespace VideoWeb.UnitTests.EventHandlers
     {
         private EndpointTransferEventHandler _eventHandler;
 
-        [TestCase(RoomType.WaitingRoom, RoomType.HearingRoom, EndpointState.Connected, EndpointStatus.Connected)]
+        [TestCase(RoomType.WaitingRoom, RoomType.HearingRoom, EndpointState.InHearing, EndpointStatus.InHearing)]
         [TestCase(RoomType.HearingRoom, RoomType.WaitingRoom, EndpointState.Connected, EndpointStatus.Connected)]
         public async Task Should_send_endpoint_status_messages_to_clients(RoomType from, RoomType to,
             EndpointState endpointState, EndpointStatus expectedEndpointStatus)

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
+++ b/VideoWeb/VideoWeb.UnitTests/VideoWeb.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
-    <PackageReference Include="VideoApi.Client" Version="3.1.4" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VideoWeb.Common\VideoWeb.Common.csproj" />

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -108,9 +108,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[3.1.7-pr-0701-0002, )",
-        "resolved": "3.1.7-pr-0701-0002",
-        "contentHash": "gJDz+Un5yNG2T/nItY3RKqZUoxao5M4xlhW5BX0zbosMwVMZ2d8cbADbaDfqtqeKu92Fn7dCyS6gTc/T9wzuzw==",
+        "requested": "[3.1.7, )",
+        "resolved": "3.1.7",
+        "contentHash": "l7/NvSybO0/k+rAg1jY78hjZrQ1v2P/qdmh75gJeK+tax3Ukwc0G6+QvKbvlbetzU1TjKf2GFrublKZ5h1OdMg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.4"
@@ -2288,7 +2288,7 @@
           "Swashbuckle.AspNetCore": "[6.6.1, )",
           "Swashbuckle.AspNetCore.Annotations": "[6.6.1, )",
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.6.1, )",
-          "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
+          "VideoApi.Client": "[3.1.7, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -2306,14 +2306,14 @@
           "Microsoft.Identity.Client": "[4.61.3, )",
           "StackExchange.Redis": "[2.8.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.2, )",
-          "VideoApi.Client": "[3.1.7-pr-0701-0002, )"
+          "VideoApi.Client": "[3.1.7, )"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
           "BookingsApi.Client": "[3.1.8, )",
-          "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
+          "VideoApi.Client": "[3.1.7, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
       },

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -108,9 +108,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[3.1.4, )",
-        "resolved": "3.1.4",
-        "contentHash": "CJxSasYEP/2UqCWwb7Oq7WEDTk6yNlr7R2MoGm/hn0c7i5XhapaVsMEpaLBCCeyTY/lr/0X2rI1l5JZn1ezWMQ==",
+        "requested": "[3.1.7-pr-0701-0002, )",
+        "resolved": "3.1.7-pr-0701-0002",
+        "contentHash": "gJDz+Un5yNG2T/nItY3RKqZUoxao5M4xlhW5BX0zbosMwVMZ2d8cbADbaDfqtqeKu92Fn7dCyS6gTc/T9wzuzw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.4"
@@ -2368,7 +2368,7 @@
           "Swashbuckle.AspNetCore": "[6.6.1, )",
           "Swashbuckle.AspNetCore.Annotations": "[6.6.1, )",
           "Swashbuckle.AspNetCore.Newtonsoft": "[6.6.1, )",
-          "VideoApi.Client": "[3.1.4, )",
+          "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
           "VideoWeb.Common": "[1.0.0, )",
           "VideoWeb.Contract": "[1.0.0, )",
           "VideoWeb.EventHub": "[1.0.0, )"
@@ -2387,14 +2387,14 @@
           "Microsoft.Identity.Client": "[4.61.3, )",
           "StackExchange.Redis": "[2.8.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.2, )",
-          "VideoApi.Client": "[3.1.4, )"
+          "VideoApi.Client": "[3.1.7-pr-0701-0002, )"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
           "BookingsApi.Client": "[3.0.5, )",
-          "VideoApi.Client": "[3.1.4, )",
+          "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
       },

--- a/VideoWeb/VideoWeb.UnitTests/packages.lock.json
+++ b/VideoWeb/VideoWeb.UnitTests/packages.lock.json
@@ -173,18 +173,18 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "3.0.5",
-        "contentHash": "2H8DS11nNgreD6RdChNUxDUzMG6nSvXmm14w1TPZCXb0hUbPxg6Cc9iVZZmxdvP7aH62A0RGDoWNE5Wz0ClJwQ==",
+        "resolved": "3.1.8",
+        "contentHash": "mE2wBsoxMe/xVMjv0vjL/Oj3AhZzx+dYxbzMlsLahLBEcbZHYqxV6ZGNHAdTyF6vN0ZIE0SnBUENvPjJC4Me8A==",
         "dependencies": {
-          "BookingsApi.Common.DotNet6": "3.0.5",
+          "BookingsApi.Common.DotNet6": "3.1.8",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.0"
         }
       },
       "BookingsApi.Common.DotNet6": {
         "type": "Transitive",
-        "resolved": "3.0.5",
-        "contentHash": "31drJq2GLeosigbFD7xXywZRCCGAEYF0JdiqI1hvu3dNDN6Cacr+xwvIoA5UmpdgAo8J1CX1ba6LfGNnPhHNiw==",
+        "resolved": "3.1.8",
+        "contentHash": "x7i92cO1dfxCPkNbymrVbZyeOIbTYLXwQqzqLYnaU/hRuDEBkfPVC/7wdu/OT3riCG+At8bujShPYch53NjpNg==",
         "dependencies": {
           "System.Text.Json": "8.0.0"
         }
@@ -527,21 +527,6 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "ZcwAM9rE5yjGC+vtiNAK0INybpKIqnvB+/rntZn2/CPtyiBAtovVrEp4UZOoC31zH5t0P78ix9gLNJzII/ODsA==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.0",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.1.0",
-          "Microsoft.AspNetCore.Routing": "2.2.0",
-          "Microsoft.AspNetCore.WebSockets": "2.2.0",
-          "Newtonsoft.Json": "11.0.2",
-          "System.Security.Principal.Windows": "4.5.0"
-        }
-      },
       "Microsoft.AspNetCore.Http.Connections.Common": {
         "type": "Transitive",
         "resolved": "8.0.5",
@@ -625,15 +610,6 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0"
         }
       },
-      "Microsoft.AspNetCore.SignalR": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "V5X5XkeAHaFyyBOGPrddVeqTNo6zRPJNS5PRhlzEyBXiNG9AtqUbMyWFdZahQyMiIWJau550z59A4kdC9g5I9A==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections": "1.1.0",
-          "Microsoft.AspNetCore.SignalR.Core": "1.1.0"
-        }
-      },
       "Microsoft.AspNetCore.SignalR.Common": {
         "type": "Transitive",
         "resolved": "8.0.7",
@@ -641,29 +617,6 @@
         "dependencies": {
           "Microsoft.AspNetCore.Connections.Abstractions": "8.0.7",
           "Microsoft.Extensions.Options": "8.0.2"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Core": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "mk69z50oFk2e89d3F/AfKeAvP3kvGG7MHG4ErydZiUd3ncSRq0kl0czq/COn/QVKYua9yGr2LIDwuR1C6/pu8Q==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "2.2.0",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0",
-          "Microsoft.AspNetCore.SignalR.Protocols.Json": "1.1.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Threading.Channels": "4.5.0"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.Json": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "BOsjatDJnvnnXCMajOlC0ISmiFnJi/EyJzMo0i//5fZJVCLrQ4fyV/HzrhhAhSJuwJOQDdDozKQ9MB9jHq84pg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0",
-          "Newtonsoft.Json": "11.0.2"
         }
       },
       "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson": {
@@ -683,17 +636,6 @@
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.WebSockets": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "ZpOcg2V0rCwU9ErfDb9y3Hcjoe7rU42XlmUS0mO4pVZQSgJVqR+DfyZtYd5LDa11F7bFNS2eezI9cBM3CmfGhw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.1"
-        }
-      },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -705,35 +647,23 @@
       },
       "Microsoft.Azure.SignalR": {
         "type": "Transitive",
-        "resolved": "1.26.0",
-        "contentHash": "ql3qWjcfkf4TRYv6SGZW3zZpBLZ27R5yyiUkdh+BbW5MFrGzGk00zOvlOBLlsSquuFwEQya0Hfb0WYlLKsmrsA==",
+        "resolved": "1.29.0",
+        "contentHash": "Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
         "dependencies": {
           "Azure.Identity": "1.11.4",
-          "Microsoft.Azure.SignalR.Protocols": "1.26.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Extensions.Http": "2.1.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.Azure.SignalR.Protocols": {
         "type": "Transitive",
-        "resolved": "1.26.0",
-        "contentHash": "S8qB5PGrG5cFXuoIy0NNPxns41MEprpOi9qWja9FFJbVSlFiVlgNZToaL+/YAm7H+C/pxNRjhtxKu68xA4HC5Q==",
+        "resolved": "1.29.0",
+        "contentHash": "54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
         "dependencies": {
-          "Azure.Identity": "1.11.4",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.1.2",
-          "Microsoft.AspNetCore.Http": "2.1.22",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "2.1.0",
-          "Microsoft.Extensions.Http": "2.1.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
           "Microsoft.Extensions.Primitives": "2.1.1",
-          "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "4.6.0",
           "System.Memory": "4.5.4",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -1858,11 +1788,6 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Net.WebSockets.WebSocketProtocol": {
-        "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "O8RIMEVeOFzT8fscu6MDc4y+0LfnlXdqGovb0rJHBNVKhwn6BsNJmTY1oYUZPPsMfcc5OP20WpX4vj/aK8n98g=="
-      },
       "System.Numerics.Vectors": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -2260,11 +2185,6 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "MEH06N0rIGmRT4LOKQ2BmUO0IxfvmIY/PaouSq+DFQku72OL8cxfw8W99uGpTCFf2vx2QHLRSh374iSM3asdTA=="
-      },
       "System.Threading.Tasks": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2349,7 +2269,7 @@
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "[8.0.1, )",
           "AspNetCore.HealthChecks.Uris": "[8.0.1, )",
-          "BookingsApi.Client": "[3.0.5, )",
+          "BookingsApi.Client": "[3.1.8, )",
           "Castle.Core": "[5.1.1, )",
           "FluentValidation.AspNetCore": "[11.3.0, )",
           "MicroElements.Swashbuckle.FluentValidation": "[6.0.0, )",
@@ -2358,7 +2278,7 @@
           "Microsoft.AspNetCore.Http.Connections.Common": "[8.0.5, )",
           "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson": "[8.0.7, )",
           "Microsoft.AspNetCore.SpaServices.Extensions": "[8.0.5, )",
-          "Microsoft.Azure.SignalR": "[1.26.0, )",
+          "Microsoft.Azure.SignalR": "[1.29.0, )",
           "Microsoft.Extensions.Caching.StackExchangeRedis": "[8.0.7, )",
           "Microsoft.Extensions.DependencyModel": "[8.0.0, )",
           "Microsoft.Extensions.Http.Polly": "[8.0.5, )",
@@ -2377,11 +2297,10 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[3.0.5, )",
+          "BookingsApi.Client": "[3.1.8, )",
           "LaunchDarkly.ServerSdk": "[8.5.0, )",
           "Microsoft.ApplicationInsights": "[2.22.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
-          "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Options": "[8.0.2, )",
           "Microsoft.Identity.Client": "[4.61.3, )",
@@ -2393,7 +2312,7 @@
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[3.0.5, )",
+          "BookingsApi.Client": "[3.1.8, )",
           "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
@@ -2402,7 +2321,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
-          "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "System.Text.Json": "[8.0.5, )",
           "VideoWeb.Common": "[1.0.0, )",

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/clients/api-client.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/clients/api-client.ts
@@ -7680,7 +7680,8 @@ export enum EndpointState {
     NotYetJoined = 'NotYetJoined',
     Connected = 'Connected',
     Disconnected = 'Disconnected',
-    InConsultation = 'InConsultation'
+    InConsultation = 'InConsultation',
+    InHearing = 'InHearing'
 }
 
 export enum EventType {
@@ -8556,7 +8557,8 @@ export enum EndpointStatus {
     NotYetJoined = 'NotYetJoined',
     Connected = 'Connected',
     Disconnected = 'Disconnected',
-    InConsultation = 'InConsultation'
+    InConsultation = 'InConsultation',
+    InHearing = 'InHearing'
 }
 
 export enum LinkType {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/testing/mocks/data/conference-test-data.ts
@@ -851,7 +851,7 @@ export class ConferenceTestData {
         });
         const point2 = new VideoEndpointResponse({
             display_name: 'DispName2',
-            status: EndpointStatus.Connected,
+            status: EndpointStatus.InHearing,
             id: '123232355',
             defence_advocate_username: 'john.doe@hearings.net',
             pexip_display_name: 'PSTN;DispName2;123232355',

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/video-endpoint-panel-model.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/models/video-endpoint-panel-model.ts
@@ -26,7 +26,7 @@ export class VideoEndpointPanelModel extends IndividualPanelModel {
     }
 
     isInHearing(): boolean {
-        return this.status === EndpointStatus.Connected;
+        return this.status === EndpointStatus.InHearing;
     }
 
     isDisconnected(): boolean {

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.1" />
-    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.7" />

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -32,12 +32,12 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
-    <PackageReference Include="BookingsApi.Client" Version="3.0.5" />
+    <PackageReference Include="BookingsApi.Client" Version="3.1.8" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="2.7.1" />
-    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.26.0" />
+    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.29.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="Polly" Version="8.4.0" />
     <PackageReference Include="Scrutor" Version="4.2.2" />

--- a/VideoWeb/VideoWeb/VideoWeb.csproj
+++ b/VideoWeb/VideoWeb/VideoWeb.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.1" />
-    <PackageReference Include="VideoApi.Client" Version="3.1.4" />
+    <PackageReference Include="VideoApi.Client" Version="3.1.7-pr-0701-0002" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.7" />

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -229,9 +229,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[3.1.4, )",
-        "resolved": "3.1.4",
-        "contentHash": "CJxSasYEP/2UqCWwb7Oq7WEDTk6yNlr7R2MoGm/hn0c7i5XhapaVsMEpaLBCCeyTY/lr/0X2rI1l5JZn1ezWMQ==",
+        "requested": "[3.1.7-pr-0701-0002, )",
+        "resolved": "3.1.7-pr-0701-0002",
+        "contentHash": "gJDz+Un5yNG2T/nItY3RKqZUoxao5M4xlhW5BX0zbosMwVMZ2d8cbADbaDfqtqeKu92Fn7dCyS6gTc/T9wzuzw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.4"
@@ -1903,14 +1903,14 @@
           "Microsoft.Identity.Client": "[4.61.3, )",
           "StackExchange.Redis": "[2.8.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.2, )",
-          "VideoApi.Client": "[3.1.4, )"
+          "VideoApi.Client": "[3.1.7-pr-0701-0002, )"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
           "BookingsApi.Client": "[3.0.5, )",
-          "VideoApi.Client": "[3.1.4, )",
+          "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
       },

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -229,9 +229,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[3.1.7-pr-0701-0002, )",
-        "resolved": "3.1.7-pr-0701-0002",
-        "contentHash": "gJDz+Un5yNG2T/nItY3RKqZUoxao5M4xlhW5BX0zbosMwVMZ2d8cbADbaDfqtqeKu92Fn7dCyS6gTc/T9wzuzw==",
+        "requested": "[3.1.7, )",
+        "resolved": "3.1.7",
+        "contentHash": "l7/NvSybO0/k+rAg1jY78hjZrQ1v2P/qdmh75gJeK+tax3Ukwc0G6+QvKbvlbetzU1TjKf2GFrublKZ5h1OdMg==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.4"
@@ -1800,14 +1800,14 @@
           "Microsoft.Identity.Client": "[4.61.3, )",
           "StackExchange.Redis": "[2.8.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.2, )",
-          "VideoApi.Client": "[3.1.7-pr-0701-0002, )"
+          "VideoApi.Client": "[3.1.7, )"
         }
       },
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
           "BookingsApi.Client": "[3.1.8, )",
-          "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
+          "VideoApi.Client": "[3.1.7, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
       },

--- a/VideoWeb/VideoWeb/packages.lock.json
+++ b/VideoWeb/VideoWeb/packages.lock.json
@@ -24,11 +24,11 @@
       },
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[3.0.5, )",
-        "resolved": "3.0.5",
-        "contentHash": "2H8DS11nNgreD6RdChNUxDUzMG6nSvXmm14w1TPZCXb0hUbPxg6Cc9iVZZmxdvP7aH62A0RGDoWNE5Wz0ClJwQ==",
+        "requested": "[3.1.8, )",
+        "resolved": "3.1.8",
+        "contentHash": "mE2wBsoxMe/xVMjv0vjL/Oj3AhZzx+dYxbzMlsLahLBEcbZHYqxV6ZGNHAdTyF6vN0ZIE0SnBUENvPjJC4Me8A==",
         "dependencies": {
-          "BookingsApi.Common.DotNet6": "3.0.5",
+          "BookingsApi.Common.DotNet6": "3.1.8",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "System.Text.Json": "8.0.0"
         }
@@ -122,12 +122,12 @@
       },
       "Microsoft.Azure.SignalR": {
         "type": "Direct",
-        "requested": "[1.26.0, )",
-        "resolved": "1.26.0",
-        "contentHash": "ql3qWjcfkf4TRYv6SGZW3zZpBLZ27R5yyiUkdh+BbW5MFrGzGk00zOvlOBLlsSquuFwEQya0Hfb0WYlLKsmrsA==",
+        "requested": "[1.29.0, )",
+        "resolved": "1.29.0",
+        "contentHash": "Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
         "dependencies": {
           "Azure.Identity": "1.11.4",
-          "Microsoft.Azure.SignalR.Protocols": "1.26.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Extensions.Http": "2.1.0",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -268,8 +268,8 @@
       },
       "BookingsApi.Common.DotNet6": {
         "type": "Transitive",
-        "resolved": "3.0.5",
-        "contentHash": "31drJq2GLeosigbFD7xXywZRCCGAEYF0JdiqI1hvu3dNDN6Cacr+xwvIoA5UmpdgAo8J1CX1ba6LfGNnPhHNiw==",
+        "resolved": "3.1.8",
+        "contentHash": "x7i92cO1dfxCPkNbymrVbZyeOIbTYLXwQqzqLYnaU/hRuDEBkfPVC/7wdu/OT3riCG+At8bujShPYch53NjpNg==",
         "dependencies": {
           "System.Text.Json": "8.0.0"
         }
@@ -558,21 +558,6 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "ZcwAM9rE5yjGC+vtiNAK0INybpKIqnvB+/rntZn2/CPtyiBAtovVrEp4UZOoC31zH5t0P78ix9gLNJzII/ODsA==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.0",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.1.0",
-          "Microsoft.AspNetCore.Routing": "2.2.0",
-          "Microsoft.AspNetCore.WebSockets": "2.2.0",
-          "Newtonsoft.Json": "11.0.2",
-          "System.Security.Principal.Windows": "4.5.0"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -670,15 +655,6 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0"
         }
       },
-      "Microsoft.AspNetCore.SignalR": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "V5X5XkeAHaFyyBOGPrddVeqTNo6zRPJNS5PRhlzEyBXiNG9AtqUbMyWFdZahQyMiIWJau550z59A4kdC9g5I9A==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections": "1.1.0",
-          "Microsoft.AspNetCore.SignalR.Core": "1.1.0"
-        }
-      },
       "Microsoft.AspNetCore.SignalR.Common": {
         "type": "Transitive",
         "resolved": "8.0.7",
@@ -686,40 +662,6 @@
         "dependencies": {
           "Microsoft.AspNetCore.Connections.Abstractions": "8.0.7",
           "Microsoft.Extensions.Options": "8.0.2"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Core": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "mk69z50oFk2e89d3F/AfKeAvP3kvGG7MHG4ErydZiUd3ncSRq0kl0czq/COn/QVKYua9yGr2LIDwuR1C6/pu8Q==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "2.2.0",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0",
-          "Microsoft.AspNetCore.SignalR.Protocols.Json": "1.1.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Threading.Channels": "4.5.0"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.Json": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "BOsjatDJnvnnXCMajOlC0ISmiFnJi/EyJzMo0i//5fZJVCLrQ4fyV/HzrhhAhSJuwJOQDdDozKQ9MB9jHq84pg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0",
-          "Newtonsoft.Json": "11.0.2"
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "ZpOcg2V0rCwU9ErfDb9y3Hcjoe7rU42XlmUS0mO4pVZQSgJVqR+DfyZtYd5LDa11F7bFNS2eezI9cBM3CmfGhw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.1"
         }
       },
       "Microsoft.AspNetCore.WebUtilities": {
@@ -733,24 +675,12 @@
       },
       "Microsoft.Azure.SignalR.Protocols": {
         "type": "Transitive",
-        "resolved": "1.26.0",
-        "contentHash": "S8qB5PGrG5cFXuoIy0NNPxns41MEprpOi9qWja9FFJbVSlFiVlgNZToaL+/YAm7H+C/pxNRjhtxKu68xA4HC5Q==",
+        "resolved": "1.29.0",
+        "contentHash": "54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
         "dependencies": {
-          "Azure.Identity": "1.11.4",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.1.2",
-          "Microsoft.AspNetCore.Http": "2.1.22",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "2.1.0",
-          "Microsoft.Extensions.Http": "2.1.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
           "Microsoft.Extensions.Primitives": "2.1.1",
-          "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "4.6.0",
           "System.Memory": "4.5.4",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -1531,11 +1461,6 @@
           "System.Runtime.Handles": "4.3.0"
         }
       },
-      "System.Net.WebSockets.WebSocketProtocol": {
-        "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "O8RIMEVeOFzT8fscu6MDc4y+0LfnlXdqGovb0rJHBNVKhwn6BsNJmTY1oYUZPPsMfcc5OP20WpX4vj/aK8n98g=="
-      },
       "System.Numerics.Vectors": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -1549,28 +1474,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.IO": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit.ILGeneration": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
           "System.Runtime": "4.3.0"
         }
@@ -1857,11 +1760,6 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "MEH06N0rIGmRT4LOKQ2BmUO0IxfvmIY/PaouSq+DFQku72OL8cxfw8W99uGpTCFf2vx2QHLRSh374iSM3asdTA=="
-      },
       "System.Threading.Tasks": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1893,11 +1791,10 @@
       "videoweb.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[3.0.5, )",
+          "BookingsApi.Client": "[3.1.8, )",
           "LaunchDarkly.ServerSdk": "[8.5.0, )",
           "Microsoft.ApplicationInsights": "[2.22.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
-          "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Options": "[8.0.2, )",
           "Microsoft.Identity.Client": "[4.61.3, )",
@@ -1909,7 +1806,7 @@
       "videoweb.contract": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "[3.0.5, )",
+          "BookingsApi.Client": "[3.1.8, )",
           "VideoApi.Client": "[3.1.7-pr-0701-0002, )",
           "VideoWeb.Common": "[1.0.0, )"
         }
@@ -1918,7 +1815,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
-          "Microsoft.AspNetCore.SignalR": "[1.1.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "System.Text.Json": "[8.0.5, )",
           "VideoWeb.Common": "[1.0.0, )",


### PR DESCRIPTION
## Jira link

VIH-11189

## Change description

### Enum Updates:
* Added `InHearing` status to `EndpointStatus` in `VideoWeb/VideoWeb.Common/Models/EndpointStatus.cs`.
* Added `InHearing` state to `EndpointState` in `VideoWeb/VideoWeb.EventHub/Enums/EndpointState.cs`.
* Updated `DeriveEndpointState` method to handle `InHearing` state and status in `VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs`.

### Package Updates:
* Changed project SDK from `Microsoft.NET.Sdk` to `Microsoft.NET.Sdk.Web` in `VideoWeb/VideoWeb.Common/VideoWeb.Common.csproj` and `VideoWeb/VideoWeb.EventHub/VideoWeb.EventHub.csproj`. SignalR is now a part of the framework and the nuget packages are obsolete and vulnerable 