### PR TITLE
VIH-11404 Refactor NotificationEffects to track previous endpoints and improve notification logic on endpoint updates

### DIFF
--- a/VideoWeb/VideoWeb/ClientApp/src/app/app.module.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/app.module.ts
@@ -73,12 +73,12 @@ export function getLocale() {
         environment.production
             ? []
             : StoreDevtoolsModule.instrument({
-                  maxAge: 25, // Keeps last 25 states
+                  maxAge: 40,
                   logOnly: environment.production, // Disable extension logging in production
 
                   autoPause: true, // Auto-pause when DevTools isn't open
                   trace: true, // Enables tracing for debugging
-                  traceLimit: 25,
+                  traceLimit: 40,
                   serialize: true // Ensures state serialization,
               }),
         EffectsModule.forRoot([])

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.spec.ts
@@ -761,4 +761,23 @@ describe('NotificationEffects', () => {
             expect(result).toBeTrue();
         });
     });
+
+    describe('resetParticipantList$', () => {
+        it('should update the participants and endpoints list when conference has loaded', () => {
+            const action = ConferenceActions.loadConferenceSuccess({
+                conference: {
+                    ...vhConference,
+                    participants: [...vhConference.participants],
+                    endpoints: [...vhConference.endpoints]
+                }
+            });
+
+            actions$ = hot('-a-', { a: action });
+
+            effects.resetParticipantList$.subscribe(() => {
+                expect(effects.previousParticipants).toEqual(vhConference.participants);
+                expect(effects.previousEndpoints).toEqual(vhConference.endpoints);
+            });
+        });
+    });
 });

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.spec.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.spec.ts
@@ -256,33 +256,42 @@ describe('NotificationEffects', () => {
                 { id: '1232323', displayName: 'DispName1' } as VHEndpoint,
                 { id: '2356789', displayName: 'DispName2' } as VHEndpoint
             ];
+
+            const updatedEndpoints = [
+                { id: '1232323', displayName: 'DispName1 Updated' } as VHEndpoint,
+                { id: '2356789', displayName: 'DispName2 Updated' } as VHEndpoint
+            ];
+            const action = ConferenceActions.updateExistingEndpoints({ conferenceId, endpoints: updatedEndpoints });
+            const loggedInParticipant = { status: ParticipantStatus.InHearing, role: Role.Individual } as VHParticipant;
+            const activeConference = { id: conferenceId } as VHConference;
+
+            effects.previousEndpoints = endpoints;
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getActiveConference, activeConference);
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getLoggedInParticipant, loggedInParticipant);
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, endpoints);
+
+            actions$ = hot('-a-', { a: action });
+
+            effects.endpointsUpdated$.subscribe(() => {
+                expect(toastNotificationService.showEndpointUpdated).toHaveBeenCalledWith(updatedEndpoints[0], true);
+                expect(toastNotificationService.showEndpointUpdated).toHaveBeenCalledWith(updatedEndpoints[1], true);
+            });
+        });
+
+        it('should not call showEndpointUpdated when endpoints have not changed', () => {
+            const conferenceId = '1234567';
+            const endpoints = [
+                { id: '1232323', displayName: 'DispName1', participantsLinked: [] } as VHEndpoint,
+                { id: '2356789', displayName: 'DispName2', participantsLinked: [] } as VHEndpoint
+            ];
+            effects.previousEndpoints = endpoints;
             const action = ConferenceActions.updateExistingEndpoints({ conferenceId, endpoints });
             const loggedInParticipant = { status: ParticipantStatus.InHearing, role: Role.Individual } as VHParticipant;
             const activeConference = { id: conferenceId } as VHConference;
 
             mockConferenceStore.overrideSelector(ConferenceSelectors.getActiveConference, activeConference);
             mockConferenceStore.overrideSelector(ConferenceSelectors.getLoggedInParticipant, loggedInParticipant);
-
-            actions$ = hot('-a-', { a: action });
-
-            effects.endpointsUpdated$.subscribe(() => {
-                expect(toastNotificationService.showEndpointUpdated).toHaveBeenCalledWith(endpoints[0], true);
-                expect(toastNotificationService.showEndpointUpdated).toHaveBeenCalledWith(endpoints[1], true);
-            });
-        });
-
-        it('should not call showEndpointUpdated when conference id does not match', () => {
-            const conferenceId = '1234567';
-            const endpoints = [
-                { id: '1232323', displayName: 'DispName1' } as VHEndpoint,
-                { id: '2356789', displayName: 'DispName2' } as VHEndpoint
-            ];
-            const action = ConferenceActions.updateExistingEndpoints({ conferenceId, endpoints });
-            const loggedInParticipant = { status: ParticipantStatus.InHearing, role: Role.Individual } as VHParticipant;
-            const activeConference = { id: '123' } as VHConference;
-
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getActiveConference, activeConference);
-            mockConferenceStore.overrideSelector(ConferenceSelectors.getLoggedInParticipant, loggedInParticipant);
+            mockConferenceStore.overrideSelector(ConferenceSelectors.getEndpoints, endpoints);
 
             actions$ = hot('-a-', { a: action });
 

--- a/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.ts
+++ b/VideoWeb/VideoWeb/ClientApp/src/app/waiting-space/store/effects/notification.effects.ts
@@ -135,6 +135,19 @@ export class NotificationEffects {
         { dispatch: false }
     );
 
+    // create an effect to populate the previousParticipants array when LoadConferenceSuccess is dispatched
+    resetParticipantList$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConferenceActions.loadConferenceSuccess),
+                tap(action => {
+                    this.previousParticipants = [...action.conference.participants];
+                    this.previousEndpoints = [...action.conference.endpoints];
+                })
+            ),
+        { dispatch: false }
+    );
+
     participantAdded$ = createEffect(
         () => {
             // Initialize previousParticipants with current store value


### PR DESCRIPTION
### Jira link

VIH-11404

### Change description

Due to endpoints being published despite no change to the service bus to update their role with the supplier, the UI needs to handle whether or not to display the toast notifcation. Simiilar to participants added