### PR TITLE
VIH-11245 ignore conference updates that do not match the active conference

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.spec.ts
@@ -241,6 +241,15 @@ describe('Conference Reducer', () => {
             expect(result.currentConference.caseName).toEqual('Updating conference');
             expect(result.currentConference.endpoints[0].pexipInfo).toBeTruthy();
         });
+
+        it('should ignore the conference if the id does not match the active conference id', () => {
+            const conferenceWithDifferentId: VHConference = { ...conferenceTestData, id: 'different-id' };
+            const result = conferenceReducer(
+                existingInitialState,
+                ConferenceActions.loadConferenceSuccess({ conference: conferenceWithDifferentId })
+            );
+            expect(result).toEqual(existingInitialState);
+        });
     });
 
     describe('leaveConference action', () => {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
@@ -45,6 +45,11 @@ const updateLoggedInParticipant = (state: ConferenceState, participants: VHParti
 export const conferenceReducer = createReducer(
     initialState,
     on(ConferenceActions.loadConferenceSuccess, (state, { conference }) => {
+        if (state.currentConference && state.currentConference.id !== conference.id) {
+            // participants will get updates to other hearings they're booked to on the same day. We only want to update the current conference
+            // To replace the hearing, dispatch the leaveConference action first
+            return state;
+        }
         // retain the pexip info and media device status for the participants (this does not come from the API)
         const updatedParticipants = conference.participants.map(p => {
             const existingParticipant = state.currentConference?.participants.find(cp => cp.id === p.id);


### PR DESCRIPTION
### Jira link

VIH-11245

### Change description

The participant would display notifications for conference they are booked to but is not their active one. Ignore updates if the ids to not match. To replace the hearing, dispatch the leaveConference action first