### PR TITLE
VIH-11132 Hide invite button for screened participants

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/models/consultation-rules.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/models/consultation-rules.spec.ts
@@ -1,0 +1,237 @@
+import { VHConference, VHParticipant, VHRoom } from 'src/app/waiting-space/store/models/vh-conference';
+import { ConsultationRules } from './consultation-rules';
+import { ConferenceTestData } from 'src/app/testing/mocks/data/conference-test-data';
+import { mapConferenceToVHConference } from 'src/app/waiting-space/store/models/api-contract-to-state-model-mappers';
+import { ParticipantStatus, Role } from '../clients/api-client';
+import { HearingRole } from 'src/app/waiting-space/models/hearing-role-model';
+
+describe('ConsultationRules', () => {
+    let consultationRules: ConsultationRules;
+    let conference: VHConference;
+
+    beforeEach(() => {
+        conference = mapConferenceToVHConference(new ConferenceTestData().getConferenceDetailFuture());
+        conference.participants = [];
+        consultationRules = new ConsultationRules(conference);
+    });
+
+    describe('getParticipantsInRoom', () => {
+        it('should return participants in the current room', () => {
+            // Arrange
+            const currentRoom = 'Room1';
+            const participants: VHParticipant[] = [
+                { id: '1', status: ParticipantStatus.InConsultation, room: { label: currentRoom } } as VHParticipant,
+                { id: '2', status: ParticipantStatus.InConsultation, room: { label: currentRoom } } as VHParticipant,
+                { id: '3', status: ParticipantStatus.InConsultation, room: { label: 'Room2' } } as VHParticipant,
+                { id: '4', status: ParticipantStatus.Available } as VHParticipant,
+                { id: '5', status: ParticipantStatus.NotSignedIn } as VHParticipant
+            ];
+            conference.participants = participants;
+
+            // Act
+            const result = consultationRules.getParticipantsInRoom(currentRoom);
+
+            // Assert
+            expect(result.length).toBe(2);
+            expect(result[0].id).toBe('1');
+            expect(result[1].id).toBe('2');
+        });
+
+        it('should return empty array when no participants are in the current room', () => {
+            // Arrange
+            const currentRoom = 'Room1';
+            conference.participants = [];
+
+            // Act
+            const result = consultationRules.getParticipantsInRoom(currentRoom);
+
+            // Assert
+            expect(result.length).toBe(0);
+        });
+    });
+
+    describe('participantsAreScreenedFromEachOther', () => {
+        it('should return true when participant 1 is screened from participant 2', () => {
+            // Arrange
+            const participant1: VHParticipant = { externalReferenceId: '1', protectedFrom: ['2'] } as VHParticipant;
+            const participant2: VHParticipant = { externalReferenceId: '2', protectedFrom: [] } as VHParticipant;
+
+            // Act
+            const result = consultationRules.participantsAreScreenedFromEachOther(participant1, participant2);
+
+            // Assert
+            expect(result).toBeTrue();
+        });
+
+        it('should return true when participant 2 is screened from participant 2', () => {
+            // Arrange
+            const participant1: VHParticipant = { externalReferenceId: '1', protectedFrom: [] } as VHParticipant;
+            const participant2: VHParticipant = { externalReferenceId: '2', protectedFrom: ['1'] } as VHParticipant;
+
+            // Act
+            const result = consultationRules.participantsAreScreenedFromEachOther(participant1, participant2);
+
+            // Assert
+            expect(result).toBeTrue();
+        });
+
+        it('should return false when participants are not screened from each other', () => {
+            // Arrange
+            const participant1: VHParticipant = { externalReferenceId: '1', protectedFrom: [] } as VHParticipant;
+            const participant2: VHParticipant = { externalReferenceId: '2', protectedFrom: [] } as VHParticipant;
+
+            // Act
+            const result = consultationRules.participantsAreScreenedFromEachOther(participant1, participant2);
+
+            // Assert
+            expect(result).toBeFalse();
+        });
+    });
+
+    describe('participantHasInviteRestrictions', () => {
+        const currentRoom = 'Room1';
+        let loggedInUser: VHParticipant;
+        let targetParticipant: VHParticipant;
+        let participantB: VHParticipant;
+
+        beforeEach(() => {
+            loggedInUser = {
+                id: '1',
+                externalReferenceId: 'er-1',
+                role: Role.Judge,
+                hearingRole: HearingRole.JUDGE,
+                status: ParticipantStatus.InConsultation,
+                room: { label: currentRoom } as VHRoom
+            } as VHParticipant;
+            targetParticipant = {
+                id: '2',
+                externalReferenceId: 'er-2',
+                role: Role.Individual,
+                hearingRole: HearingRole.APPELLANT,
+                status: ParticipantStatus.Available,
+                room: { label: currentRoom } as VHRoom
+            } as VHParticipant;
+            participantB = {
+                id: '3',
+                externalReferenceId: 'participantB',
+                role: Role.Individual,
+                hearingRole: HearingRole.APPELLANT,
+                status: ParticipantStatus.Available,
+                room: { label: currentRoom } as VHRoom
+            } as VHParticipant;
+
+            conference.participants = [loggedInUser, targetParticipant, participantB];
+        });
+
+        describe('without screening', () => {
+            it('should return true if user is not judical, and participant is not allowed to be invited', () => {
+                // Arrange
+                loggedInUser.role = Role.Individual;
+                targetParticipant.hearingRole = HearingRole.WITNESS;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeTrue();
+            });
+
+            it('should return false if user is not judicial, and participant is allowed to be invited', () => {
+                // Arrange
+                loggedInUser.role = Role.Individual;
+                targetParticipant.hearingRole = HearingRole.APPELLANT;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeFalse();
+            });
+
+            it('should return false if user is judical', () => {
+                // Arrange
+                // default for this test suit is judge
+                targetParticipant.role = Role.StaffMember;
+                targetParticipant.hearingRole = HearingRole.STAFF_MEMBER;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeFalse();
+            });
+        });
+
+        describe('with screening', () => {
+            it('should return true if the target participant is screened from participant B, and participant B is present in the consultation', () => {
+                // Arrange
+                targetParticipant.protectedFrom = [participantB.externalReferenceId];
+                participantB.status = ParticipantStatus.InConsultation;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeTrue();
+            });
+
+            it('should return true if participant B is screened from the target participant, and participant B is present in the consultation', () => {
+                // Arrange
+                participantB.protectedFrom = [targetParticipant.externalReferenceId];
+                participantB.status = ParticipantStatus.InConsultation;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeTrue();
+            });
+
+            it('should return false if the target participant is screened from participant B, and participant B is not present in the consultation', () => {
+                // Arrange
+                targetParticipant.protectedFrom = [participantB.externalReferenceId];
+                participantB.status = ParticipantStatus.Available;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeFalse();
+            });
+
+            it('should return false if participant B is screened from the target participant, and participant B is not present in the consultation', () => {
+                // Arrange
+                participantB.protectedFrom = [targetParticipant.externalReferenceId];
+                participantB.status = ParticipantStatus.Available;
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeFalse();
+            });
+
+            it('should return true if the logged in user is screened from the target participant', () => {
+                // Arrange
+                loggedInUser.protectedFrom = [targetParticipant.externalReferenceId];
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeTrue();
+            });
+
+            it('should return true if the target participant is screened from the logged in user', () => {
+                // Arrange
+                targetParticipant.protectedFrom = [loggedInUser.externalReferenceId];
+
+                // Act
+                const result = consultationRules.participantHasInviteRestrictions(targetParticipant, currentRoom, loggedInUser);
+
+                // Assert
+                expect(result).toBeTrue();
+            });
+        });
+    });
+});

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/models/consultation-rules.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/models/consultation-rules.ts
@@ -1,0 +1,52 @@
+import { VHConference, VHParticipant } from 'src/app/waiting-space/store/models/vh-conference';
+import { ParticipantStatus, Role } from '../clients/api-client';
+import { HearingRole } from 'src/app/waiting-space/models/hearing-role-model';
+
+export class ConsultationRules {
+    constructor(public conference: VHConference) {}
+
+    getParticipantsInRoom(roomLabel: string): VHParticipant[] {
+        return this.conference.participants.filter(x => x.status === ParticipantStatus.InConsultation && x.room?.label === roomLabel);
+    }
+
+    participantsAreScreenedFromEachOther(participant1: VHParticipant, participant2: VHParticipant): boolean {
+        if (participant1.protectedFrom?.includes(participant2.externalReferenceId)) {
+            return true;
+        }
+
+        if (participant2.protectedFrom?.includes(participant1.externalReferenceId)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    participantHasInviteRestrictions(participant: VHParticipant, roomLabel: string, loggedInUser: VHParticipant) {
+        if (this.participantsAreScreenedFromEachOther(participant, loggedInUser)) {
+            return true;
+        }
+
+        const participantsInRoom = this.getParticipantsInRoom(roomLabel);
+        if (participantsInRoom.some(participantInRoom => this.participantsAreScreenedFromEachOther(participant, participantInRoom))) {
+            return true;
+        }
+
+        const userIsJudicial =
+            loggedInUser.role === Role.Judge || loggedInUser.role === Role.StaffMember || loggedInUser.role === Role.JudicialOfficeHolder;
+        if (!userIsJudicial) {
+            switch (participant.hearingRole) {
+                case HearingRole.WINGER:
+                case HearingRole.WITNESS:
+                case HearingRole.OBSERVER:
+                case HearingRole.JUDGE:
+                case HearingRole.STAFF_MEMBER:
+                case HearingRole.PANEL_MEMBER:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -772,7 +772,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
     });
 
     describe('participantHasInviteRestrictions', () => {
-        fit('should return true if user is not judical, and participant is in not allowed to be invited', () => {
+        it('should return true if user is not judical, and participant is in not allowed to be invited', () => {
             // arrange
             component.loggedInUser.role = Role.Individual;
             const participant = {
@@ -915,8 +915,6 @@ describe('PrivateConsultationParticipantsComponent', () => {
                 // assert
                 expect(result).toBeTrue();
             });
-
-            // TODO tests with participants that are filtered out of this.getConsultationParticipants() - judges, staff members, witnesses etc
 
             function loadParticipants() {
                 const participants = [targetParticipant, participantB, loggedInUserParticipant];

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -9,8 +9,7 @@ import {
     LoggedParticipantResponse,
     ParticipantResponse,
     ParticipantStatus,
-    Role,
-    RoomSummaryResponse
+    Role
 } from 'src/app/services/clients/api-client';
 import { Logger } from 'src/app/services/logging/logger-base';
 import { ConsultationRequestResponseMessage } from 'src/app/services/models/consultation-request-response-message';
@@ -773,168 +772,17 @@ describe('PrivateConsultationParticipantsComponent', () => {
     });
 
     describe('participantHasInviteRestrictions', () => {
-        it('should return true if user is not judical, and participant is in not allowed to be invited', () => {
-            // arrange
-            component.loggedInUser.role = Role.Individual;
-            const participant = {
-                hearingRole: HearingRole.WITNESS
-            } as ParticipantListItem;
-            // act
-            const result = component.participantHasInviteRestrictions(participant);
-            // assert
-            expect(result).toBeTrue();
-        });
-
         it('should return false if user is not judical, and participant is allowed to be invited', () => {
             // arrange
             component.loggedInUser.role = Role.Individual;
-            const participant = {
-                hearingRole: HearingRole.APPELLANT
-            } as ParticipantListItem;
+            const vhParticipant = component.conference.participants.find(x => x.role === Role.Individual);
+            vhParticipant.hearingRole = HearingRole.APPELLANT;
+            component.initParticipants();
+            const participant = component.getConsultationParticipants().find(x => x.id === vhParticipant.id);
             // act
             const result = component.participantHasInviteRestrictions(participant);
             // assert
             expect(result).toBeFalse();
-        });
-
-        it('should return false if user is judical', () => {
-            // arrange
-            // default for this test suit is judge
-            const participant = {
-                hearingRole: HearingRole.STAFF_MEMBER
-            } as ParticipantListItem;
-            // act
-            const result = component.participantHasInviteRestrictions(participant);
-            // assert
-            expect(result).toBeFalse();
-        });
-
-        describe('participants with screening', () => {
-            let targetParticipant: ParticipantResponse;
-            let participantB: ParticipantResponse;
-            let loggedInUserParticipant: ParticipantResponse;
-
-            beforeEach(() => {
-                targetParticipant = new ParticipantResponse({
-                    id: 'targetParticipant',
-                    display_name: 'targetParticipant',
-                    role: Role.Individual,
-                    external_reference_id: 'targetParticipant'
-                });
-                participantB = new ParticipantResponse({
-                    id: 'participantB',
-                    display_name: 'participantB',
-                    role: Role.Individual,
-                    external_reference_id: 'participantB'
-                });
-                loggedInUserParticipant = new ParticipantResponse({
-                    id: 'loggedInUserParticipant',
-                    display_name: 'loggedInUserParticipant',
-                    role: Role.Individual,
-                    external_reference_id: 'loggedInUserParticipant'
-                });
-                component.loggedInUser.participant_id = loggedInUserParticipant.id;
-                component.loggedInUser.role = loggedInUserParticipant.role;
-                component.roomLabel = 'ConsultationRoom1';
-            });
-
-            it('should return true if the target participant is screened from participant B, and participant B is present in the consultation', () => {
-                // arrange
-                targetParticipant.protect_from = [participantB.external_reference_id];
-                setParticipantToInConsultation(participantB);
-                loadParticipants();
-
-                // act
-                const userListItem = getParticipantListItemForParticipantResponse(targetParticipant);
-                const result = component.participantHasInviteRestrictions(userListItem);
-
-                // assert
-                expect(result).toBeTrue();
-            });
-
-            it('should return true if participant B is screened from the target participant, and participant B is present in the consultation', () => {
-                // arrange
-                participantB.protect_from = [targetParticipant.external_reference_id];
-                setParticipantToInConsultation(participantB);
-                loadParticipants();
-
-                // act
-                const userListItem = getParticipantListItemForParticipantResponse(targetParticipant);
-                const result = component.participantHasInviteRestrictions(userListItem);
-
-                // assert
-                expect(result).toBeTrue();
-            });
-
-            it('should return false if the target participant is screened from participant B, and participant B is not present in the consultation', () => {
-                // arrange
-                targetParticipant.protect_from = [participantB.external_reference_id];
-                loadParticipants();
-
-                // act
-                const userListItem = getParticipantListItemForParticipantResponse(targetParticipant);
-                const result = component.participantHasInviteRestrictions(userListItem);
-
-                // assert
-                expect(result).toBeFalse();
-            });
-
-            it('should return false if participant B is screened from the target participant, and participant B is not present in the consultation', () => {
-                // arrange
-                participantB.protect_from = [targetParticipant.external_reference_id];
-                loadParticipants();
-
-                // act
-                const userListItem = getParticipantListItemForParticipantResponse(targetParticipant);
-                const result = component.participantHasInviteRestrictions(userListItem);
-
-                // assert
-                expect(result).toBeFalse();
-            });
-
-            it('should return true if the logged in user is screened from the target participant', () => {
-                // arrange
-                loggedInUserParticipant.protect_from = [targetParticipant.external_reference_id];
-                loadParticipants();
-
-                // act
-                const userListItem = getParticipantListItemForParticipantResponse(targetParticipant);
-                const result = component.participantHasInviteRestrictions(userListItem);
-
-                // assert
-                expect(result).toBeTrue();
-            });
-
-            it('should return true if the target participant is screened from the logged in user', () => {
-                // arrange
-                targetParticipant.protect_from = [loggedInUserParticipant.external_reference_id];
-                loadParticipants();
-
-                // act
-                const userListItem = getParticipantListItemForParticipantResponse(targetParticipant);
-                const result = component.participantHasInviteRestrictions(userListItem);
-
-                // assert
-                expect(result).toBeTrue();
-            });
-
-            function loadParticipants() {
-                const participants = [targetParticipant, participantB, loggedInUserParticipant];
-                conference.participants = participants.map(x => mapParticipantToVHParticipant(x));
-                component.initParticipants();
-            }
         });
     });
-
-    function getParticipantListItemForParticipantResponse(participantResponse: ParticipantResponse) {
-        const participantListItems = component.getConsultationParticipants();
-        return participantListItems.find(x => x.id === participantResponse.id);
-    }
-
-    function setParticipantToInConsultation(participant: ParticipantResponse) {
-        participant.status = ParticipantStatus.InConsultation;
-        participant.current_room = new RoomSummaryResponse({
-            label: component.roomLabel
-        });
-    }
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.spec.ts
@@ -79,6 +79,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
         activatedRoute = <any>{
             snapshot: { data: { loggedUser: logged } }
         };
+
         component = new PrivateConsultationParticipantsComponent(
             consultationService,
             eventsService,
@@ -834,6 +835,7 @@ describe('PrivateConsultationParticipantsComponent', () => {
                 });
                 component.loggedInUser.participant_id = loggedInUserParticipant.id;
                 component.loggedInUser.role = loggedInUserParticipant.role;
+                component.roomLabel = 'ConsultationRoom1';
             });
 
             it('should return true if the target participant is screened from participant B, and participant B is present in the consultation', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { ConsultationService } from 'src/app/services/api/consultation.service';
 import { VideoWebService } from 'src/app/services/api/video-web.service';
-import { ConferenceStatus, LinkType, ParticipantStatus, Role } from 'src/app/services/clients/api-client';
+import { ConferenceStatus, LinkType, ParticipantStatus } from 'src/app/services/clients/api-client';
 import { EventsService } from 'src/app/services/events.service';
 import { Logger } from 'src/app/services/logging/logger-base';
 import { ParticipantStatusMessage } from 'src/app/services/models/participant-status-message';
@@ -187,39 +187,10 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
         return item.status;
     }
     participantHasInviteRestrictions(participant: ParticipantListItem): boolean {
-        const loggedInUserParticipant = this.conference.participants.find(x => x.id === this.loggedInUser.participant_id);
-        if (this.consultationRules.participantsAreScreenedFromEachOther(loggedInUserParticipant, participant)) {
-            return true;
-        }
+        const vhParticipant = this.conference.participants.find(x => x.id === participant.id);
+        const vhLoggedInUser = this.conference.participants.find(x => x.id === this.loggedInUser.participant_id);
 
-        const participantsInRoom = this.consultationRules.getParticipantsInRoom(this.roomLabel);
-        if (
-            participantsInRoom.some(participantInRoom =>
-                this.consultationRules.participantsAreScreenedFromEachOther(participant, participantInRoom)
-            )
-        ) {
-            return true;
-        }
-
-        const userIsJudicial =
-            this.loggedInUser.role === Role.Judge ||
-            this.loggedInUser.role === Role.StaffMember ||
-            this.loggedInUser.role === Role.JudicialOfficeHolder;
-        if (!userIsJudicial) {
-            switch (participant.hearingRole) {
-                case HearingRole.WINGER:
-                case HearingRole.WITNESS:
-                case HearingRole.OBSERVER:
-                case HearingRole.JUDGE:
-                case HearingRole.STAFF_MEMBER:
-                case HearingRole.PANEL_MEMBER:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        return false;
+        return this.consultationRules.participantHasInviteRestrictions(vhParticipant, this.roomLabel, vhLoggedInUser);
     }
 
     private mapResponseToListItem(vhParticipant: VHParticipant): ParticipantListItem {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -187,11 +187,17 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
         return item.status;
     }
     participantHasInviteRestrictions(participant: ParticipantListItem): boolean {
-        if (this.participantAndLoggedInUserAreScreenedFromEachOther(participant)) {
+        const loggedInUserParticipant = this.conference.participants.find(x => x.id === this.loggedInUser.participant_id);
+        if (this.consultationRules.participantsAreScreenedFromEachOther(loggedInUserParticipant, participant)) {
             return true;
         }
 
-        if (this.participantAndPresentParticipantsAreScreenedFromEachOther(participant)) {
+        const participantsInRoom = this.consultationRules.getParticipantsInRoom(this.roomLabel);
+        if (
+            participantsInRoom.some(participantInRoom =>
+                this.consultationRules.participantsAreScreenedFromEachOther(participant, participantInRoom)
+            )
+        ) {
             return true;
         }
 
@@ -211,36 +217,6 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
                 default:
                     return false;
             }
-        }
-
-        return false;
-    }
-
-    private participantAndPresentParticipantsAreScreenedFromEachOther(participant: ParticipantListItem) {
-        const presentParticipants = this.conference.participants.filter(
-            x => x.status === ParticipantStatus.InConsultation && x.room?.label === this.roomLabel
-        );
-
-        if (participant.protectedFrom?.some(id => presentParticipants.map(p => p.externalReferenceId).includes(id))) {
-            return true;
-        }
-
-        if (presentParticipants?.some(x => x.protectedFrom?.includes(participant.externalReferenceId))) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private participantAndLoggedInUserAreScreenedFromEachOther(participant: ParticipantListItem): boolean {
-        const loggedInUserParticipant = this.conference.participants.find(x => x.id === this.loggedInUser.participant_id);
-
-        if (loggedInUserParticipant.protectedFrom?.includes(participant.externalReferenceId)) {
-            return true;
-        }
-
-        if (participant.protectedFrom?.includes(loggedInUserParticipant.externalReferenceId)) {
-            return true;
         }
 
         return false;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/participant-waiting-room/private-consultation-participants/private-consultation-participants.component.ts
@@ -217,8 +217,7 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
     }
 
     private participantAndPresentParticipantsAreScreenedFromEachOther(participant: ParticipantListItem) {
-        const participants = this.getConsultationParticipants();
-        const presentParticipants = participants.filter(
+        const presentParticipants = this.conference.participants.filter(
             x => x.status === ParticipantStatus.InConsultation && x.room?.label === this.roomLabel
         );
 
@@ -226,7 +225,7 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
             return true;
         }
 
-        if (presentParticipants.some(x => x.protectedFrom?.includes(participant.externalReferenceId))) {
+        if (presentParticipants?.some(x => x.protectedFrom?.includes(participant.externalReferenceId))) {
             return true;
         }
 
@@ -234,8 +233,7 @@ export class PrivateConsultationParticipantsComponent extends WRParticipantStatu
     }
 
     private participantAndLoggedInUserAreScreenedFromEachOther(participant: ParticipantListItem): boolean {
-        const participants = this.getConsultationParticipants();
-        const loggedInUserParticipant = participants.find(x => x.id === this.loggedInUser.participant_id);
+        const loggedInUserParticipant = this.conference.participants.find(x => x.id === this.loggedInUser.participant_id);
 
         if (loggedInUserParticipant.protectedFrom?.includes(participant.externalReferenceId)) {
             return true;

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/waiting-room-shared/wr-participant-list-shared.component.ts
@@ -12,6 +12,7 @@ import { HearingRoleHelper } from 'src/app/shared/helpers/hearing-role-helper';
 import { HearingRole } from '../models/hearing-role-model';
 import { FocusService } from 'src/app/services/focus.service';
 import { VHConference, VHEndpoint, VHParticipant } from '../store/models/vh-conference';
+import { ConsultationRules } from 'src/app/services/models/consultation-rules';
 
 @Directive()
 export abstract class WRParticipantStatusListDirective implements OnChanges {
@@ -30,6 +31,8 @@ export abstract class WRParticipantStatusListDirective implements OnChanges {
     eventHubSubscriptions$ = new Subscription();
     loggedInUser: LoggedParticipantResponse;
     loggerPrefix = '[WRParticipantStatusListDirective] -';
+
+    protected consultationRules: ConsultationRules;
 
     private _conference: VHConference;
 
@@ -73,6 +76,7 @@ export abstract class WRParticipantStatusListDirective implements OnChanges {
 
     @Input() set conference(conference: VHConference) {
         this._conference = conference;
+        this.consultationRules = new ConsultationRules(conference);
         this.initParticipants();
     }
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11132

### Change description
For private consultations, hide the call/invite button when participants are screened
- When the current user is screened from the target participant, or vice versa
- When one of the screening participant pair is already in the consultation

Updates the `participantHasInviteRestrictions` logic, and refactors it into a separate class (ConsultationRules) along with the tests