### PR TITLE
VIH-0000 Changed the reconnectWowzaAgent function to an arrow function

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -522,9 +522,9 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
         this.audioErrorRetryToast = this.notificationToastrService.showAudioRecordingErrorWithRestart(this.reconnectWowzaAgent);
     }
 
-    private reconnectWowzaAgent(): void {
+    private reconnectWowzaAgent = (): void => {
         this.audioRecordingService.cleanupDialOutConnections();
-        this.audioRecordingService.reconnectToWowza.bind(this, () => {
+        this.audioRecordingService.reconnectToWowza(() => {
             this.notificationToastrService.showAudioRecordingRestartFailure(this.audioRestartCallback.bind(this));
         });
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/judge-waiting-room/judge-waiting-room.component.ts
@@ -527,5 +527,5 @@ export class JudgeWaitingRoomComponent extends WaitingRoomBaseDirective implemen
         this.audioRecordingService.reconnectToWowza(() => {
             this.notificationToastrService.showAudioRecordingRestartFailure(this.audioRestartCallback.bind(this));
         });
-    }
+    };
 }


### PR DESCRIPTION
### Change description
Changed the reconnectWowzaAgent function to an arrow function, as it loses 'this' context, and is treating audioRecordingService as undefined when being called as a callback from the toaster. Should now inherit 'this' from its lexical scope meaning it wont jump over these functions.