### PR TITLE
VIH-10695 update pexip client in line with audio only toggle

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -1,4 +1,4 @@
-import { discardPeriodicTasks, fakeAsync, flush, tick } from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, flush } from '@angular/core/testing';
 import { Guid } from 'guid-typescript';
 import { of, ReplaySubject } from 'rxjs';
 import { ConfigService } from 'src/app/services/api/config.service';

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.spec.ts
@@ -422,7 +422,7 @@ describe('VideoCallService', () => {
             expect(service['renegotiateCall']).toHaveBeenCalled();
         }));
 
-        fdescribe('handleAudioOnlyChange', () => {
+        describe('handleAudioOnlyChange', () => {
             describe('audioOnly true', () => {
                 it('should toggle video on pexip client if client does not match user toggle', fakeAsync(() => {
                     const dispatchSpy = spyOn(mockStore, 'dispatch');

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -175,6 +175,10 @@ export class VideoCallService {
             self.onStoppedScreenshareSubject.next(new StoppedScreenshare(reason));
         };
 
+        this.userMediaService.isAudioOnly$
+            .pipe(takeUntil(this.hasDisconnected$))
+            .subscribe(isAudioOnly => this.handleAudioOnlyChange(isAudioOnly));
+
         this.userMediaStreamService.currentStream$.pipe(skip(1), takeUntil(this.hasDisconnected$)).subscribe(currentStream => {
             this.pexipAPI.user_media_stream = currentStream;
             this.logMediaStreamInfo();
@@ -201,6 +205,12 @@ export class VideoCallService {
             .subscribe(uniqueCallTags => {
                 this.uniqueCallTagsPerCall = uniqueCallTags;
             });
+    }
+
+    handleAudioOnlyChange(isAudioOnly: boolean) {
+        this.logger.debug(`${this.loggerPrefix} Audio only setting changed`, { isAudioOnly });
+        this.pexipAPI.video_source = isAudioOnly ? false : null;
+        this.pexipAPI.recv_video = !isAudioOnly;
     }
 
     initTurnServer() {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -33,6 +33,7 @@ import {
 } from '../store/models/api-contract-to-state-model-mappers';
 import { UserMediaStreamServiceV2 } from 'src/app/services/user-media-stream-v2.service';
 import { FEATURE_FLAGS, LaunchDarklyService } from 'src/app/services/launch-darkly.service';
+import { VideoCallActions } from '../store/actions/video-call.action';
 
 @Injectable()
 export class VideoCallService {
@@ -209,8 +210,9 @@ export class VideoCallService {
 
     handleAudioOnlyChange(isAudioOnly: boolean) {
         this.logger.debug(`${this.loggerPrefix} Audio only setting changed`, { isAudioOnly });
-        this.pexipAPI.video_source = isAudioOnly ? false : null;
-        this.pexipAPI.recv_video = !isAudioOnly;
+        if (this.pexipAPI?.call?.mutedVideo !== isAudioOnly) {
+            this.store.dispatch(VideoCallActions.toggleOutgoingVideo());
+        }
     }
 
     initTurnServer() {

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -118,7 +118,6 @@ export class VideoCallService {
         this.userMediaStreamService.createAndPublishStream();
         this.logger.debug(`${this.loggerPrefix} attempting to setup user media stream`);
         this.pexipAPI.user_media_stream = await this.userMediaStreamService.currentStream$.pipe(take(1)).toPromise();
-        this.logMediaStreamInfo();
 
         this.pexipAPI.onSetup = this.handleSetup.bind(this);
 
@@ -274,7 +273,6 @@ export class VideoCallService {
             this.pexipAPI.disconnect();
             this.cleanUpConnection();
             this.userMediaStreamService.closeCurrentStream();
-            this.pexipAPI = null; // Reset the Pexip API instance
         } else {
             this.logger.warn(`${this.loggerPrefix} No active Pexip client to disconnect.`);
         }

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/services/video-call.service.ts
@@ -209,7 +209,7 @@ export class VideoCallService {
 
     handleAudioOnlyChange(isAudioOnly: boolean) {
         this.logger.debug(`${this.loggerPrefix} Audio only setting changed`, { isAudioOnly });
-        if (this.pexipAPI?.call?.mutedVideo !== isAudioOnly) {
+        if (!!this.pexipAPI?.call && this.pexipAPI?.call?.mutedVideo !== isAudioOnly) {
             this.store.dispatch(VideoCallActions.toggleOutgoingVideo());
         }
     }

--- a/VideoWeb/VideoWeb/ClientApp/src/typings.d.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/typings.d.ts
@@ -103,6 +103,7 @@ declare interface PexipDialOutParams {
 
 declare interface PexipClient {
     video_source: string | boolean;
+    recv_video: boolean;
     audio_source: string | boolean;
     h264_enabled: boolean;
     mutedAudio: boolean;


### PR DESCRIPTION
### Jira link

VIH-10695

### Change description

update pexip client in line with audio only toggle.
Currently the image for audio only is a custom one out of the box. If a user were to mute their video Pexip provides a slightly different UX for participants. The audio only toggle handling should give the same experience.

Before:
![image](https://github.com/user-attachments/assets/c87a76db-5055-4c0d-a179-b0300f2c9d11)


After:
![image](https://github.com/user-attachments/assets/67683fea-8b64-47f7-96b1-b5a3829a6583)
