### PR TITLE
VIH-11391 record event timestamps in cache

### DIFF
--- a/VideoWeb/VideoWeb.Common/Models/Endpoint.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Endpoint.cs
@@ -13,5 +13,9 @@ namespace VideoWeb.Common.Models
         public InterpreterLanguage InterpreterLanguage { get; set; }
         public string ExternalReferenceId { get; set; }
         public List<string> ProtectFrom { get; set; } = [];
+        /// <summary>
+        /// This is the time stamp of the last event that was sent for a change to the endpoint
+        /// </summary>
+        public DateTime? LastEventTime { get; set; }
     }
 }

--- a/VideoWeb/VideoWeb.Common/Models/Participant.cs
+++ b/VideoWeb/VideoWeb.Common/Models/Participant.cs
@@ -29,6 +29,10 @@ namespace VideoWeb.Common.Models
         public List<LinkedParticipant> LinkedParticipants { get; set; }
         public string ExternalReferenceId { get; set; }
         public List<string> ProtectFrom { get; set; } = [];
+        /// <summary>
+        /// This is the time stamp of the last event that was sent for a change to the participant
+        /// </summary>
+        public DateTime? LastEventTime { get; set; }
 
         public bool IsJudge()
         {

--- a/VideoWeb/VideoWeb.Common/Models/TelephoneParticipant.cs
+++ b/VideoWeb/VideoWeb.Common/Models/TelephoneParticipant.cs
@@ -8,6 +8,10 @@ public class TelephoneParticipant
     public string PhoneNumber { get; set; }
     public bool Connected { get; set; }
     public RoomType Room { get; set; }
+    /// <summary>
+    /// This is the time stamp of the last event that was sent for a change to the tel participant
+    /// </summary>
+    public DateTime? LastEventTime { get; set; }
     
     public void UpdateRoom(RoomType room)
     {

--- a/VideoWeb/VideoWeb.Contract/Responses/ConferenceResponse.cs
+++ b/VideoWeb/VideoWeb.Contract/Responses/ConferenceResponse.cs
@@ -45,6 +45,11 @@ namespace VideoWeb.Contract.Responses
         public ConferenceStatus Status { get; set; }
         
         /// <summary>
+        /// Has the countdown completed
+        /// </summary>
+        public bool CountdownCompleted { get; set; }
+        
+        /// <summary>
         /// The participant meeting room uri
         /// </summary>
         public string ParticipantUri { get; set; }

--- a/VideoWeb/VideoWeb.EventHub/Exceptions/UnexpectedEventOrderException.cs
+++ b/VideoWeb/VideoWeb.EventHub/Exceptions/UnexpectedEventOrderException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace VideoWeb.EventHub.Exceptions;
+
+public class UnexpectedEventOrderException(CallbackEvent callbackEvent, Exception innerException)
+    : Exception("Event received in an unexpected order", innerException)
+{
+    public CallbackEvent CallbackEvent { get; } = callbackEvent;
+}

--- a/VideoWeb/VideoWeb.EventHub/Handlers/CloseEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/CloseEventHandler.cs
@@ -17,7 +17,7 @@ namespace VideoWeb.EventHub.Handlers
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
             var conferenceState = ConferenceStatus.Closed;
-            return PublishConferenceStatusMessage(conferenceState);
+            return PublishConferenceStatusMessage(conferenceState, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/Core/EventHandlerBase.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/Core/EventHandlerBase.cs
@@ -20,6 +20,7 @@ namespace VideoWeb.EventHub.Handlers.Core
         public Participant SourceParticipant { get; set; }
         protected Conference SourceConference { get; set; }
         protected Endpoint SourceEndpoint { get; set; }
+        protected TelephoneParticipant SourceTelephoneParticipant { get; set; }
         protected readonly IHubContext<Hub.EventHub, IEventHubClient> HubContext = hubContext;
         protected readonly ILogger<EventHandlerBase> Logger = logger;
 
@@ -30,6 +31,8 @@ namespace VideoWeb.EventHub.Handlers.Core
             SourceParticipant = SourceConference.Participants
                 .SingleOrDefault(x => x.Id == callbackEvent.ParticipantId);
             SourceEndpoint = SourceConference.Endpoints
+                .SingleOrDefault(x => x.Id == callbackEvent.ParticipantId);
+            SourceTelephoneParticipant = SourceConference.TelephoneParticipants
                 .SingleOrDefault(x => x.Id == callbackEvent.ParticipantId);
 
             Logger.LogTrace("Handling Event: {EventType} for conferenceId {ConferenceId} with reason {Reason}",
@@ -45,11 +48,13 @@ namespace VideoWeb.EventHub.Handlers.Core
         /// <param name="participantState">Participant status event to publish</param>
         /// <param name="newStatus">the new status to publish</param>
         /// <param name="reason">reason for the disconnect</param>
+        /// <param name="callbackEvent">the callback event payload</param>
         /// <returns></returns>
         protected async Task PublishParticipantStatusMessage(ParticipantState participantState,
-            ParticipantStatus newStatus, string reason)
+            ParticipantStatus newStatus, string reason, CallbackEvent callbackEvent)
         {
-            SourceConference.UpdateParticipantStatus(SourceParticipant, newStatus);
+            ValidateParticipantEventReceivedAfterLastUpdate(callbackEvent);
+            SourceConference.UpdateParticipantStatus(SourceParticipant, newStatus, callbackEvent?.TimeStampUtc);
             await conferenceService.UpdateConferenceAsync(SourceConference);
             foreach (var username in SourceConference.Participants.Select(x => x.Username.ToLowerInvariant()))
             {
@@ -74,10 +79,12 @@ namespace VideoWeb.EventHub.Handlers.Core
         ///     Publish a hearing event to all participants in conference to those connected to the HubContext
         /// </summary>
         /// <param name="hearingEventStatus">Hearing status event to publish</param>
+        /// <param name="callbackEvent">the callback event payload</param>
         /// <returns></returns>
-        protected async Task PublishConferenceStatusMessage(ConferenceStatus hearingEventStatus)
+        protected async Task PublishConferenceStatusMessage(ConferenceStatus hearingEventStatus, CallbackEvent callbackEvent)
         {
-            SourceConference.UpdateConferenceStatus(hearingEventStatus);
+            ValidateConferenceEventReceivedAfterLastUpdate(callbackEvent);
+            SourceConference.UpdateConferenceStatus(hearingEventStatus, callbackEvent.TimeStampUtc);
             if (hearingEventStatus == ConferenceStatus.Closed)
                 SourceConference.UpdateClosedDateTime(DateTime.UtcNow);
             await conferenceService.UpdateConferenceAsync(SourceConference);
@@ -93,9 +100,10 @@ namespace VideoWeb.EventHub.Handlers.Core
                 .ConferenceStatusMessage(SourceConference.Id, hearingEventStatus);
         }
 
-        protected async Task PublishEndpointStatusMessage(EndpointState endpointState, EndpointStatus newStatus)
+        protected async Task PublishEndpointStatusMessage(EndpointState endpointState, EndpointStatus newStatus, CallbackEvent callbackEvent)
         {
-            SourceConference.UpdateEndpointStatus(SourceEndpoint, newStatus);
+            ValidateJvsEventReceivedAfterLastUpdate(callbackEvent);
+            SourceConference.UpdateEndpointStatus(SourceEndpoint, newStatus, callbackEvent.TimeStampUtc);
             await conferenceService.UpdateConferenceAsync(SourceConference);
             foreach (var participant in SourceConference.Participants)
             {
@@ -171,5 +179,42 @@ namespace VideoWeb.EventHub.Handlers.Core
         private static bool IsToConsultationRoom(string toRoom) => toRoom.Contains("consultation", StringComparison.CurrentCultureIgnoreCase);
 
         protected abstract Task PublishStatusAsync(CallbackEvent callbackEvent);
+
+        private void ValidateConferenceEventReceivedAfterLastUpdate(CallbackEvent callbackEvent)
+        {
+            var eventReceivedAfterLastUpdate = SourceConference.LastEventTime > callbackEvent.TimeStampUtc;
+            if (!eventReceivedAfterLastUpdate) return;
+            var innerException = new InvalidOperationException(
+                $"Conference {SourceConference.Id} has already been updated since this event {callbackEvent.EventType} with the time {callbackEvent.TimeStampUtc:O}. Current Status: {SourceConference.CurrentStatus} - Last Updated At: {SourceConference.LastEventTime.GetValueOrDefault():O}");
+            Logger.LogError(new UnexpectedEventOrderException(callbackEvent, innerException), "Unexpected event order for conference");
+        }
+
+        private void ValidateParticipantEventReceivedAfterLastUpdate(CallbackEvent callbackEvent)
+        {
+            var eventReceivedAfterLastUpdate = SourceParticipant?.LastEventTime > callbackEvent?.TimeStampUtc;
+            if (!eventReceivedAfterLastUpdate) return;
+            var innerException = new InvalidOperationException(
+                $"Participant {SourceParticipant.Id} has already been updated since this event {callbackEvent.EventType} with the time {callbackEvent.TimeStampUtc:O}. Current Status: {SourceParticipant.ParticipantStatus} - Last Updated At: {SourceParticipant.LastEventTime.GetValueOrDefault():O}");
+            Logger.LogError(new UnexpectedEventOrderException(callbackEvent, innerException), "Unexpected event order for participant");
+        }
+
+        private void ValidateJvsEventReceivedAfterLastUpdate(CallbackEvent callbackEvent)
+        {
+            var eventReceivedAfterLastUpdate = SourceEndpoint.LastEventTime > callbackEvent.TimeStampUtc;
+            if(!eventReceivedAfterLastUpdate) return;
+            var innerException = new InvalidOperationException(
+                $"Endpoint {SourceEndpoint.Id} has already been updated since this event {callbackEvent.EventType} with the time {callbackEvent.TimeStampUtc:O}. Current Status: {SourceEndpoint.EndpointStatus} - Last Updated At: {SourceEndpoint.LastEventTime.GetValueOrDefault():O}");
+            Logger.LogError(new UnexpectedEventOrderException(callbackEvent, innerException), "Unexpected event order for endpoint");
+        }
+        
+        protected void ValidateTelephoneParticipantEventReceivedAfterLastUpdate(CallbackEvent callbackEvent)
+        {
+            // Telephone participants are added dynamically so we have to use the null operator
+            var eventReceivedAfterLastUpdate = SourceTelephoneParticipant?.LastEventTime > callbackEvent.TimeStampUtc;
+            if(!eventReceivedAfterLastUpdate) return;
+            var innerException = new InvalidOperationException(
+                $"TelephoneParticipant {SourceTelephoneParticipant.Id} has already been updated since this event {callbackEvent.EventType} with the time {callbackEvent.TimeStampUtc:O}. Current Status: {SourceTelephoneParticipant.Connected} - Last Updated At: {SourceTelephoneParticipant.LastEventTime.GetValueOrDefault():O}");
+            Logger.LogError(new UnexpectedEventOrderException(callbackEvent, innerException), "Unexpected event order for telephone participant");
+        }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/CountdownFinishedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/CountdownFinishedEventHandler.cs
@@ -10,13 +10,14 @@ namespace VideoWeb.EventHub.Handlers
         ILogger<EventHandlerBase> logger)
         : EventHandlerBase(hubContext, conferenceService, logger)
     {
+        private readonly IConferenceService _conferenceService = conferenceService;
 
         public override EventType EventType => EventType.CountdownFinished;
 
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
             SourceConference.CountdownComplete = true;
-            await conferenceService.UpdateConferenceAsync(SourceConference);
+            await _conferenceService.UpdateConferenceAsync(SourceConference);
             foreach (var participant in SourceConference.Participants)
             {
                 await HubContext.Clients.Group(participant.Username.ToLowerInvariant())

--- a/VideoWeb/VideoWeb.EventHub/Handlers/CountdownFinishedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/CountdownFinishedEventHandler.cs
@@ -15,6 +15,8 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
+            SourceConference.CountdownComplete = true;
+            await conferenceService.UpdateConferenceAsync(SourceConference);
             foreach (var participant in SourceConference.Participants)
             {
                 await HubContext.Clients.Group(participant.Username.ToLowerInvariant())

--- a/VideoWeb/VideoWeb.EventHub/Handlers/DisconnectedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/DisconnectedEventHandler.cs
@@ -17,7 +17,8 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishParticipantStatusMessage(ParticipantState.Disconnected, ParticipantStatus.Disconnected, callbackEvent.Reason);
+            return PublishParticipantStatusMessage(ParticipantState.Disconnected, ParticipantStatus.Disconnected,
+                callbackEvent.Reason, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/EndpointDisconnectedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/EndpointDisconnectedEventHandler.cs
@@ -16,7 +16,7 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishEndpointStatusMessage(EndpointState.Disconnected, EndpointStatus.Disconnected);
+            return PublishEndpointStatusMessage(EndpointState.Disconnected, EndpointStatus.Disconnected, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/EndpointJoinedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/EndpointJoinedEventHandler.cs
@@ -17,7 +17,7 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishEndpointStatusMessage(EndpointState.Connected, EndpointStatus.Connected);
+            return PublishEndpointStatusMessage(EndpointState.Connected, EndpointStatus.Connected, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/EndpointTransferEventHandler.cs
@@ -22,7 +22,7 @@ namespace VideoWeb.EventHub.Handlers
         {
             var endpointStatus = DeriveEndpointStatusForTransferEvent(callbackEvent);
             await PublishRoomTransferMessage(new RoomTransfer { ParticipantId = callbackEvent.ParticipantId, FromRoom = callbackEvent.TransferFrom, ToRoom = callbackEvent.TransferTo });
-            await PublishEndpointStatusMessage(endpointStatus.state, endpointStatus.newStatus);
+            await PublishEndpointStatusMessage(endpointStatus.state, endpointStatus.newStatus, callbackEvent);
         }
 
         private static (EndpointState state, EndpointStatus newStatus) DeriveEndpointStatusForTransferEvent(CallbackEvent callbackEvent)

--- a/VideoWeb/VideoWeb.EventHub/Handlers/JoinedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/JoinedEventHandler.cs
@@ -33,7 +33,7 @@ namespace VideoWeb.EventHub.Handlers
 
             Logger.LogTrace("Participant {ParticipantId} joined conference {ConferenceId} with status {ParticipantStatus}",
                 callbackEvent.ParticipantId, callbackEvent.ConferenceId, newStatus);
-            await PublishParticipantStatusMessage(state, newStatus, callbackEvent.Reason);
+            await PublishParticipantStatusMessage(state, newStatus, callbackEvent.Reason, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/LeaveEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/LeaveEventHandler.cs
@@ -23,7 +23,7 @@ namespace VideoWeb.EventHub.Handlers
             if (SourceParticipant.ParticipantStatus == ParticipantStatus.InHearing ||
                 SourceParticipant.ParticipantStatus == ParticipantStatus.InConsultation || anotherDeviceDetected)
                 return PublishParticipantStatusMessage(ParticipantState.Disconnected, ParticipantStatus.Disconnected,
-                    callbackEvent.Reason);
+                    callbackEvent.Reason, callbackEvent);
 
             return Task.CompletedTask;
         }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/ParticipantJoiningEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/ParticipantJoiningEventHandler.cs
@@ -16,7 +16,8 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishParticipantStatusMessage(ParticipantState.Joining, ParticipantStatus.Joining, callbackEvent.Reason);
+            return PublishParticipantStatusMessage(ParticipantState.Joining, ParticipantStatus.Joining,
+                callbackEvent.Reason, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/ParticipantNotSignedInEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/ParticipantNotSignedInEventHandler.cs
@@ -19,7 +19,7 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishParticipantStatusMessage(ParticipantState.NotSignedIn, ParticipantStatus.NotSignedIn, callbackEvent.Reason);
+            return PublishParticipantStatusMessage(ParticipantState.NotSignedIn, ParticipantStatus.NotSignedIn, callbackEvent.Reason, null);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/PauseEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/PauseEventHandler.cs
@@ -16,7 +16,7 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishConferenceStatusMessage(ConferenceStatus.Paused);
+            return PublishConferenceStatusMessage(ConferenceStatus.Paused, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/StartEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/StartEventHandler.cs
@@ -16,7 +16,7 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishConferenceStatusMessage(ConferenceStatus.InSession);
+            return PublishConferenceStatusMessage(ConferenceStatus.InSession, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/SuspendEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/SuspendEventHandler.cs
@@ -15,7 +15,7 @@ namespace VideoWeb.EventHub.Handlers
 
         protected override Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            return PublishConferenceStatusMessage(ConferenceStatus.Suspended);
+            return PublishConferenceStatusMessage(ConferenceStatus.Suspended, callbackEvent);
         }
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/TelephoneDisconnectedEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/TelephoneDisconnectedEventHandler.cs
@@ -4,7 +4,7 @@ using VideoWeb.EventHub.Enums;
 
 namespace VideoWeb.EventHub.Handlers;
 
-public class TelephoneJoinedEventHandler(
+public class TelephoneDisconnectedEventHandler(
     IHubContext<Hub.EventHub, IEventHubClient> hubContext,
     IConferenceService conferenceService,
     ILogger<EventHandlerBase> logger)
@@ -12,12 +12,12 @@ public class TelephoneJoinedEventHandler(
 {
     private readonly IConferenceService _conferenceService = conferenceService;
 
-    public override EventType EventType => EventType.TelephoneJoined;
+    public override EventType EventType => EventType.TelephoneDisconnected;
 
     protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
     {
         ValidateTelephoneParticipantEventReceivedAfterLastUpdate(callbackEvent);
-        SourceConference.AddTelephoneParticipant(callbackEvent.ParticipantId, callbackEvent.PhoneNumber);
+        SourceConference.RemoveTelephoneParticipant(callbackEvent.ParticipantId);
         await _conferenceService.UpdateConferenceAsync(SourceConference);
     }
 }

--- a/VideoWeb/VideoWeb.EventHub/Handlers/TelephoneTransferEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/TelephoneTransferEventHandler.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using VideoWeb.Common.Models;
+using VideoWeb.EventHub.Enums;
+using VideoWeb.EventHub.Exceptions;
+
+namespace VideoWeb.EventHub.Handlers;
+
+public class TelephoneTransferEventHandler(
+    IHubContext<Hub.EventHub, IEventHubClient> hubContext,
+    IConferenceService conferenceService,
+    ILogger<EventHandlerBase> logger)
+    : EventHandlerBase(hubContext, conferenceService, logger)
+{
+    private readonly IConferenceService _conferenceService = conferenceService;
+
+    public override EventType EventType => EventType.TelephoneTransfer;
+
+    protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
+    {
+        var room = DeriveRoomForTransferEvent(callbackEvent);
+        if (SourceTelephoneParticipant != null)
+        {
+            ValidateTelephoneParticipantEventReceivedAfterLastUpdate(callbackEvent);
+            SourceTelephoneParticipant.UpdateRoom(room);
+            SourceTelephoneParticipant.LastEventTime = callbackEvent.TimeStampUtc;
+            await _conferenceService.UpdateConferenceAsync(SourceConference);
+        }
+    }
+    
+    private static RoomType DeriveRoomForTransferEvent(CallbackEvent callbackEvent)
+    {
+        var isRoomToEnum = Enum.TryParse<RoomType>(callbackEvent.TransferTo, out var transferTo);
+        if (!isRoomToEnum && transferTo != RoomType.HearingRoom && transferTo != RoomType.WaitingRoom)
+        {
+            throw new RoomTransferException(callbackEvent.TransferFrom, callbackEvent.TransferTo);
+        }
+
+        return transferTo;
+    }
+}

--- a/VideoWeb/VideoWeb.EventHub/Handlers/TransferEventHandler.cs
+++ b/VideoWeb/VideoWeb.EventHub/Handlers/TransferEventHandler.cs
@@ -20,8 +20,13 @@ namespace VideoWeb.EventHub.Handlers
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
             var participantStatusTuple = DeriveParticipantStatusForTransferEvent(callbackEvent);
-            await PublishRoomTransferMessage(new RoomTransfer { ParticipantId = callbackEvent.ParticipantId, FromRoom = callbackEvent.TransferFrom, ToRoom = callbackEvent.TransferTo });
-            await PublishParticipantStatusMessage(participantStatusTuple.state, participantStatusTuple.status, callbackEvent.Reason);
+            await PublishRoomTransferMessage(new RoomTransfer
+            {
+                ParticipantId = callbackEvent.ParticipantId, FromRoom = callbackEvent.TransferFrom,
+                ToRoom = callbackEvent.TransferTo
+            });
+            await PublishParticipantStatusMessage(participantStatusTuple.state, participantStatusTuple.status,
+                callbackEvent.Reason, callbackEvent);
         }
 
         private static (ParticipantState state, ParticipantStatus status) DeriveParticipantStatusForTransferEvent(CallbackEvent callbackEvent)

--- a/VideoWeb/VideoWeb.UnitTests/Controllers/ConsultationController/StartConsultationTest.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Controllers/ConsultationController/StartConsultationTest.cs
@@ -349,6 +349,7 @@ public class StartConsultationTest
     public async Task Does_Not_Update_Cache_When_JOH_Consultation_Room_Is_Locked()
     {
         var controller = GetControllerWithContextForRole(AppRoles.JudgeRole);
+        controller.WaitForLockRoomTime = 1;
         var request = ConsultationHelper.GetStartJohConsultationRequest(_testConference);
         var expectedKeyName = $"johConsultationRoomLockedStatus_{request.ConferenceId}";
         _mocker.Mock<IDistributedJohConsultationRoomLockCache>().Setup(x => x.IsJohRoomLocked(expectedKeyName, It.IsAny<CancellationToken>()))

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/CloseEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/CloseEventHandlerTests.cs
@@ -20,6 +20,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             _eventHandler = new CloseEventHandler(EventHubContextMock.Object, ConferenceServiceMock.Object, LoggerMock.Object);
 
             var conference = TestConference;
+            conference.CountdownComplete = true;
             var participantCount = conference.Participants.Count + 1; // plus one for admin
             var callbackEvent = new CallbackEvent
             {
@@ -36,6 +37,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             EventHubClientMock.Verify(x => x.ConferenceStatusMessage(conference.Id, ConferenceStatus.Closed),
                 Times.Exactly(participantCount));
             TestConference.ClosedDateTime.Should().BeOnOrAfter(currentDateTime);
+            TestConference.CountdownComplete.Should().BeFalse();
         }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/CountdownFinishedEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/CountdownFinishedEventHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using VideoWeb.EventHub.Enums;
@@ -18,6 +19,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             _eventHandler = new CountdownFinishedEventHandler(EventHubContextMock.Object, ConferenceServiceMock.Object, LoggerMock.Object);
 
             var conference = TestConference;
+            conference.CountdownComplete = false;
             var participantCount = conference.Participants.Count + 1; // plus one for admin
             var callbackEvent = new CallbackEvent
             {
@@ -32,6 +34,8 @@ namespace VideoWeb.UnitTests.EventHandlers
             // Verify messages sent to event hub clients
             EventHubClientMock.Verify(x => x.CountdownFinished(conference.Id),
                 Times.Exactly(participantCount));
+
+            conference.CountdownComplete.Should().BeTrue();
         }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/EndpointJoinedEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/EndpointJoinedEventHandlerTests.cs
@@ -40,5 +40,33 @@ namespace VideoWeb.UnitTests.EventHandlers
                 Times.Exactly(participantCount));
             TestConference.Endpoints.Find(x => x.Id == participantForEvent.Id).EndpointStatus.Should().Be(EndpointStatus.Connected);
         }
+        
+        [Test]
+        public async Task should_send_endpoint_connected_message_to_participants_and_admin_despite_being_an_older_event()
+        {
+            _eventHandler = new EndpointJoinedEventHandler(EventHubContextMock.Object, ConferenceServiceMock.Object, LoggerMock.Object);
+            
+            var conference = TestConference;
+            var participantCount = conference.Participants.Count + 1; // plus one for admin
+            var participantForEvent = conference.Endpoints[0];
+            participantForEvent.LastEventTime = DateTime.UtcNow.AddMilliseconds(1);
+            var callbackEvent = new CallbackEvent
+            {
+                EventType = EventType.EndpointJoined,
+                EventId = Guid.NewGuid().ToString(),
+                ParticipantId = participantForEvent.Id,
+                ConferenceId = conference.Id,
+                Reason = "JVC Connection",
+                TimeStampUtc = DateTime.UtcNow.AddMilliseconds(-1)
+            };
+            
+            await _eventHandler.HandleAsync(callbackEvent);
+            
+            // Verify messages sent to event hub clients
+            EventHubClientMock.Verify(
+                x => x.EndpointStatusMessage(participantForEvent.Id, conference.Id, EndpointState.Connected),
+                Times.Exactly(participantCount));
+            TestConference.Endpoints.Find(x => x.Id == participantForEvent.Id).EndpointStatus.Should().Be(EndpointStatus.Connected);
+        }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/PauseEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/PauseEventHandlerTests.cs
@@ -20,6 +20,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             _eventHandler = new PauseEventHandler(EventHubContextMock.Object, ConferenceServiceMock.Object, LoggerMock.Object);
 
             var conference = TestConference;
+            conference.CountdownComplete = true;
             var participantCount = conference.Participants.Count + 1; // plus one for admin
             var callbackEvent = new CallbackEvent
             {
@@ -35,6 +36,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             EventHubClientMock.Verify(x => x.ConferenceStatusMessage(conference.Id, ConferenceStatus.Paused),
                 Times.Exactly(participantCount));
             TestConference.CurrentStatus.Should().Be(ConferenceStatus.Paused);
+            TestConference.CountdownComplete.Should().BeFalse();
         }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/SuspendEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/SuspendEventHandlerTests.cs
@@ -20,6 +20,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             _eventHandler = new SuspendEventHandler(EventHubContextMock.Object, ConferenceServiceMock.Object, LoggerMock.Object);
 
             var conference = TestConference;
+            conference.CountdownComplete = true;
             var participantCount = conference.Participants.Count + 1; // plus one for admin
             var callbackEvent = new CallbackEvent
             {
@@ -36,6 +37,7 @@ namespace VideoWeb.UnitTests.EventHandlers
             EventHubClientMock.Verify(x => x.ConferenceStatusMessage(conference.Id, ConferenceStatus.Suspended),
                 Times.Exactly(participantCount));
             TestConference.CurrentStatus.Should().Be(ConferenceStatus.Suspended);
+            TestConference.CountdownComplete.Should().BeFalse();
         }
     }
 }

--- a/VideoWeb/VideoWeb.UnitTests/EventHandlers/TelephoneDisconnectedEventHandlerTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/EventHandlers/TelephoneDisconnectedEventHandlerTests.cs
@@ -36,4 +36,34 @@ public class TelephoneDisconnectedEventHandlerTests : EventHandlerTestBase
         var removedParticipant = TestConference.TelephoneParticipants.Find(x => x.Id == telephoneId);
         removedParticipant.Should().BeNull();
     }
+    
+    [Test]
+    public async Task should_remove_telephone_participant_despite_being_old_event()
+    {
+        var eventHandler = new TelephoneDisconnectedEventHandler(EventHubContextMock.Object,
+            ConferenceServiceMock.Object, LoggerMock.Object);
+        
+        var conference = TestConference;
+        var telephoneId = Guid.NewGuid();
+        conference.AddTelephoneParticipant(telephoneId, "Anonymous");
+        var telephoneParticipant = conference.TelephoneParticipants.Find(x => x.Id == telephoneId);
+        telephoneParticipant.LastEventTime = DateTime.UtcNow.AddMilliseconds(1);
+        
+        
+        var callbackEvent = new CallbackEvent
+        {
+            EventType = EventType.TelephoneDisconnected,
+            EventId = Guid.NewGuid().ToString(),
+            ConferenceId = conference.Id,
+            ParticipantId = telephoneId,
+            TransferFrom = null,
+            TransferTo = null,
+            TimeStampUtc = DateTime.UtcNow.AddMilliseconds(-1),
+            PhoneNumber = "Anonymous",
+        };
+
+        await eventHandler.HandleAsync(callbackEvent);
+        var removedParticipant = TestConference.TelephoneParticipants.Find(x => x.Id == telephoneId);
+        removedParticipant.Should().BeNull();
+    }
 }

--- a/VideoWeb/VideoWeb.UnitTests/Mappings/ConferenceResponseMapperTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Mappings/ConferenceResponseMapperTests.cs
@@ -36,7 +36,7 @@ public class ConferenceResponseMapperTests
         };
         
         
-        var expectedConferenceStatus = ConferenceStatus.Suspended;
+        var expectedConferenceStatus = ConferenceStatus.InSession;
         
         var meetingRoomResponse = Builder<MeetingRoomResponse>.CreateNew().Build();
         var meetingRoom = new ConferenceMeetingRoom()
@@ -48,10 +48,11 @@ public class ConferenceResponseMapperTests
         
         
         var conference = Builder<Conference>.CreateNew()
-            .With(x => x.CurrentStatus = ConferenceStatus.Suspended)
+            .With(x => x.CurrentStatus = ConferenceStatus.InSession)
             .With(x => x.Participants = participants)
             .With(x => x.MeetingRoom = meetingRoom)
             .With(x => x.IsScottish = true)
+            .With(x=> x.CountdownComplete = true)
             .Build();
         
         var response = ConferenceResponseMapper.Map(conference);
@@ -63,6 +64,7 @@ public class ConferenceResponseMapperTests
         response.ScheduledDateTime.Should().Be(conference.ScheduledDateTime);
         response.ScheduledDuration.Should().Be(conference.ScheduledDuration);
         response.Status.Should().Be(expectedConferenceStatus);
+        response.CountdownCompleted.Should().BeTrue();
         response.HearingVenueIsScottish.Should().Be(conference.IsScottish);
         
         var participantsResponse = response.Participants;

--- a/VideoWeb/VideoWeb.UnitTests/Models/Conference/UpdateParticipantStatusTests.cs
+++ b/VideoWeb/VideoWeb.UnitTests/Models/Conference/UpdateParticipantStatusTests.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using NUnit.Framework;
 using VideoWeb.Common.Models;
@@ -15,12 +16,14 @@ public class UpdateParticipantStatusTests
             .Build();
         var participant = conference.Participants.Find(x => !x.IsHost());
         participant.ParticipantStatus = ParticipantStatus.Disconnected;
+        var eventTimeStamp = DateTime.UtcNow;
         
         // Act
-        conference.UpdateParticipantStatus(participant, ParticipantStatus.Available);
+        conference.UpdateParticipantStatus(participant, ParticipantStatus.Available, eventTimeStamp);
         
         // Assert
         participant.ParticipantStatus.Should().Be(ParticipantStatus.Available);
+        participant.LastEventTime.Should().Be(eventTimeStamp);
     }
     
     [Test(Description = "Refreshing in a consultation room should set the room to null when a disconnect event is sent")]
@@ -31,6 +34,7 @@ public class UpdateParticipantStatusTests
             .Build();
         var participant = conference.Participants.Find(x => !x.IsHost());
         participant.ParticipantStatus = ParticipantStatus.InConsultation;
+        var eventTimeStamp = DateTime.UtcNow;
         participant.CurrentRoom = new ConsultationRoom()
         {
             Label = "Room1",
@@ -39,10 +43,11 @@ public class UpdateParticipantStatusTests
         };
         
         // Act
-        conference.UpdateParticipantStatus(participant, ParticipantStatus.Disconnected);
+        conference.UpdateParticipantStatus(participant, ParticipantStatus.Disconnected, eventTimeStamp);
         
         // Assert
         participant.ParticipantStatus.Should().Be(ParticipantStatus.Disconnected);
         participant.CurrentRoom.Should().BeNull();
+        participant.LastEventTime.Should().Be(eventTimeStamp);
     }
 }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/services/clients/api-client.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/services/clients/api-client.ts
@@ -8834,6 +8834,8 @@ export class ConferenceResponse implements IConferenceResponse {
     /** The case name */
     case_name?: string | undefined;
     status?: ConferenceStatus;
+    /** Has the countdown completed */
+    countdown_completed?: boolean;
     /** The participant meeting room uri */
     participant_uri?: string | undefined;
     /** The pexip node to connect to */
@@ -8881,6 +8883,7 @@ export class ConferenceResponse implements IConferenceResponse {
             this.case_number = _data['case_number'];
             this.case_name = _data['case_name'];
             this.status = _data['status'];
+            this.countdown_completed = _data['countdown_completed'];
             this.participant_uri = _data['participant_uri'];
             this.pexip_node_uri = _data['pexip_node_uri'];
             this.pexip_self_test_node_uri = _data['pexip_self_test_node_uri'];
@@ -8921,6 +8924,7 @@ export class ConferenceResponse implements IConferenceResponse {
         data['case_number'] = this.case_number;
         data['case_name'] = this.case_name;
         data['status'] = this.status;
+        data['countdown_completed'] = this.countdown_completed;
         data['participant_uri'] = this.participant_uri;
         data['pexip_node_uri'] = this.pexip_node_uri;
         data['pexip_self_test_node_uri'] = this.pexip_self_test_node_uri;
@@ -8961,6 +8965,8 @@ export interface IConferenceResponse {
     /** The case name */
     case_name?: string | undefined;
     status?: ConferenceStatus;
+    /** Has the countdown completed */
+    countdown_completed?: boolean;
     /** The participant meeting room uri */
     participant_uri?: string | undefined;
     /** The pexip node to connect to */

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -525,7 +525,7 @@ export class VideoCallService {
     }
 
     logMediaStreamInfo() {
-        this.logger.debug(`${this.loggerPrefix} set user media stream`, this.pexipAPI.user_media_stream ? 'stream set' : 'stream not set');
+        this.logger.debug(`${this.loggerPrefix} set user media stream`, this.pexipAPI?.user_media_stream ? 'stream set' : 'stream not set');
     }
 
     private makePexipCall(

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/models/api-contract-to-state-model-mappers.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/models/api-contract-to-state-model-mappers.ts
@@ -21,6 +21,7 @@ export function mapConferenceToVHConference(conference: ConferenceResponse): VHC
         id: conference.id,
         scheduledDateTime: conference.scheduled_date_time,
         endDateTime: conference.closed_date_time,
+        countdownComplete: conference.countdown_completed,
         duration: conference.scheduled_duration,
         caseNumber: conference.case_number,
         caseName: conference.case_name,

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/reducers/conference.reducer.ts
@@ -100,11 +100,15 @@ export const conferenceReducer = createReducer(
             const existingEndpoint = state.currentConference?.endpoints.find(ce => ce.id === e.id);
             return { ...e, pexipInfo: existingEndpoint?.pexipInfo, transferDirection: undefined } as VHEndpoint;
         });
-        const updatedConference: VHConference = { ...conference, participants: updatedParticipants, endpoints: updatedEndpoints };
+        const updatedConference: VHConference = {
+            ...conference,
+            participants: updatedParticipants,
+            endpoints: updatedEndpoints,
+            countdownComplete: conference.countdownComplete
+        };
         const availableRooms = distinctRoomLabels(conference.participants.map(p => p.room));
-        const countdownComplete = updatedConference.status === ConferenceStatus.InSession ? true : state.countdownComplete;
         const loggedInParticipant = updateLoggedInParticipant(state, updatedConference.participants).loggedInParticipant;
-        return { ...state, currentConference: updatedConference, availableRooms: availableRooms, countdownComplete, loggedInParticipant };
+        return { ...state, currentConference: updatedConference, availableRooms: availableRooms, loggedInParticipant };
     }),
     on(ConferenceActions.leaveConference, _ => ({ ...initialState })),
     on(ConferenceActions.updateActiveConferenceStatus, (state, { conferenceId, status }) => {

--- a/VideoWeb/VideoWeb/Controllers/ConsultationsController.cs
+++ b/VideoWeb/VideoWeb/Controllers/ConsultationsController.cs
@@ -33,6 +33,9 @@ public class ConsultationsController(
     IDistributedJohConsultationRoomLockCache distributedJohConsultationRoomLockCache)
     : ControllerBase
 {
+#pragma warning disable S1104
+    public int WaitForLockRoomTime = 3000;
+#pragma warning restore S1104
     public const string ConsultationHasScreenedParticipantErrorMessage =
         "Participant is not allowed to join the consultation room with a participant they are screened from";
     
@@ -342,7 +345,7 @@ public class ConsultationsController(
         
         if (isLocked)
         {
-            Thread.Sleep(3000);
+            Thread.Sleep(WaitForLockRoomTime);
         }
         else
         {

--- a/VideoWeb/VideoWeb/Mappings/ConferenceResponseMapper.cs
+++ b/VideoWeb/VideoWeb/Mappings/ConferenceResponseMapper.cs
@@ -31,6 +31,7 @@ public static class ConferenceResponseMapper
             AllocatedCso = conference.AllocatedCso,
             AllocatedCsoId = conference.AllocatedCsoId,
             AllocatedCsoUsername = conference.AllocatedCsoUsername,
+            CountdownCompleted = conference.CountdownComplete
         };
         
         if (conference.MeetingRoom != null)


### PR DESCRIPTION
### Jira link

VIH-11391

### Change description

* record event timestamps in cache
* track countdownc complete in cache too. some may join late and it's not safe to assume a hearing in session and countdown complete are the same